### PR TITLE
Update cell size and define laser field at the cell centers

### DIFF
--- a/lasy/utils/box.py
+++ b/lasy/utils/box.py
@@ -37,5 +37,6 @@ class Box:
         self.axes = []
         self.dx = []
         for i in range(self.ndims):
-            self.axes.append(np.linspace(lo[i], hi[i], npoints[i]))
-            self.dx.append(self.axes[i][1] - self.axes[i][0])
+            self.dx.append( (hi[i] - lo[i])/npoints[i] )
+            # Define laser field at cell centers
+            self.axes.append(lo[i] + self.dx[i]*(0.5 + np.arange(npoints[i])))

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -44,8 +44,7 @@ def write_to_openpmd_file(file_prefix, file_format, box,
 
         # Define the mesh
         m = i.meshes[comp_name]
-        m.grid_spacing = [ (hi-lo)/npoints for hi, lo, npoints in \
-                               zip( box.hi, box.lo, box.npoints ) ]
+        m.grid_spacing = box.dx
         m.grid_global_offset = box.lo
         m.axis_labels = ['x', 'y', 't']
         m.unit_dimension = {
@@ -62,7 +61,7 @@ def write_to_openpmd_file(file_prefix, file_format, box,
         # Define the dataset
         dataset = io.Dataset(array_in.real.dtype, array_in.real.shape)
         E = m[io.Mesh_Record_Component.SCALAR]
-        E.position = [0]*len(dim)
+        E.position = [0.5]*len(dim) # Laser field is defined at cell centers
         E.reset_dataset(dataset)
 
         # Pick the correct field


### PR DESCRIPTION
With the current definition of `box.dx` (which is based on `np.linspace`), the box cell size is actually not `(hi-lo)/npoints` but `(hi-lo)/(npoints-1)`. This might confuse the user. 

This corrects the above by defining `box.dx` to be explicitly `(hi-lo)/npoints`. In addition, it defines the fields at the cell-centers, which might be more intuitive to the user. (Defining the fields at the nodes would require `npoints+1`.)