### PR TITLE
CI: Faster & Split

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -7,53 +7,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  unittest:
     strategy:
       matrix:
-        python-version: ["3.10"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
-    - name: Cache conda
-      uses: actions/cache@v2
-      # Increase this value to reset cache
-      env: {CACHE_NUMBER: 0}
-      with:
-        path: ~/conda_pkgs_dir
-        key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ matrix.python-version }}
 
-    - uses: conda-incubator/setup-miniconda@v2
-      name: Setup conda
-      with:
-        auto-update-conda: true
-        activate-environment: testing
-        auto-activate-base: false
-        channels: conda-forge,defaults
-        channel-priority: true
-
-    - shell: bash -eo pipefail -l {0}
-      name: Install dependencies
+    - name: Install dependencies
       run: |
-        conda install -y -c conda-forge mamba
-        mamba install -y -c conda-forge python=${{ matrix.python-version }} pyflakes pytest
-        mamba env update --name testing --file conda.yml
+        python3 -m pip install -U pip
+        python3 -m pip install -r requirements.txt
+        python3 -m pip install -U pytest openpmd-viewer
 
-    - shell: bash -eo pipefail -l {0}
-      name: Install
+    - name: Install
       run: python -m pip install -v .
 
-    - shell: bash -eo pipefail -l {0}
-      name: pyflakes
-      run: python -m pyflakes lasy
-
-    - shell: bash -eo pipefail -l {0}
-      name: Run Unit Tests
+    - name: Run Unit Tests
       run: python -m pytest tests/
 
-    - shell: bash -eo pipefail -l {0}
-      name: Run Examples
+    - name: Run Examples
       run: |
         cd examples
         python test.py
+
+  pyflakes:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: python3 -m pip install -U pyflakes
+    - name: pyflakes
+      run: python -m pyflakes lasy


### PR DESCRIPTION
We don't need conda and can quickly pull everything via `pip`.

Also splits off the `pyflakes` job as it is not related to unit tests.