### PR TITLE
New profile: from numpy array

### DIFF
--- a/docs/source/api/profiles/from_array_profile.rst
+++ b/docs/source/api/profiles/from_array_profile.rst
@@ -1,0 +1,5 @@
+Profile defined from external Numpy array
+=========================================
+
+.. autoclass:: lasy.profiles.from_array_profile.FromArrayProfile
+    :members:

--- a/docs/source/api/profiles/index.rst
+++ b/docs/source/api/profiles/index.rst
@@ -12,5 +12,6 @@ Typically a laser will be constructed through a combination of two classes ``Lon
 
    gaussian
    combined_profile
+   from_array_profile
    longitudinal/index
    transverse/index

--- a/lasy/profiles/__init__.py
+++ b/lasy/profiles/__init__.py
@@ -1,4 +1,5 @@
 from .combined_profile import CombinedLongitudinalTransverseProfile
 from .gaussian_profile import GaussianProfile
+from .from_array_profile import FromArrayProfile
 
-__all__ = ["CombinedLongitudinalTransverseProfile", "GaussianProfile"]
+__all__ = ["CombinedLongitudinalTransverseProfile", "GaussianProfile", "FromArrayProfile"]

--- a/lasy/profiles/__init__.py
+++ b/lasy/profiles/__init__.py
@@ -2,4 +2,8 @@ from .combined_profile import CombinedLongitudinalTransverseProfile
 from .gaussian_profile import GaussianProfile
 from .from_array_profile import FromArrayProfile
 
-__all__ = ["CombinedLongitudinalTransverseProfile", "GaussianProfile", "FromArrayProfile"]
+__all__ = [
+    "CombinedLongitudinalTransverseProfile",
+    "GaussianProfile",
+    "FromArrayProfile",
+]

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -34,7 +34,7 @@ class FromArrayProfile(Profile):
         ['x', 'y', 'z'] and ['z', 'y', 'x'].
     """
 
-    def __init__(self, wavelength, pol, array, axes, dim, axes_order=['x', 'y', 'z']):
+    def __init__(self, wavelength, pol, array, axes, dim, axes_order=["x", "y", "z"]):
         super().__init__(wavelength, pol)
 
         assert dim == "xyt" or dim == "rt", "dim must be 'xyt' or 'rt'"
@@ -44,10 +44,9 @@ class FromArrayProfile(Profile):
         self.dim = dim
         self.axes = axes
         if dim == "xyt":
+            assert axes_order in [["x", "y", "z"], ["z", "y", "x"]]
 
-            assert axes_order in [['x', 'y', 'z'], ['z', 'y', 'x']]
-
-            if axes_order == ['z', 'y', 'x']:
+            if axes_order == ["z", "y", "x"]:
                 self.array = np.swapaxes(array, 0, 2)
             else:
                 self.array = array

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -1,4 +1,5 @@
 from scipy.interpolate import RegularGridInterpolator
+import numpy as np
 from .profile import Profile
 
 

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -23,42 +23,33 @@ class FromArrayProfile(Profile):
     array : Array of the electric field of the laser pulse.
 
     axes : Python dictionary containing the axes vectors.
-        Keys are 'x', 'y', 't' if dim=xyt and 'r', 't' if dim=rt, respectively.
+        Keys are 'x', 'y', 't'.
         Values are the 1D arrays of each axis.
         array.shape = (axes['x'].size, axes['y'].size, axes['t'].size) in 3D,
         and similar in cylindrical geometry.
 
-    dim : Dimension of the data, 'xyt' or 'rt'
-
     axes_order : List of strings, giving the name and ordering of the axes in the array.
         Currently, only implemented for 3D, and supported values are
-        ['x', 'y', 'z'] and ['z', 'y', 'x'].
+        ['x', 'y', 't'] and ['t', 'y', 'x'].
     """
 
-    def __init__(self, wavelength, pol, array, axes, dim, axes_order=["x", "y", "z"]):
+    def __init__(self, wavelength, pol, array, axes, axes_order=["x", "y", "t"]):
         super().__init__(wavelength, pol)
 
-        assert dim == "xyt" or dim == "rt", "dim must be 'xyt' or 'rt'"
-
-        assert dim == "xyt", "Only dim='xyt' currently implemented"
-
-        self.dim = dim
         self.axes = axes
-        if dim == "xyt":
-            assert axes_order in [["x", "y", "z"], ["z", "y", "x"]]
+        assert axes_order in [["x", "y", "t"], ["t", "y", "x"]]
 
-            if axes_order == ["z", "y", "x"]:
-                self.array = np.swapaxes(array, 0, 2)
-            else:
-                self.array = array
+        if axes_order == ["t", "y", "x"]:
+            self.array = np.swapaxes(array, 0, 2)
+        else:
+            self.array = array
 
-        if dim == "xyt":
-            self.field_interp = RegularGridInterpolator(
-                (axes["x"], axes["y"], axes["t"]),
-                array,
-                bounds_error=False,
-                fill_value=0.0,
-            )
+        self.field_interp = RegularGridInterpolator(
+            (axes["x"], axes["y"], axes["t"]),
+            array,
+            bounds_error=False,
+            fill_value=0.0,
+        )
 
     def evaluate(self, x, y, t):
         """Return the envelope field of the scaled profile."""

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -31,22 +31,19 @@ class FromArrayProfile(Profile):
     """
 
     def __init__(self, wavelength, pol, array, axes, dim):
-        super().__init__(
-            wavelength,
-            pol
-        )
+        super().__init__(wavelength, pol)
 
-        assert dim == 'xyt' or dim == 'rt', "dim must be 'xyt' or 'rt'"
+        assert dim == "xyt" or dim == "rt", "dim must be 'xyt' or 'rt'"
 
-        assert dim == 'xyt', "Only dim='xyt' currently implemented"
+        assert dim == "xyt", "Only dim='xyt' currently implemented"
 
         self.array = array
         self.axes = axes
         self.dim = dim
 
-        if dim == 'xyt':
+        if dim == "xyt":
             self.field_interp = RegularGridInterpolator(
-                (axes['x'], axes['y'], axes['t']),
+                (axes["x"], axes["y"], axes["t"]),
                 array,
                 bounds_error=False,
                 fill_value=0.0,

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -1,4 +1,3 @@
-import numpy as np
 from scipy.interpolate import RegularGridInterpolator
 from .profile import Profile
 
@@ -28,7 +27,7 @@ class FromArrayProfile(Profile):
         array.shape = (axes['x'].size, axes['y'].size, axes['t'].size) in 3D,
         and similar in cylindrical geometry.
 
-    dim : Dimension of the data, 'xyt' or 'rt'.
+    dim : Dimension of the data, 'xyt' or 'rt'
     """
 
     def __init__(self, wavelength, pol, array, axes, dim):

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -51,6 +51,5 @@ class FromArrayProfile(Profile):
 
     def evaluate(self, x, y, t):
         """Return the envelope field of the scaled profile."""
-
         envelope = self.field_interp((x, y, t))
         return envelope

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -1,0 +1,60 @@
+import numpy as np
+from scipy.interpolate import RegularGridInterpolator
+from .profile import Profile
+
+
+class FromArrayProfile(Profile):
+    r"""
+    Profile defined from numpy array directly.
+
+    Parameters
+    ----------
+    wavelength : float (in meter)
+        The main laser wavelength :math:`\\lambda_0` of the laser, which
+        defines :math:`\\omega_0` in the above formula, according to
+        :math:`\\omega_0 = 2\\pi c/\\lambda_0`.
+
+    pol : list of 2 complex numbers (dimensionless)
+        Polarization vector. It corresponds to :math:`p_u` in the above
+        formula ; :math:`p_x` is the first element of the list and
+        :math:`p_y` is the second element of the list. Using complex
+        numbers enables elliptical polarizations.
+
+    array : Array of the electric field of the laser pulse.
+
+    axes : Python dictionary containing the axes vectors.
+        Keys are 'x', 'y', 't' if dim=xyt and 'r', 't' if dim=rt, respectively.
+        Values are the 1D arrays of each axis.
+        array.shape = (axes['x'].size, axes['y'].size, axes['t'].size) in 3D,
+        and similar in cylindrical geometry.
+
+    dim : Dimension of the data, 'xyt' or 'rt'.
+    """
+
+    def __init__(self, wavelength, pol, array, axes, dim):
+        super().__init__(
+            wavelength,
+            pol
+        )
+
+        assert dim == 'xyt' or dim == 'rt', "dim must be 'xyt' or 'rt'"
+
+        assert dim == 'xyt', "Only dim='xyt' currently implemented"
+
+        self.array = array
+        self.axes = axes
+        self.dim = dim
+
+        if dim == 'xyt':
+            self.field_interp = RegularGridInterpolator(
+                (axes['x'], axes['y'], axes['t']),
+                array,
+                bounds_error=False,
+                fill_value=0.0,
+            )
+
+    def evaluate(self, x, y, t):
+        """Return the envelope field of the scaled profile."""
+
+        envelope = self.field_interp((x, y, t))
+        return envelope

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -28,18 +28,29 @@ class FromArrayProfile(Profile):
         and similar in cylindrical geometry.
 
     dim : Dimension of the data, 'xyt' or 'rt'
+
+    axes_order : List of strings, giving the name and ordering of the axes in the array.
+        Currently, only implemented for 3D, and supported values are
+        ['x', 'y', 'z'] and ['z', 'y', 'x'].
     """
 
-    def __init__(self, wavelength, pol, array, axes, dim):
+    def __init__(self, wavelength, pol, array, axes, dim, axes_order=['x', 'y', 'z']):
         super().__init__(wavelength, pol)
 
         assert dim == "xyt" or dim == "rt", "dim must be 'xyt' or 'rt'"
 
         assert dim == "xyt", "Only dim='xyt' currently implemented"
 
-        self.array = array
-        self.axes = axes
         self.dim = dim
+        self.axes = axes
+        if dim == "xyt":
+
+            assert axes_order in [['x', 'y', 'z'], ['z', 'y', 'x']]
+
+            if axes_order == ['z', 'y', 'x']:
+                self.array = np.swapaxes(array, 0, 2)
+            else:
+                self.array = array
 
         if dim == "xyt":
             self.field_interp = RegularGridInterpolator(

--- a/lasy/profiles/transverse/transverse_profile_from_data.py
+++ b/lasy/profiles/transverse/transverse_profile_from_data.py
@@ -85,13 +85,13 @@ class TransverseProfileFromData(TransverseProfile):
 
         Parameters
         ----------
-        x, y: ndarrays of floats
+        x, y : ndarrays of floats
             Define points on which to evaluate the envelope
             These arrays need to all have the same shape.
 
         Returns
         -------
-        envelope: ndarray of floats
+        envelope : ndarray of floats
             Contains the value of the envelope at the specified points
             This array has the same shape as the arrays x, y
         """

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -163,30 +163,38 @@ def test_from_array_profile():
     # and check that the resulting profile has the correct width
     lo = (-10e-6, -20e-6, -30e-15)
     hi = (+10e-6, +20e-6, +30e-15)
-    npoints=(16, 32, 64)
+    npoints = (16, 32, 64)
     x = np.linspace(lo[0], hi[0], npoints[0])
     y = np.linspace(lo[1], hi[1], npoints[1])
     t = np.linspace(lo[2], hi[2], npoints[2])
-    X, Y, T = np.meshgrid(x, y, t, indexing='ij')
-    e0 = 4.e12 # Approx a0 = 1 for wavelength = 800 nm
-    wx = 3.e-6
-    wy = 5.e-6
-    tau = 5.e-15
-    E = 1j * e0 * np.exp(-X**2/wx**2-Y**2/wy**2-t**2/tau**2)
+    X, Y, T = np.meshgrid(x, y, t, indexing="ij")
+    e0 = 4.0e12  # Approx a0 = 1 for wavelength = 800 nm
+    wx = 3.0e-6
+    wy = 5.0e-6
+    tau = 5.0e-15
+    E = 1j * e0 * np.exp(-(X**2) / wx**2 - Y**2 / wy**2 - t**2 / tau**2)
     wavelength = 0.8e-6
-    pol = (1,0)
-    axes = {'x':x, 'y':y, 't':t}
-    dim = 'xyt'
+    pol = (1, 0)
+    axes = {"x": x, "y": y, "t": t}
+    dim = "xyt"
 
-    profile = FromArrayProfile(wavelength=wavelength, pol=pol, array=E, axes=axes, dim=dim)
+    profile = FromArrayProfile(
+        wavelength=wavelength, pol=pol, array=E, axes=axes, dim=dim
+    )
     laser = Laser(dim, lo, hi, npoints, profile)
-    laser.write_to_file('fromArray')
+    laser.write_to_file("fromArray")
 
     F = profile.evaluate(X, Y, T)
-    width = np.sqrt(np.sum(np.abs(F)**2*x.reshape((x.size,1,1))**2)/np.sum(np.abs(F)**2))*2
+    width = (
+        np.sqrt(
+            np.sum(np.abs(F) ** 2 * x.reshape((x.size, 1, 1)) ** 2)
+            / np.sum(np.abs(F) ** 2)
+        )
+        * 2
+    )
     print("theory width  : ", wx)
     print("Measured width: ", width)
-    assert np.abs((width - wx) / wx) < 1.e-5
+    assert np.abs((width - wx) / wx) < 1.0e-5
 
 
 def test_add_profiles():

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -5,8 +5,8 @@ import numpy as np
 from scipy.special import gamma as gamma
 
 from lasy.laser import Laser
-from lasy.profiles.profile import Profile, SummedProfile, ScaledProfile, FromArrayProfile
-from lasy.profiles import GaussianProfile
+from lasy.profiles.profile import Profile, SummedProfile, ScaledProfile
+from lasy.profiles import GaussianProfile, FromArrayProfile
 from lasy.profiles.longitudinal import GaussianLongitudinalProfile
 from lasy.profiles.transverse import (
     GaussianTransverseProfile,

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -179,7 +179,7 @@ def test_from_array_profile():
     dim = "xyt"
 
     profile = FromArrayProfile(
-        wavelength=wavelength, pol=pol, array=E, axes=axes, dim=dim
+        wavelength=wavelength, pol=pol, array=E, axes=axes
     )
     laser = Laser(dim, lo, hi, npoints, profile)
     laser.write_to_file("fromArray")

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -183,7 +183,7 @@ def test_from_array_profile():
     laser.write_to_file('fromArray')
 
     F = profile.evaluate(X, Y, T)
-    width = np.sqrt(np.sum(np.abs(F)**2*m.x.reshape((m.x.size,1,1))**2)/np.sum(np.abs(F)**2))*2
+    width = np.sqrt(np.sum(np.abs(F)**2*x.reshape((x.size,1,1))**2)/np.sum(np.abs(F)**2))*2
     print("theory width  : ", wx)
     print("Measured width: ", width)
     assert np.abs((width - wx) / wx) < 1.e-5

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -178,9 +178,7 @@ def test_from_array_profile():
     axes = {"x": x, "y": y, "t": t}
     dim = "xyt"
 
-    profile = FromArrayProfile(
-        wavelength=wavelength, pol=pol, array=E, axes=axes
-    )
+    profile = FromArrayProfile(wavelength=wavelength, pol=pol, array=E, axes=axes)
     laser = Laser(dim, lo, hi, npoints, profile)
     laser.write_to_file("fromArray")
 


### PR DESCRIPTION
This PR proposes a new Profile, created from a numpy array. With the following script, it makes it possible to read the output of an FBPIC simulation, and use it as an input in a HiPACE++ simulation, as can be seen in the figure below.
![fig](https://github.com/LASY-org/lasy/assets/26292713/59c1e70f-5f68-41a6-bfee-0970c3b8a39a)

It uses `scipy.interpolate` to enable a different resolution in the FBPIC output and in the LASY representation.

The final implementation could have a new profile `FromSimulationProfile` deriving from `FromArrayProfile` (so the option to initialize a profile from a numpy array is easily exposed). With this approach, the role of each class would be:
- `FromSimulationProfile`: Read simulation output, convert to envelope representation, handle polarization etc. Could use openpmd-viewer.
- `FromArrayProfile`: convert between geometries if needed (this could even be in the class above, not sure yet). Would not use openpmd-viewer.

```py
import numpy as np
from scipy.constants import c
from openpmd_viewer import OpenPMDTimeSeries
from scipy.signal import hilbert
from lasy.laser import Laser
from lasy.profiles.from_array_profile import FromArrayProfile

wavelength = 0.8e-6

# Read output of a FBPIC simulation, extract to 3D for simplicity
ts = OpenPMDTimeSeries('lab_diags/hdf5/')
F, m = ts.get_field(iteration=10, field='E', coord='y', theta=None)

# Get envelope from full profile
k0 = 2*np.pi/wavelength
env_F = hilbert(F)*np.exp(-1j*k0*m.z)

# Create LASY profile
pol = (1,0)
dim = 'xyt'
array = np.flip(env_F, axis=2) # Need to flip z vs. t
axes = {'x':m.x, 'y':m.y, 't':(m.z-m.z[0])/scc.c}
profile = FromArrayProfile(wavelength=wavelength, pol=pol, array=array, axes=axes, dim=dim)

# Create LASY laser object and save to file
lo = (-120e-6, -120e-6, -10e-15)
hi = (+120e-6, +120e-6, +60e-15)
npoints=(32,64,128)
laser = Laser(dim, lo, hi, npoints, profile)
laser.write_to_file('./laserfbpic/laser3d')
```