### PR TITLE
Fix warning 'DeprecationWarning: invalid escape sequence' in lasy/pro…

### DIFF
--- a/lasy/profiles/gaussian_profile.py
+++ b/lasy/profiles/gaussian_profile.py
@@ -31,7 +31,7 @@ class GaussianProfile(CombinedLongitudinalTransverseProfile):
         ----------
         wavelength: float (in meter)
             The main laser wavelength :math:`\\lambda_0` of the laser, which
-            defines :math:`\omega_0` in the above formula, according to
+            defines :math:`\\omega_0` in the above formula, according to
             :math:`\\omega_0 = 2\\pi c/\\lambda_0`.
 
         pol: list of 2 complex numbers (dimensionless)


### PR DESCRIPTION
This PR fixes a `DeprecationWarning: invalid escape sequence` in `gaussian_profile.py`