### PR TITLE
[WIP] Add jinc laser-profile

### DIFF
--- a/lasy/profiles/transverse/jinc_profile.py
+++ b/lasy/profiles/transverse/jinc_profile.py
@@ -44,6 +44,6 @@ class JincTransverseProfile(TransverseProfile):
             This array has the same shape as the arrays x, y
         """
         r_over_w0 = np.sqrt(x**2 + y**2)/self.w0
-        envelope = np.where(r_over_w0 !=0, scispe.jv(1, r_over_w0)/r_over_w0, 1.0)
+        envelope = np.where(r_over_w0 !=0, 2.0*scispe.jv(1, r_over_w0)/r_over_w0, 1.0)
 
         return envelope

--- a/lasy/profiles/transverse/jinc_profile.py
+++ b/lasy/profiles/transverse/jinc_profile.py
@@ -1,0 +1,49 @@
+import numpy as np
+import scipy.special as scispe
+from .transverse_profile import TransverseProfile
+
+class JincTransverseProfile(TransverseProfile):
+    """
+    Derived class for the analytic profile of a Jinc laser pulse.
+    """
+
+    def __init__(self, w0):
+        """
+        Defines a Jinc transverse envelope.
+
+        More precisely, the transverse envelope
+        (to be used in the :class:CombinedLongitudinalTransverseLaser class)
+        corresponds to:
+
+        .. math::
+
+            \\mathcal{T}(x, y) = \\frac{J_1(r/w_0)}{r/w_0} \\textrm{, with } r=\\sqrt{x^2+y^2}
+        where :math:`J_1` is the Bessel function of the first kind with order one
+
+        Parameters
+        ----------
+        w0: float (in meter)
+            The waist of the laser pulse, i.e. :math:`w_0` in the above formula.
+        """
+        self.w0 = w0
+
+    def evaluate( self, x, y ):
+        """
+        Returns the transverse envelope
+
+        Parameters
+        ----------
+        x, y: ndarrays of floats
+            Define points on which to evaluate the envelope
+            These arrays need to all have the same shape.
+
+        Returns
+        -------
+        envelope: ndarray of complex numbers
+            Contains the value of the envelope at the specified points
+            This array has the same shape as the arrays x, y
+        """
+        r_over_w0 = np.sqrt(x**2 + y**2)/self.w0
+        envelope = np.where(r_over_w0 !=0, scispe.jv(1, r_over_w0)/r_over_w0, 1.0)
+
+        return envelope

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -70,3 +70,26 @@ def test_profile_laguerre_gauss():
     laser.write_to_file('laguerrelaserRZ')
     laser.propagate(1e-6)
     laser.write_to_file('laguerrelaserRZ')
+
+def test_profile_jinc():
+    # Case with Jinc laser
+    wavelength=.8e-6
+    pol = (1,0)
+    laser_energy = 1. # J
+    t_peak = 0.e-15 # s
+    tau = 30.e-15 # s
+    w0 = 5.e-6 # m
+    profile = CombinedLongitudinalTransverseProfile( wavelength, pol, laser_energy,
+                GaussianLongitudinalProfile( wavelength, tau, t_peak ),
+                JincTransverseProfile( w0 ) )
+
+    # - Cylindrical case
+    dim = 'rt'
+    lo = (0e-6, -60e-15)
+    hi = (10e-6, +60e-15)
+    npoints=(50,100)
+
+    laser = Laser(dim, lo, hi, npoints, profile, n_azimuthal_modes=2)
+    laser.write_to_file('jinclaserRZ')
+    laser.propagate(1e-6)
+    laser.write_to_file('jinclaserRZ')


### PR DESCRIPTION
This Work-In-Progress PR adds Jinc transverse laser-profile.

I think that we have one point to discuss:
- Should we choose the parameter `k` in `2 J1(κ_r/r_0)/(κr/r_0)` in such a way that the FWHM matches that of a Gaussian pulse?