### PR TITLE
Revert to name Laser from Lasy

### DIFF
--- a/examples/test.py
+++ b/examples/test.py
@@ -1,5 +1,5 @@
 import numpy as np
-from lasy.lasy import Lasy
+from lasy.laser import Laser
 from lasy.laser_profiles.gaussian_laser import GaussianLaser
 
 wavelength=.8e-6
@@ -17,7 +17,7 @@ lo = (-10e-6, -10e-6, -60e-15)
 hi = (+10e-6, +10e-6, +60e-15)
 npoints=(100,100,100)
 
-laser = Lasy(dim, lo, hi, npoints, profile)
+laser = Laser(dim, lo, hi, npoints, profile)
 laser.write_to_file('laser3d')
 laser.propagate(1)
 laser.write_to_file('laser3d')
@@ -29,7 +29,7 @@ lo = (0e-6, -60e-15)
 hi = (10e-6, +60e-15)
 npoints=(50,100)
 
-laser = Lasy(dim, lo, hi, npoints, profile)
+laser = Laser(dim, lo, hi, npoints, profile)
 laser.write_to_file('laserRZ')
 laser.propagate(1)
 laser.write_to_file('laserRZ')

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -4,7 +4,7 @@ from lasy.utils.box import Box
 from lasy.utils.grid import Grid
 from lasy.utils.openpmd_output import write_to_openpmd_file
 
-class Lasy:
+class Laser:
     """
     Top-level class that can evaluate a laser profile on a grid,
     propagate it, and write it to a file.
@@ -12,7 +12,7 @@ class Lasy:
 
     def __init__(self, dim, lo, hi, npoints, profile):
         """
-        Construct a lasy object
+        Construct a laser object
 
         Parameters
         ----------


### PR DESCRIPTION
PR https://github.com/LASY-org/lasy/pull/25 fixed a few things in the API, I merged it so we could proceed. However, I don't think we had a final decision on whether the main class would be called `Laser` vs `Lasy`. #25 proposed Lasy, but I think this adds more confusion. This is what we had chosen originally, and I believe it opens the possibility to manipulate other objects later (e.g. a particle beam or whatever), and keep the name `lasy` if we need a wrapper class above all objects. Besides, it looks to me that `Lasy` (the class) is currently a subset of `lasy` (the library), which is weird. If that's fine with you, let's revert to the previous behaviour. Hopefully, after that everything is settled and we can move ahead!