### PR TITLE
[DO NOT MERGE] (but please comment!) openPMD extension for laser envelope profile

### DIFF
--- a/EXT_Laser.md
+++ b/EXT_Laser.md
@@ -30,7 +30,7 @@ where $\operatorname{Re}$ stands for real part,  $E_x$ (resp. $E_y$) is the lase
 
 When added to an output, the following naming conventions shall be used for complex electric field `mesh records`.
 
-- `envelope/`
+- `laser_envelope/`
   - type: *(complexX)*
   - scope: *(required)*
   - decription: Scalar field for the envelope (in V/m). See above for description.


### PR DESCRIPTION
This PR proposes a standard for defining a laser profile in the openPMD standard.

Our current plan (open for discussion) is to include it as an extension of the openPMD standard (there is e.g. one for PIC simulations, one for beam dynamics, etc.). This would take place on the openPMD repo, but I still want to open a PR here to have a first round of discussion from the LASY perspective.

## Choices

The following choices were made (consistent with what's in LASY):
- Ex and Ey or E + polarization vector?  *the latter*.
- Array of complex or 2 arrays (real,imag) / (amplitude,phase)? *array of complex numbers*.

## Sources

- The base openPMD standard can be found [here](https://github.com/openPMD/openPMD-standard/blob/upcoming-2.0.0/STANDARD.md).
- This extension is the same approach as the [ED-PIC extension](https://github.com/openPMD/openPMD-standard/blob/upcoming-2.0.0/EXT_ED-PIC.md) and the the [wavefront propagation extension](https://github.com/openPMD/openPMD-standard/blob/upcoming-2.0.0/EXT_Wavefront.md).