### PR TITLE
RTD Build: Latest Ubuntu

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,10 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.7"
-    nodejs: "16"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Update RTD to use the lastest Ubuntu for new system libs, e.g., a recent OpenSSL.

Same as https://github.com/ECP-WarpX/WarpX/pull/3896