### PR TITLE
Fix ordering of `globalOffset` in openPMD metadata

### DIFF
--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -50,7 +50,7 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
         (hi - lo) / (npoints - 1)
         for hi, lo, npoints in zip(box.hi, box.lo, box.npoints)
     ][::-1]
-    m.grid_global_offset = box.lo
+    m.grid_global_offset = box.lo[::-1]
     m.unit_dimension = {
         io.Unit_Dimension.M: 1,
         io.Unit_Dimension.L: 1,


### PR DESCRIPTION
I forgot to switch the ordering of `globalOffset` in this PR: https://github.com/LASY-org/lasy/pull/105