### PR TITLE
Go back to `xyt`/`rt` order internal representation in `lasy`

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -55,14 +55,14 @@ class Laser:
 
         # Create the grid on which to evaluate the laser, evaluate it
         if self.dim == "xyt":
-            x, y, t = np.meshgrid( *box.axes, indexing='ij')
-            self.field.field[...] = profile.evaluate( x, y, t )
+            x, y, t = np.meshgrid(*box.axes, indexing="ij")
+            self.field.field[...] = profile.evaluate(x, y, t)
         elif self.dim == "rt":
             # Generate 2*n_azimuthal_modes - 1 evenly-spaced values of
             # theta, to evaluate the laser
             n_theta = 2 * box.n_azimuthal_modes - 1
-            theta1d = 2 * np.pi/n_theta * np.arange(n_theta)
-            theta, r, t = np.meshgrid( theta1d, *box.axes, indexing="ij")
+            theta1d = 2 * np.pi / n_theta * np.arange(n_theta)
+            theta, r, t = np.meshgrid(theta1d, *box.axes, indexing="ij")
             x = r * np.cos(theta)
             y = r * np.sin(theta)
             # Evaluate the profile on the generated grid

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -55,14 +55,14 @@ class Laser:
 
         # Create the grid on which to evaluate the laser, evaluate it
         if self.dim == "xyt":
-            t, x, y = np.meshgrid(*box.axes, indexing="ij")
-            self.field.field[...] = profile.evaluate(x, y, t)
+            x, y, t = np.meshgrid( *box.axes, indexing='ij')
+            self.field.field[...] = profile.evaluate( x, y, t )
         elif self.dim == "rt":
             # Generate 2*n_azimuthal_modes - 1 evenly-spaced values of
             # theta, to evaluate the laser
             n_theta = 2 * box.n_azimuthal_modes - 1
-            theta1d = 2 * np.pi / n_theta * np.arange(n_theta)
-            theta, t, r = np.meshgrid(theta1d, *box.axes, indexing="ij")
+            theta1d = 2 * np.pi/n_theta * np.arange(n_theta)
+            theta, r, t = np.meshgrid( theta1d, *box.axes, indexing="ij")
             x = r * np.cos(theta)
             y = r * np.sin(theta)
             # Evaluate the profile on the generated grid

--- a/lasy/utils/box.py
+++ b/lasy/utils/box.py
@@ -39,27 +39,14 @@ class Box:
         assert len(lo) == ndims
         assert len(hi) == ndims
 
-        self.lo = []
-        self.hi = []
-        self.npoints = []
+        self.lo = list(lo)
+        self.hi = list(hi)
+        self.npoints = npoints
         self.axes = []
         self.dx = []
-        # Loop through coordinates, starting with time (index -1, i.e. last
-        # element in `lo`, `hi`, etc.) and then continuing with x and y
-        # in 3D Cartesian (index 0 and 1) or with r in cylindrical (index 0)
-        # This is in order to make time the slowest-varying variable
-        # throughout the code (i.e. first variable, in C-order arrays)
-        if dim == "xyt":
-            coords = [-1, 0, 1]
-        else:
-            coords = [-1, 0]
-        for i in coords:
-            axis = np.linspace(lo[i], hi[i], npoints[i])
-            self.axes.append(axis)
-            self.dx.append(axis[1] - axis[0])
-            self.npoints.append(npoints[i])
-            self.lo.append(lo[i])
-            self.hi.append(hi[i])
+        for i in range(ndims):
+            self.axes.append(np.linspace(lo[i], hi[i], npoints[i]))
+            self.dx.append(self.axes[i][1] - self.axes[i][0])
 
         if dim == "rt":
             self.n_azimuthal_modes = n_azimuthal_modes

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -35,18 +35,18 @@ def compute_laser_energy(dim, grid):
     envelope = grid.field
     box = grid.box
 
-    dz = box.dx[0] * scc.c
+    dz = box.dx[-1] * scc.c
 
     if dim == "xyt":
-        dV = box.dx[1] * box.dx[2] * dz
+        dV = box.dx[0] * box.dx[1] * dz
         energy = ((dV * scc.epsilon_0 * 0.5) * abs(envelope) ** 2).sum()
     elif dim == "rt":
-        r = box.axes[1]
-        dr = box.dx[1]
+        r = box.axes[0]
+        dr = box.dx[0]
         # 1D array that computes the volume of radial cells
         dV = np.pi * ((r + 0.5 * dr) ** 2 - (r - 0.5 * dr) ** 2) * dz
         energy = (
-            dV[np.newaxis, np.newaxis, :]
+            dV[np.newaxis, :, np.newaxis]
             * scc.epsilon_0
             * 0.5
             * abs(envelope[:, :, :]) ** 2

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -47,8 +47,8 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
     m = i.meshes["laserEnvelope"]
     m.grid_spacing = [
         (hi - lo) / npoints for hi, lo, npoints \
-        in zip(box.hi, box.lo, box.npoints)[::-1]
-    ]
+        in zip(box.hi, box.lo, box.npoints)
+    ][::-1]
     m.grid_global_offset = box.lo
     m.unit_dimension = {
         io.Unit_Dimension.M: 1,
@@ -67,7 +67,7 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
     if dim == "xyt":
         # Switch from x,y,t (internal to lasy) to t,y,x (in openPMD file)
         # This is because many PIC codes expect x to be the fastest index
-        data = np.transpose( array )
+        data = np.transpose( array ).copy()
     elif dim == "rt":
         # The representation of modes in openPMD
         # (see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#required-attributes-for-each-mesh-record)
@@ -83,7 +83,7 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
             data[2 * mode, :, :] = -1.0j * array[mode, :, :] + 1.0j * array[-mode, :, :]
         # Switch from m,r,t (internal to lasy) to m,t,r (in openPMD file)
         # This is because many PIC codes expect r to be the fastest index
-        data = np.transpose( data, axes=[0, 2, 1] )
+        data = np.transpose( data, axes=[0, 2, 1] ).copy()
 
     # Define the dataset
     dataset = io.Dataset(data.dtype, data.shape)

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -46,8 +46,7 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
     # Define the mesh
     m = i.meshes["laserEnvelope"]
     m.grid_spacing = [
-        (hi - lo) / npoints for hi, lo, npoints \
-        in zip(box.hi, box.lo, box.npoints)
+        (hi - lo) / npoints for hi, lo, npoints in zip(box.hi, box.lo, box.npoints)
     ][::-1]
     m.grid_global_offset = box.lo
     m.unit_dimension = {

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -46,7 +46,8 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
     # Define the mesh
     m = i.meshes["laserEnvelope"]
     m.grid_spacing = [
-        (hi - lo) / npoints for hi, lo, npoints in zip(box.hi, box.lo, box.npoints)
+        (hi - lo) / npoints for hi, lo, npoints \
+        in zip(box.hi, box.lo, box.npoints)[::-1]
     ]
     m.grid_global_offset = box.lo
     m.unit_dimension = {
@@ -61,12 +62,6 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
     elif dim == "rt":
         m.geometry = io.Geometry.thetaMode
         m.axis_labels = ["t", "r"]
-
-    # Define the dataset
-    dataset = io.Dataset(array.dtype, array.shape)
-    env = m[io.Mesh_Record_Component.SCALAR]
-    env.position = [0] * len(dim)
-    env.reset_dataset(dataset)
 
     # Pick the correct field
     if dim == "xyt":
@@ -90,6 +85,11 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
         # This is because many PIC codes expect r to be the fastest index
         data = np.transpose( data, axes=[0, 2, 1] )
 
+    # Define the dataset
+    dataset = io.Dataset(data.dtype, data.shape)
+    env = m[io.Mesh_Record_Component.SCALAR]
+    env.position = [0] * len(dim)
+    env.reset_dataset(dataset)
     env.store_chunk(data)
 
     series.flush()

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -70,8 +70,9 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
 
     # Pick the correct field
     if dim == "xyt":
-        data = array
-
+        # Switch from x,y,t (internal to lasy) to t,y,x (in openPMD file)
+        # This is because many PIC codes expect x to be the fastest index
+        data = np.transpose( array )
     elif dim == "rt":
         # The representation of modes in openPMD
         # (see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#required-attributes-for-each-mesh-record)
@@ -85,6 +86,9 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
             data[2 * mode - 1, :, :] = array[mode, :, :] + array[-mode, :, :]
             # sin(m*theta) part of the mode
             data[2 * mode, :, :] = -1.0j * array[mode, :, :] + 1.0j * array[-mode, :, :]
+        # Switch from m,r,t (internal to lasy) to m,t,r (in openPMD file)
+        # This is because many PIC codes expect r to be the fastest index
+        data = np.transpose( data, axes=[0, 2, 1] )
 
     env.store_chunk(data)
 

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -57,7 +57,7 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
     }
     if dim == "xyt":
         m.geometry = io.Geometry.cartesian
-        m.axis_labels = ["t", "x", "y"]
+        m.axis_labels = ["t", "y", "x"]
     elif dim == "rt":
         m.geometry = io.Geometry.thetaMode
         m.axis_labels = ["t", "r"]

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -72,7 +72,7 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
     if dim == "xyt":
         # Switch from x,y,t (internal to lasy) to t,y,x (in openPMD file)
         # This is because many PIC codes expect x to be the fastest index
-        data = np.transpose( array )
+        data = np.transpose(array)
     elif dim == "rt":
         # The representation of modes in openPMD
         # (see https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#required-attributes-for-each-mesh-record)
@@ -88,7 +88,7 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
             data[2 * mode, :, :] = -1.0j * array[mode, :, :] + 1.0j * array[-mode, :, :]
         # Switch from m,r,t (internal to lasy) to m,t,r (in openPMD file)
         # This is because many PIC codes expect r to be the fastest index
-        data = np.transpose( data, axes=[0, 2, 1] )
+        data = np.transpose(data, axes=[0, 2, 1])
 
     env.store_chunk(data)
 


### PR DESCRIPTION
After some discussion, it seems that having `xyt` / `rt` as the internal representation inside `lasy` is more intuitive.

This PR goes back to this internal representation.

Then, when writing to the openPMD file, we switch to `tyx`, as it is more convenient for most PIC codes.