### PR TITLE
Remove colons in numpy-like docstrings

### DIFF
--- a/lasy/profiles/combined_profile.py
+++ b/lasy/profiles/combined_profile.py
@@ -22,8 +22,8 @@ class CombinedLongitudinalTransverseProfile(Profile):
         the polarization vector, :math:`Re` represent the real part.
         The other parameters in this formula are defined below.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         wavelength: float (in meter)
             The main laser wavelength :math:`\lambda_0` of the laser, which
             defines :math:`\omega_0` in the above formula, according to
@@ -57,14 +57,14 @@ class CombinedLongitudinalTransverseProfile(Profile):
         """
         Returns the envelope field of the laser
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         x, y, t: ndarrays of floats
             Define points on which to evaluate the envelope
             These arrays need to all have the same shape.
 
-        Returns:
-        --------
+        Returns
+        -------
         envelope: ndarray of complex numbers
             Contains the value of the envelope at the specified points
             This array has the same shape as the arrays x, y, t

--- a/lasy/profiles/gaussian_profile.py
+++ b/lasy/profiles/gaussian_profile.py
@@ -27,8 +27,8 @@ class GaussianProfile(CombinedLongitudinalTransverseProfile):
         to the propagation direction). The other parameters in this formula
         are defined below.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         wavelength: float (in meter)
             The main laser wavelength :math:`\lambda_0` of the laser, which
             defines :math:`\omega_0` in the above formula, according to

--- a/lasy/profiles/longitudinal/gaussian_profile.py
+++ b/lasy/profiles/longitudinal/gaussian_profile.py
@@ -19,8 +19,8 @@ class GaussianLongitudinalProfile(LongitudinalProfile):
             \mathcal{L}(t) = \exp\left( - \frac{(t-t_{peak})^2}{\tau^2}
                             + i\omega_0t_{peak} \right)
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         tau: float (in second)
             The duration of the laser pulse, i.e. :math:`\tau` in the above
             formula. Note that :math:`\tau = \tau_{FWHM}/\sqrt{2\log(2)}`,
@@ -45,8 +45,8 @@ class GaussianLongitudinalProfile(LongitudinalProfile):
         """
         Returns the longitudinal envelope
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         t: ndarrays of floats
             Define points on which to evaluate the envelope
 

--- a/lasy/profiles/longitudinal/longitudinal_profile.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile.py
@@ -19,13 +19,13 @@ class LongitudinalProfile(object):
         """
         Returns the longitudinal envelope
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         t: ndarrays of floats
             Define points on which to evaluate the envelope
 
-        Returns:
-        --------
+        Returns
+        -------
         envelope: ndarray of complex numbers
             Contains the value of the longitudinal envelope at the
             specified points. This array has the same shape as the array t.

--- a/lasy/profiles/profile.py
+++ b/lasy/profiles/profile.py
@@ -13,8 +13,8 @@ class Profile(object):
         Initialize the propagation direction of the laser.
         (Each subclass should call this method at initialization.)
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         wavelength: scalar
             Central wavelength for which the laser pulse envelope is defined.
 
@@ -39,14 +39,14 @@ class Profile(object):
         """
         Returns the envelope field of the laser
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         x, y, t: ndarrays of floats
             Define points on which to evaluate the envelope
             These arrays need to all have the same shape.
 
-        Returns:
-        --------
+        Returns
+        -------
         envelope: ndarray of complex numbers
             Contains the value of the envelope at the specified points
             This array has the same shape as the arrays x, y, t

--- a/lasy/profiles/transverse/gaussian_profile.py
+++ b/lasy/profiles/transverse/gaussian_profile.py
@@ -18,8 +18,8 @@ class GaussianTransverseProfile(TransverseProfile):
 
             \mathcal{T}(x, y) = \exp\left( -\frac{x^2 + y^2}{w_0^2} \right)
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         w0: float (in meter)
             The waist of the laser pulse, i.e. :math:`w_0` in the above formula.
         """
@@ -29,14 +29,14 @@ class GaussianTransverseProfile(TransverseProfile):
         """
         Returns the transverse envelope
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         x, y: ndarrays of floats
             Define points on which to evaluate the envelope
             These arrays need to all have the same shape.
 
-        Returns:
-        --------
+        Returns
+        -------
         envelope: ndarray of complex numbers
             Contains the value of the envelope at the specified points
             This array has the same shape as the arrays x, y

--- a/lasy/profiles/transverse/hermite_gaussian_profile.py
+++ b/lasy/profiles/transverse/hermite_gaussian_profile.py
@@ -24,8 +24,8 @@ class HermiteGaussianTransverseProfile(TransverseProfile):
 
         where  :math:`H_{n}` is the Hermite polynomial of order :math:`n`.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         w0: float (in meter)
             The waist of the laser pulse, i.e. :math:`w_0` in the above formula.
         n_x: int (dimensionless)
@@ -42,14 +42,14 @@ class HermiteGaussianTransverseProfile(TransverseProfile):
         """
         Returns the transverse envelope
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         x, y: ndarrays of floats
             Define points on which to evaluate the envelope
             These arrays need to all have the same shape.
 
-        Returns:
-        --------
+        Returns
+        -------
         envelope: ndarray of complex numbers
             Contains the value of the envelope at the specified points
             This array has the same shape as the arrays x, y

--- a/lasy/profiles/transverse/laguerre_gaussian_profile.py
+++ b/lasy/profiles/transverse/laguerre_gaussian_profile.py
@@ -27,8 +27,8 @@ class LaguerreGaussianTransverseProfile(TransverseProfile):
         Generalised Laguerre polynomial of radial order :math:`p` and
         azimuthal order :math:`|m|`
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         w0: float (in meter)
             The waist of the laser pulse, i.e. :math:`w_0` in the above formula.
         p: int (dimensionless)
@@ -45,14 +45,14 @@ class LaguerreGaussianTransverseProfile(TransverseProfile):
         """
         Returns the transverse envelope
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         x, y: ndarrays of floats
             Define points on which to evaluate the envelope
             These arrays need to all have the same shape.
 
-        Returns:
-        --------
+        Returns
+        -------
         envelope: ndarray of complex numbers
             Contains the value of the envelope at the specified points
             This array has the same shape as the arrays x, y

--- a/lasy/profiles/transverse/transverse_profile.py
+++ b/lasy/profiles/transverse/transverse_profile.py
@@ -17,14 +17,14 @@ class TransverseProfile(object):
         """
         Returns the transverse envelope
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         x, y: ndarrays of floats
             Define points on which to evaluate the envelope
             These arrays need to all have the same shape.
 
-        Returns:
-        --------
+        Returns
+        -------
         envelope: ndarray of complex numbers
             Contains the value of the envelope at the specified points
             This array has the same shape as the arrays x, y

--- a/lasy/utils/laser_energy.py
+++ b/lasy/utils/laser_energy.py
@@ -6,14 +6,14 @@ def compute_laser_energy(grid):
     Computes the total laser energy that corresponds to the current
     envelope data. This is used mainly for normalization purposes.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     grid: a Grid object. It contains a ndarrays (V/m) with
           the value of the envelope field and an object of type
           lasy.utils.Box that defines the points at which evaluate the laser
 
-    Returns:
-    --------
+    Returns
+    -------
     energy: float (in Joules)
     """
     # This uses the following volume integral:
@@ -46,7 +46,7 @@ def normalize_energy(energy, grid):
     Normalize energy of the laser pulse contained in grid
 
     Parameters
-    -----------
+    ----------
     energy: scalar (J)
         Energy of the laser pulse after normalization
 


### PR DESCRIPTION
I believe the correct numpy doctsring formatting is
```
Parameters
-----------
```
instead of
```
Parameters:
------------
```
This PR proposes to fix it. To be merged after #67 to avoid potential conflicts.