### PR TITLE
Add transverse laser from data and offset profile functionality

### DIFF
--- a/lasy/profiles/transverse/gaussian_profile.py
+++ b/lasy/profiles/transverse/gaussian_profile.py
@@ -28,7 +28,7 @@ class GaussianTransverseProfile(TransverseProfile):
         super().__init__()
         self.w0 = w0
 
-    def evaluate(self, x, y):
+    def _evaluate(self, x, y):
         """
         Returns the transverse envelope
 

--- a/lasy/profiles/transverse/hermite_gaussian_profile.py
+++ b/lasy/profiles/transverse/hermite_gaussian_profile.py
@@ -40,7 +40,7 @@ class HermiteGaussianTransverseProfile(TransverseProfile):
         self.n_x = n_x
         self.n_y = n_y
 
-    def evaluate(self, x, y):
+    def _evaluate(self, x, y):
         """
         Returns the transverse envelope
 

--- a/lasy/profiles/transverse/laguerre_gaussian_profile.py
+++ b/lasy/profiles/transverse/laguerre_gaussian_profile.py
@@ -43,7 +43,7 @@ class LaguerreGaussianTransverseProfile(TransverseProfile):
         self.p = p
         self.m = m
 
-    def evaluate(self, x, y):
+    def _evaluate(self, x, y):
         """
         Returns the transverse envelope
 

--- a/lasy/profiles/transverse/super_gaussian_profile.py
+++ b/lasy/profiles/transverse/super_gaussian_profile.py
@@ -32,7 +32,7 @@ class SuperGaussianTransverseProfile(TransverseProfile):
         self.w0 = w0
         self.n_order = n_order
 
-    def evaluate(self, x, y):
+    def _evaluate(self, x, y):
         """
         Returns the transverse envelope
 

--- a/lasy/profiles/transverse/transverse_profile.py
+++ b/lasy/profiles/transverse/transverse_profile.py
@@ -12,10 +12,14 @@ class TransverseProfile(object):
     def __init__(self):
         """
         Initialize the transverse profile.
-        """
-        pass
 
-    def evaluate(self, x, y):
+        Here we initialise x and y spatial offsets as placeholders
+        """
+        self.x_offset = 0
+        self.y_offset = 0
+        
+
+    def _evaluate(self, x, y):
         """
         Returns the transverse envelope
 
@@ -34,3 +38,44 @@ class TransverseProfile(object):
         # The base class only defines dummy fields
         # (This should be replaced by any class that inherits from this one.)
         return np.zeros(x.shape, dtype="complex128")
+
+    def evaluate(self, x, y):
+        """
+        Returns the transverse envelope modified by any spatial offsets.
+        This is the public facing evaluate method.
+
+        Parameters
+        ----------
+        x, y: ndarrays of floats
+            Define points on which to evaluate the envelope
+            These arrays need to all have the same shape.
+
+        Returns
+        -------
+        envelope: ndarray of complex numbers
+            Contains the value of the envelope at the specified points
+            This array has the same shape as the arrays x, y
+        """
+        
+        return self._evaluate( x + self.x_offset, y + self.y_offset )
+
+    def offset(self,x_offset,y_offset):
+        """ 
+        Populates the x and y spatial offsets of the profile
+        The profile will be shifted by these according to
+        x+x_offset and y+y_offset prior to execution of 
+        _evaluate
+        
+
+        Parameters
+        ----------
+        x_offset, y_offset: floats (m)
+            Define spatial offsets to the beam. That is, how much
+            to shift the beam by transversely 
+
+        """
+
+        self.x_offset = x_offset
+        self.y_offset = y_offset
+
+        return self

--- a/lasy/profiles/transverse/transverse_profile.py
+++ b/lasy/profiles/transverse/transverse_profile.py
@@ -58,7 +58,7 @@ class TransverseProfile(object):
 
         return self._evaluate(x + self.x_offset, y + self.y_offset)
 
-    def offset(self, x_offset, y_offset):
+    def set_offset(self, x_offset, y_offset):
         """
         Populates the x and y spatial offsets of the profile
         The profile will be shifted by these according to

--- a/lasy/profiles/transverse/transverse_profile.py
+++ b/lasy/profiles/transverse/transverse_profile.py
@@ -41,7 +41,7 @@ class TransverseProfile(object):
     def evaluate(self, x, y):
         """
         Returns the transverse envelope modified by any spatial offsets.
-        This is the public facing evaluate method.
+        This is the public facing evaluate method, it calls the _evaluate function of the derived class.
 
         Parameters
         ----------

--- a/lasy/profiles/transverse/transverse_profile.py
+++ b/lasy/profiles/transverse/transverse_profile.py
@@ -17,7 +17,6 @@ class TransverseProfile(object):
         """
         self.x_offset = 0
         self.y_offset = 0
-        
 
     def _evaluate(self, x, y):
         """
@@ -56,22 +55,22 @@ class TransverseProfile(object):
             Contains the value of the envelope at the specified points
             This array has the same shape as the arrays x, y
         """
-        
-        return self._evaluate( x + self.x_offset, y + self.y_offset )
 
-    def offset(self,x_offset,y_offset):
-        """ 
+        return self._evaluate(x + self.x_offset, y + self.y_offset)
+
+    def offset(self, x_offset, y_offset):
+        """
         Populates the x and y spatial offsets of the profile
         The profile will be shifted by these according to
-        x+x_offset and y+y_offset prior to execution of 
+        x+x_offset and y+y_offset prior to execution of
         _evaluate
-        
+
 
         Parameters
         ----------
         x_offset, y_offset: floats (m)
             Define spatial offsets to the beam. That is, how much
-            to shift the beam by transversely 
+            to shift the beam by transversely
 
         """
 

--- a/lasy/profiles/transverse/transverse_profile_from_data.py
+++ b/lasy/profiles/transverse/transverse_profile_from_data.py
@@ -41,6 +41,8 @@ class TransverseProfileFromData(TransverseProfile):
             center of mass.
 
         """
+        super().__init__()
+        
         intensity_data = intensity_data.astype("float64")
 
         n_y, n_x = np.shape(intensity_data)
@@ -56,20 +58,6 @@ class TransverseProfileFromData(TransverseProfile):
         # Normalise the profile such that its squared integeral == 1
         intensity_data /= np.sum(intensity_data) * dx * dy
 
-        if center_beam:
-            # find the beam center using COM
-            img_tot = np.sum(intensity_data)
-            x0 = np.sum(np.dot(intensity_data, x_data)) / img_tot
-            y0 = np.sum(np.dot(intensity_data.T, y_data)) / img_tot
-
-            x_data -= x0
-            y_data -= y0
-
-            self.beam_shift_x = x0
-            self.beam_shift_y = y0
-        else:
-            self.beam_shift_x = 0
-            self.beam_shift_y = 0
 
         # Note here we use the square root of intensity to get the 'field'
         self.field_interp = RegularGridInterpolator(
@@ -81,7 +69,7 @@ class TransverseProfileFromData(TransverseProfile):
 
         self.center_beam = center_beam
 
-    def evaluate(self, x, y):
+    def _evaluate(self, x, y):
         """
         Returns the transverse envelope
 

--- a/lasy/profiles/transverse/transverse_profile_from_data.py
+++ b/lasy/profiles/transverse/transverse_profile_from_data.py
@@ -11,7 +11,7 @@ class TransverseProfileFromData(TransverseProfile):
     of another code.
     """
 
-    def __init__(self, intensity_data, lo, hi, center_beam=True):
+    def __init__(self, intensity_data, lo, hi):
         """
         Uses user supplied data to define the transverse profile
         of the laser pulse.
@@ -35,11 +35,6 @@ class TransverseProfileFromData(TransverseProfile):
         lo, hi : list of scalars (in meters)
             Lower and higher end of the physical domain of the data.
             One element per direction (in this case 2)
-
-        center_beam: bool
-            If True (default), the beam will be centered based on its
-            center of mass.
-
         """
         super().__init__()
 
@@ -65,8 +60,6 @@ class TransverseProfileFromData(TransverseProfile):
             bounds_error=False,
             fill_value=0.0,
         )
-
-        self.center_beam = center_beam
 
     def _evaluate(self, x, y):
         """

--- a/lasy/profiles/transverse/transverse_profile_from_data.py
+++ b/lasy/profiles/transverse/transverse_profile_from_data.py
@@ -41,7 +41,8 @@ class TransverseProfileFromData(TransverseProfile):
             center of mass.
 
         """
-
+        intensity_data = intensity_data.astype('float64')
+        
         n_y, n_x = np.shape(intensity_data)
         
         dx = (hi[0] - lo[0])/n_x
@@ -51,10 +52,12 @@ class TransverseProfileFromData(TransverseProfile):
         y_data = np.linspace(lo[1],hi[1],n_y)
         
         assert dx == dy, "Data elements are not square"
-
+        
+        # Normalise the profile such that its squared integeral == 1
+        intensity_data /= np.sum(intensity_data)*dx*dy
 
         if center_beam:
-            # find the beam center
+            # find the beam center using COM
             img_tot = np.sum(intensity_data)
             x0 = np.sum(np.dot(intensity_data, x_data)) / img_tot
             y0 = np.sum(np.dot(intensity_data.T, y_data)) / img_tot
@@ -68,9 +71,10 @@ class TransverseProfileFromData(TransverseProfile):
             self.beam_shift_x = 0
             self.beam_shift_y = 0
 
+        # Note here we use the square root of intensity to get the 'field'
         self.field_interp = RegularGridInterpolator((y_data,x_data),
                                 np.sqrt(intensity_data), bounds_error=False,
-                                fill_value=0)
+                                fill_value=0.0)
                                 
         self.center_beam = center_beam
 

--- a/lasy/profiles/transverse/transverse_profile_from_data.py
+++ b/lasy/profiles/transverse/transverse_profile_from_data.py
@@ -1,0 +1,100 @@
+import numpy as np
+from scipy.interpolate import RegularGridInterpolator
+
+from .transverse_profile import TransverseProfile
+
+
+class TransverseProfileFromData(TransverseProfile):
+    """
+    Derived class for transverse laser profile created using
+    data from an experimental measurement or from the output
+    of another code. 
+    """
+
+    def __init__(self,intensity_data,lo,hi,center_beam=True):
+        """
+        Uses user supplied data to define the transverse profile
+        of the laser pulse.
+
+        The data must be supplied as a 2D numpy array of intensity 
+        values (for example an imported cameran image from an 
+        experimental measurement). 
+        
+        In the case of experimental measurements, this data 
+        should already have some undergone some preprocessing 
+        such as background subtraction and noise removal.
+
+        The beam will be imported and automatically centered unless
+        otherwise specified.
+        
+        Parameters:
+        -----------
+        intensity_data: 2Darray of floats 
+            The 2D transverse intensity profile of the laser pulse. 
+            
+        lo, hi : list of scalars (in meters)
+            Lower and higher end of the physical domain of the data.
+            One element per direction (in this case 2)
+
+        center_beam: bool
+            If True (default), the beam will be centered based on its
+            center of mass.
+
+        """
+
+        n_y, n_x = np.shape(intensity_data)
+        
+        dx = (hi[0] - lo[0])/n_x
+        dy = (hi[1] - lo[1])/n_y
+
+        x_data = np.linspace(lo[0],hi[0],n_x)
+        y_data = np.linspace(lo[1],hi[1],n_y)
+        
+        assert dx == dy, "Data elements are not square"
+
+
+        if center_beam:
+            # find the beam center
+            img_tot = np.sum(intensity_data)
+            x0 = np.sum(np.dot(intensity_data, x_data)) / img_tot
+            y0 = np.sum(np.dot(intensity_data.T, y_data)) / img_tot
+
+            x_data -= x0
+            y_data -= y0
+
+            self.beam_shift_x = x0
+            self.beam_shift_y = y0
+        else:
+            self.beam_shift_x = 0
+            self.beam_shift_y = 0
+
+        self.field_interp = RegularGridInterpolator((y_data,x_data),
+                                np.sqrt(intensity_data), bounds_error=False,
+                                fill_value=0)
+                                
+        self.center_beam = center_beam
+
+
+
+
+    def evaluate(self, x, y):
+        """
+        Returns the transverse envelope
+
+        Parameters
+        ----------
+        x, y: ndarrays of floats
+            Define points on which to evaluate the envelope
+            These arrays need to all have the same shape.
+
+        Returns
+        -------
+        envelope: ndarray of floats
+            Contains the value of the envelope at the specified points
+            This array has the same shape as the arrays x, y
+        """
+
+        envelope = self.field_interp((y,x))
+
+        return envelope
+

--- a/lasy/profiles/transverse/transverse_profile_from_data.py
+++ b/lasy/profiles/transverse/transverse_profile_from_data.py
@@ -8,30 +8,30 @@ class TransverseProfileFromData(TransverseProfile):
     """
     Derived class for transverse laser profile created using
     data from an experimental measurement or from the output
-    of another code. 
+    of another code.
     """
 
-    def __init__(self,intensity_data,lo,hi,center_beam=True):
+    def __init__(self, intensity_data, lo, hi, center_beam=True):
         """
         Uses user supplied data to define the transverse profile
         of the laser pulse.
 
-        The data must be supplied as a 2D numpy array of intensity 
-        values (for example an imported cameran image from an 
-        experimental measurement). 
-        
-        In the case of experimental measurements, this data 
-        should already have some undergone some preprocessing 
+        The data must be supplied as a 2D numpy array of intensity
+        values (for example an imported cameran image from an
+        experimental measurement).
+
+        In the case of experimental measurements, this data
+        should already have some undergone some preprocessing
         such as background subtraction and noise removal.
 
         The beam will be imported and automatically centered unless
         otherwise specified.
-        
+
         Parameters:
         -----------
-        intensity_data: 2Darray of floats 
-            The 2D transverse intensity profile of the laser pulse. 
-            
+        intensity_data: 2Darray of floats
+            The 2D transverse intensity profile of the laser pulse.
+
         lo, hi : list of scalars (in meters)
             Lower and higher end of the physical domain of the data.
             One element per direction (in this case 2)
@@ -41,20 +41,20 @@ class TransverseProfileFromData(TransverseProfile):
             center of mass.
 
         """
-        intensity_data = intensity_data.astype('float64')
-        
-        n_y, n_x = np.shape(intensity_data)
-        
-        dx = (hi[0] - lo[0])/n_x
-        dy = (hi[1] - lo[1])/n_y
+        intensity_data = intensity_data.astype("float64")
 
-        x_data = np.linspace(lo[0],hi[0],n_x)
-        y_data = np.linspace(lo[1],hi[1],n_y)
-        
+        n_y, n_x = np.shape(intensity_data)
+
+        dx = (hi[0] - lo[0]) / n_x
+        dy = (hi[1] - lo[1]) / n_y
+
+        x_data = np.linspace(lo[0], hi[0], n_x)
+        y_data = np.linspace(lo[1], hi[1], n_y)
+
         assert dx == dy, "Data elements are not square"
-        
+
         # Normalise the profile such that its squared integeral == 1
-        intensity_data /= np.sum(intensity_data)*dx*dy
+        intensity_data /= np.sum(intensity_data) * dx * dy
 
         if center_beam:
             # find the beam center using COM
@@ -72,14 +72,14 @@ class TransverseProfileFromData(TransverseProfile):
             self.beam_shift_y = 0
 
         # Note here we use the square root of intensity to get the 'field'
-        self.field_interp = RegularGridInterpolator((y_data,x_data),
-                                np.sqrt(intensity_data), bounds_error=False,
-                                fill_value=0.0)
-                                
+        self.field_interp = RegularGridInterpolator(
+            (y_data, x_data),
+            np.sqrt(intensity_data),
+            bounds_error=False,
+            fill_value=0.0,
+        )
+
         self.center_beam = center_beam
-
-
-
 
     def evaluate(self, x, y):
         """
@@ -98,7 +98,6 @@ class TransverseProfileFromData(TransverseProfile):
             This array has the same shape as the arrays x, y
         """
 
-        envelope = self.field_interp((y,x))
+        envelope = self.field_interp((y, x))
 
         return envelope
-

--- a/lasy/profiles/transverse/transverse_profile_from_data.py
+++ b/lasy/profiles/transverse/transverse_profile_from_data.py
@@ -42,7 +42,7 @@ class TransverseProfileFromData(TransverseProfile):
 
         """
         super().__init__()
-        
+
         intensity_data = intensity_data.astype("float64")
 
         n_y, n_x = np.shape(intensity_data)
@@ -57,7 +57,6 @@ class TransverseProfileFromData(TransverseProfile):
 
         # Normalise the profile such that its squared integeral == 1
         intensity_data /= np.sum(intensity_data) * dx * dy
-
 
         # Note here we use the square root of intensity to get the 'field'
         self.field_interp = RegularGridInterpolator(

--- a/lasy/utils/exp_data_utils.py
+++ b/lasy/utils/exp_data_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def find_com(img):
+def find_center_of_mass(img):
     """
     Finds the center of mass of an image.
 

--- a/lasy/utils/exp_data_utils.py
+++ b/lasy/utils/exp_data_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+def find_com(img):
+    """
+    Finds the center of mass of an image.
+
+    Parameters:
+    -----------
+    img: 2Darray of floats
+        The image on which to calculate the COM
+
+    Returns:
+    --------
+    x0 , y0: floats
+        The center of mass of the image along the horizontal
+        and the vertical. The units are in pixels.
+    
+    """
+    rows,cols = np.shape(img)
+    x_data = np.linspace(0,cols-1,cols)
+    y_data = np.linspace(0,rows-1,rows)
+
+    # find the beam center using COM
+    img_tot = np.sum(img)
+    x0 = np.sum(np.dot(img, x_data)) / img_tot
+    y0 = np.sum(np.dot(img.T, y_data)) / img_tot
+    
+    return x0 , y0
+
+

--- a/lasy/utils/exp_data_utils.py
+++ b/lasy/utils/exp_data_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def find_com(img):
     """
     Finds the center of mass of an image.
@@ -14,17 +15,15 @@ def find_com(img):
     x0 , y0: floats
         The center of mass of the image along the horizontal
         and the vertical. The units are in pixels.
-    
+
     """
-    rows,cols = np.shape(img)
-    x_data = np.linspace(0,cols-1,cols)
-    y_data = np.linspace(0,rows-1,rows)
+    rows, cols = np.shape(img)
+    x_data = np.linspace(0, cols - 1, cols)
+    y_data = np.linspace(0, rows - 1, rows)
 
     # find the beam center using COM
     img_tot = np.sum(img)
     x0 = np.sum(np.dot(img, x_data)) / img_tot
     y0 = np.sum(np.dot(img.T, y_data)) / img_tot
-    
-    return x0 , y0
 
-
+    return x0, y0


### PR DESCRIPTION
simple class to import a transverse laser profile from data. It takes a 2D intensity image together with the lo and hi ends of the physical domain on which the data is defined. Importantly, the data must already be imported into a numpy array and pre-processed to have the background removed. This should be done outside this class and we can provide some functionality for it in utils. 

Another optional argument is "center_beam" which is true by default and centers the beam beam based on the center of mass of the data. This is useful when pulling in images from cameras where the beam position is arbitrary, but may want to be set to False when the laser beam position in the data is important. 

The profiles are normalised such that the 2D integral of the intensity is 1.