### PR TITLE
Fix calculation of `box.dx`, following #74

### DIFF
--- a/lasy/utils/box.py
+++ b/lasy/utils/box.py
@@ -53,8 +53,9 @@ class Box:
         else:
             coords = [-1, 0]
         for i in coords:
-            self.axes.append(np.linspace(lo[i], hi[i], npoints[i]))
-            self.dx.append(self.axes[i][1] - self.axes[i][0])
+            axis = np.linspace(lo[i], hi[i], npoints[i])
+            self.axes.append(axis)
+            self.dx.append(axis[1] - axis[0])
             self.npoints.append( npoints[i] )
             self.lo.append( lo[i] )
             self.hi.append( hi[i] )


### PR DESCRIPTION
#74 introduces a bug in the calculation of `box.dx`, which in turn lead to an incorrect calculation of the laser energy, and an incorrect laser amplitude, as mentioned in the comments of #74.

This PR fixes the issue.