### PR TITLE
Populate __init__ to simplify imports

### DIFF
--- a/examples/test.py
+++ b/examples/test.py
@@ -1,6 +1,5 @@
 from lasy.laser import Laser
-from lasy.profiles import CombinedLongitudinalTransverseProfile
-from lasy.profiles import GaussianProfile
+from lasy.profiles import CombinedLongitudinalTransverseProfile, GaussianProfile
 from lasy.profiles.longitudinal import GaussianLongitudinalProfile
 from lasy.profiles.transverse import LaguerreGaussianTransverseProfile
 

--- a/examples/test.py
+++ b/examples/test.py
@@ -1,10 +1,8 @@
 from lasy.laser import Laser
-from lasy.profiles.combined_profile import CombinedLongitudinalTransverseProfile
-from lasy.profiles.gaussian_profile import GaussianProfile
-from lasy.profiles.longitudinal.gaussian_profile import GaussianLongitudinalProfile
-from lasy.profiles.transverse.laguerre_gaussian_profile import (
-    LaguerreGaussianTransverseProfile,
-)
+from lasy.profiles import CombinedLongitudinalTransverseProfile
+from lasy.profiles import GaussianProfile
+from lasy.profiles.longitudinal import GaussianLongitudinalProfile
+from lasy.profiles.transverse import LaguerreGaussianTransverseProfile
 
 # Case with Gaussian laser
 

--- a/lasy/profiles/__init__.py
+++ b/lasy/profiles/__init__.py
@@ -1,0 +1,4 @@
+from .combined_profile import CombinedLongitudinalTransverseProfile
+from .gaussian_profile import GaussianProfile
+
+__all__ = ["CombinedLongitudinalTransverseProfile", "GaussianProfile"]

--- a/lasy/profiles/gaussian_profile.py
+++ b/lasy/profiles/gaussian_profile.py
@@ -1,6 +1,6 @@
-from .combined_profile import CombinedLongitudinalTransverseProfile
-from .longitudinal.gaussian_profile import GaussianLongitudinalProfile
-from .transverse.gaussian_profile import GaussianTransverseProfile
+from . import CombinedLongitudinalTransverseProfile
+from .longitudinal import GaussianLongitudinalProfile
+from .transverse import GaussianTransverseProfile
 
 
 class GaussianProfile(CombinedLongitudinalTransverseProfile):

--- a/lasy/profiles/longitudinal/__init__.py
+++ b/lasy/profiles/longitudinal/__init__.py
@@ -1,0 +1,3 @@
+from .gaussian_profile import GaussianLongitudinalProfile
+
+__all__ = ['GaussianLongitudinalProfile']

--- a/lasy/profiles/longitudinal/__init__.py
+++ b/lasy/profiles/longitudinal/__init__.py
@@ -1,3 +1,3 @@
 from .gaussian_profile import GaussianLongitudinalProfile
 
-__all__ = ['GaussianLongitudinalProfile']
+__all__ = ["GaussianLongitudinalProfile"]

--- a/lasy/profiles/transverse/__init__.py
+++ b/lasy/profiles/transverse/__init__.py
@@ -7,5 +7,5 @@ __all__ = [
     "GaussianTransverseProfile",
     "HermiteGaussianTransverseProfile",
     "LaguerreGaussianTransverseProfile",
-    "SuperGaussianTransverProfile",
+    "SuperGaussianTransverseProfile",
 ]

--- a/lasy/profiles/transverse/__init__.py
+++ b/lasy/profiles/transverse/__init__.py
@@ -3,4 +3,9 @@ from .hermite_gaussian_profile import HermiteGaussianTransverseProfile
 from .laguerre_gaussian_profile import LaguerreGaussianTransverseProfile
 from .super_gaussian_profile import SuperGaussianTransverProfile
 
-__all__ = ['GaussianTransverseProfile', 'HermiteGaussianTransverseProfile', 'LaguerreGaussianTransverseProfile', 'SuperGaussianTransverProfile']
+__all__ = [
+    "GaussianTransverseProfile",
+    "HermiteGaussianTransverseProfile",
+    "LaguerreGaussianTransverseProfile",
+    "SuperGaussianTransverProfile",
+]

--- a/lasy/profiles/transverse/__init__.py
+++ b/lasy/profiles/transverse/__init__.py
@@ -1,7 +1,7 @@
 from .gaussian_profile import GaussianTransverseProfile
 from .hermite_gaussian_profile import HermiteGaussianTransverseProfile
 from .laguerre_gaussian_profile import LaguerreGaussianTransverseProfile
-from .super_gaussian_profile import SuperGaussianTransverProfile
+from .super_gaussian_profile import SuperGaussianTransverseProfile
 
 __all__ = [
     "GaussianTransverseProfile",

--- a/lasy/profiles/transverse/__init__.py
+++ b/lasy/profiles/transverse/__init__.py
@@ -1,0 +1,6 @@
+from .gaussian_profile import GaussianTransverseProfile
+from .hermite_gaussian_profile import HermiteGaussianTransverseProfile
+from .laguerre_gaussian_profile import LaguerreGaussianTransverseProfile
+from .super_gaussian_profile import SuperGaussianTransverProfile
+
+__all__ = ['GaussianTransverseProfile', 'HermiteGaussianTransverseProfile', 'LaguerreGaussianTransverseProfile', 'SuperGaussianTransverProfile']

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -1,18 +1,13 @@
-# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-A
 
 import pytest
 
 from lasy.laser import Laser
-from lasy.profiles.combined_profile import CombinedLongitudinalTransverseProfile
-from lasy.profiles.gaussian_profile import GaussianProfile
-from lasy.profiles.longitudinal.gaussian_profile import GaussianLongitudinalProfile
-from lasy.profiles.transverse.laguerre_gaussian_profile import (
-    LaguerreGaussianTransverseProfile,
-)
-from lasy.profiles.transverse.super_gaussian_profile import (
-    SuperGaussianTransverseProfile,
-)
-
+from lasy.profiles import CombinedLongitudinalTransverseProfile
+from lasy.profiles import GaussianProfile
+from lasy.profiles.longitudinal import GaussianLongitudinalProfile
+from lasy.profiles.transverse import LaguerreGaussianTransverseProfile
+from lasy.profiles.transverse import SuperGaussianTransverseProfile
 
 @pytest.fixture(scope="function")
 def gaussian():

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-A
+# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -9,6 +9,7 @@ from lasy.profiles.longitudinal import GaussianLongitudinalProfile
 from lasy.profiles.transverse import LaguerreGaussianTransverseProfile
 from lasy.profiles.transverse import SuperGaussianTransverseProfile
 
+
 @pytest.fixture(scope="function")
 def gaussian():
     # Cases with Gaussian laser

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -5,7 +5,10 @@ import pytest
 from lasy.laser import Laser
 from lasy.profiles import CombinedLongitudinalTransverseProfile, GaussianProfile
 from lasy.profiles.longitudinal import GaussianLongitudinalProfile
-from lasy.profiles.transverse import LaguerreGaussianTransverseProfile, SuperGaussianTransverseProfile
+from lasy.profiles.transverse import (
+    LaguerreGaussianTransverseProfile,
+    SuperGaussianTransverseProfile,
+)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -3,11 +3,9 @@
 import pytest
 
 from lasy.laser import Laser
-from lasy.profiles import CombinedLongitudinalTransverseProfile
-from lasy.profiles import GaussianProfile
+from lasy.profiles import CombinedLongitudinalTransverseProfile, GaussianProfile
 from lasy.profiles.longitudinal import GaussianLongitudinalProfile
-from lasy.profiles.transverse import LaguerreGaussianTransverseProfile
-from lasy.profiles.transverse import SuperGaussianTransverseProfile
+from lasy.profiles.transverse import LaguerreGaussianTransverseProfile, SuperGaussianTransverseProfile
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
This PR proposes to add imports in the __init__ files for easier import lines. This should also help in CI.