### PR TITLE
Make wavelength optional for transverse profiles

### DIFF
--- a/lasy/profiles/gaussian_profile.py
+++ b/lasy/profiles/gaussian_profile.py
@@ -103,7 +103,7 @@ class GaussianProfile(CombinedLongitudinalTransverseProfile):
     """
 
     def __init__(self, wavelength, pol, laser_energy, w0, tau, t_peak,
-                 cep_phase=0, z_foc=0:
+                 cep_phase=0, z_foc=0):
         super().__init__(
             wavelength,
             pol,

--- a/lasy/profiles/gaussian_profile.py
+++ b/lasy/profiles/gaussian_profile.py
@@ -58,6 +58,9 @@ class GaussianProfile(CombinedLongitudinalTransverseProfile):
         in the above formula (i.e. the phase of the laser
         oscillation, at the time where the laser envelope is maximum)
 
+    z_foc : float (in meter), optional
+        Position of the focal plane. (The laser pulse is initialized at `z=0`.)
+
     Examples
     --------
     >>> import matplotlib.pyplot as plt
@@ -99,11 +102,12 @@ class GaussianProfile(CombinedLongitudinalTransverseProfile):
     >>> plt.ylabel('r (µm)')
     """
 
-    def __init__(self, wavelength, pol, laser_energy, w0, tau, t_peak, cep_phase=0):
+    def __init__(self, wavelength, pol, laser_energy, w0, tau, t_peak,
+                 cep_phase=0, z_foc=0:
         super().__init__(
             wavelength,
             pol,
             laser_energy,
             GaussianLongitudinalProfile(wavelength, tau, t_peak, cep_phase),
-            GaussianTransverseProfile(w0),
+            GaussianTransverseProfile(w0, z_foc, wavelength),
         )

--- a/lasy/profiles/gaussian_profile.py
+++ b/lasy/profiles/gaussian_profile.py
@@ -102,8 +102,9 @@ class GaussianProfile(CombinedLongitudinalTransverseProfile):
     >>> plt.ylabel('r (µm)')
     """
 
-    def __init__(self, wavelength, pol, laser_energy, w0, tau, t_peak,
-                 cep_phase=0, z_foc=0):
+    def __init__(
+        self, wavelength, pol, laser_energy, w0, tau, t_peak, cep_phase=0, z_foc=0
+    ):
         super().__init__(
             wavelength,
             pol,

--- a/lasy/profiles/gaussian_profile.py
+++ b/lasy/profiles/gaussian_profile.py
@@ -105,5 +105,5 @@ class GaussianProfile(CombinedLongitudinalTransverseProfile):
             pol,
             laser_energy,
             GaussianLongitudinalProfile(wavelength, tau, t_peak, cep_phase),
-            GaussianTransverseProfile(w0, wavelength),
+            GaussianTransverseProfile(w0),
         )

--- a/lasy/profiles/transverse/gaussian_profile.py
+++ b/lasy/profiles/transverse/gaussian_profile.py
@@ -37,10 +37,14 @@ class GaussianTransverseProfile(TransverseProfile):
         not make this approximation.
     """
 
-    def __init__(self, w0, wavelength, z_foc=0):
+    def __init__(self, w0, wavelength=None, z_foc=0):
         super().__init__()
         self.w0 = w0
-        self.z_foc_over_zr = z_foc * wavelength / (np.pi * w0**2)
+        if z_foc == 0:
+            self.z_foc_over_zr = 0
+        else:
+            assert wavelength is not None, "You need to pass the wavelength, when `z_foc` is non-zero."
+            self.z_foc_over_zr = z_foc * wavelength / (np.pi * w0**2)
 
     def _evaluate(self, x, y):
         """

--- a/lasy/profiles/transverse/gaussian_profile.py
+++ b/lasy/profiles/transverse/gaussian_profile.py
@@ -20,11 +20,12 @@ class GaussianTransverseProfile(TransverseProfile):
     w0 : float (in meter)
         The waist of the laser pulse, i.e. :math:`w_0` in the above formula.
 
-    wavelength : float (in meter)
-        The main laser wavelength :math:`\\lambda_0` of the laser.
-
     z_foc : float (in meter), optional
         Position of the focal plane. (The laser pulse is initialized at `z=0`.)
+
+    wavelength : float (in meter), optional
+        The main laser wavelength :math:`\\lambda_0` of the laser.
+        (Only needed if `z_foc` is different than 0.)
 
     .. warning::
 

--- a/lasy/profiles/transverse/gaussian_profile.py
+++ b/lasy/profiles/transverse/gaussian_profile.py
@@ -43,7 +43,9 @@ class GaussianTransverseProfile(TransverseProfile):
         if z_foc == 0:
             self.z_foc_over_zr = 0
         else:
-            assert wavelength is not None, "You need to pass the wavelength, when `z_foc` is non-zero."
+            assert (
+                wavelength is not None
+            ), "You need to pass the wavelength, when `z_foc` is non-zero."
             self.z_foc_over_zr = z_foc * wavelength / (np.pi * w0**2)
 
     def _evaluate(self, x, y):


### PR DESCRIPTION
This is a follow-up on https://github.com/LASY-org/lasy/pull/121, and allows user to omit the wavelength in the transverse profile. 
In addition, I also allow the user to set `z_foc` when calling `GaussianProfile`.