### PR TITLE
Profile from openPMD file

### DIFF
--- a/docs/source/api/profiles/from_openpmd_profile.rst
+++ b/docs/source/api/profiles/from_openpmd_profile.rst
@@ -1,0 +1,5 @@
+Profile read from an openPMD file
+=================================
+
+.. autoclass:: lasy.profiles.from_openpmd_profile.FromOpenPMDProfile
+    :members:

--- a/docs/source/api/profiles/index.rst
+++ b/docs/source/api/profiles/index.rst
@@ -13,5 +13,6 @@ Typically a laser will be constructed through a combination of two classes ``Lon
    gaussian
    combined_profile
    from_array_profile
+   from_openpmd_profile
    longitudinal/index
    transverse/index

--- a/lasy/profiles/__init__.py
+++ b/lasy/profiles/__init__.py
@@ -7,5 +7,5 @@ __all__ = [
     "CombinedLongitudinalTransverseProfile",
     "GaussianProfile",
     "FromArrayProfile",
-    "FromOpenPMDProfile"
+    "FromOpenPMDProfile",
 ]

--- a/lasy/profiles/__init__.py
+++ b/lasy/profiles/__init__.py
@@ -1,9 +1,11 @@
 from .combined_profile import CombinedLongitudinalTransverseProfile
 from .gaussian_profile import GaussianProfile
 from .from_array_profile import FromArrayProfile
+from .from_openpmd_profile import FromOpenPMDProfile
 
 __all__ = [
     "CombinedLongitudinalTransverseProfile",
     "GaussianProfile",
     "FromArrayProfile",
+    "FromOpenPMDProfile"
 ]

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -80,13 +80,7 @@ class FromOpenPMDProfile(FromArrayProfile):
 
             # Get central wavelength from array
             phase = np.unwrap(np.angle(h))
-            omg0_h = (
-                -np.average(
-                    np.gradient(phase, axis=-1),
-                    weights=np.abs(h),
-                )
-                / dt
-            )
+            omg0_h = np.average(np.gradient(-phase, t, axis=-1), weights=np.abs(h) )
             wavelength = 2 * np.pi * c / omg0_h
             array = h * np.exp(1j * omg0_h * t)
         else:

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -43,16 +43,6 @@ class FromOpenPMDProfile(FromArrayProfile):
         Prefix of the openPMD file from which the envelope is read.
         Only used when envelope=True.
         The provided iteration is read from <path>/<prefix>_%T.h5.
-
-    wavelength : float (in meter)
-        The main laser wavelength :math:`\\lambda_0` of the laser, which defines
-        :math:`\\omega_0`, according to :math:`\\omega_0 = 2\\pi c/\\lambda_0`.
-        This argument is optional, and will overwrite the following default
-        behavior:
-        - if envelope is True, the central wavelength is read from the openPMD
-        file at openPMD envelope standard.
-        - if envelope is False, the central wavelength is obtained from the
-        Hilbert transform.
     """
 
     def __init__(
@@ -63,8 +53,7 @@ class FromOpenPMDProfile(FromArrayProfile):
         field,
         coord=None,
         envelope=False,
-        prefix=None,
-        wavelength=None,
+        prefix=None
     ):
         ts = OpenPMDTimeSeries(path)
         F, m = ts.get_field(iteration=iteration, field=field, coord=coord, theta=None)
@@ -105,23 +94,18 @@ class FromOpenPMDProfile(FromArrayProfile):
                 )
                 / dt
             )
-            wavelength_loc = 2 * np.pi * c / omg0_h
-            if wavelength is not None:
-                wavelength_loc = wavelength
+            wavelength = 2 * np.pi * c / omg0_h
             array = h * np.exp(1j * omg0_h * t)
         else:
-            if wavelength is None:
-                s = io.Series(path + "/" + prefix + "_%T.h5", io.Access.read_only)
-                it = s.iterations[iteration]
-                omg0 = it.meshes["laserEnvelope"].get_attribute("angularFrequency")
-                wavelength_loc = 2 * np.pi * c / omg0
-            else:
-                wavelength_loc = wavelength
+            s = io.Series(path + "/" + prefix + "_%T.h5", io.Access.read_only)
+            it = s.iterations[iteration]
+            omg0 = it.meshes["laserEnvelope"].get_attribute("angularFrequency")
+            wavelength = 2 * np.pi * c / omg0
             array = F
 
         axes_order = ["x", "y", "t"]
         super().__init__(
-            wavelength=wavelength_loc,
+            wavelength=wavelength,
             pol=pol,
             array=array,
             axes=axes,

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -1,0 +1,109 @@
+import numpy as np
+from scipy.signal import hilbert
+from scipy.constants import c
+from openpmd_viewer import OpenPMDTimeSeries
+from .profile import Profile
+from .from_array_profile import FromArrayProfile
+
+
+class FromOpenPMDProfile(Profile):
+    r"""
+    Profile defined from an openPMD file.
+
+    Parameters
+    ----------
+    path : string
+        Path to the openPMD file containing the laser field or envelope.
+        Passed directly OpenPMDTimeSeries.
+
+    iteration : int
+        Iteration at which the argument is read.
+        Passed directly OpenPMDTimeSeries.
+
+    pol : list of 2 complex numbers (dimensionless)
+        Polarization vector. It corresponds to :math:`p_u` in the above
+        formula ; :math:`p_x` is the first element of the list and
+        :math:`p_y` is the second element of the list. Using complex
+        numbers enables elliptical polarizations.
+
+    field : string
+        Name of the field containing the laser pulse
+        Passed directly OpenPMDTimeSeries.
+
+    coord : string
+        Name of the field containing the laser pulse
+        Passed directly OpenPMDTimeSeries.
+
+    envelope : boolean
+        Whether the file represents a laser envelope.
+        If not, the envelope is obtained from the electric field
+        using a Hilbert transform
+
+    wavelength : float (in meter)
+        The main laser wavelength :math:`\\lambda_0` of the laser, which defines
+        :math:`\\omega_0`, according to :math:`\\omega_0 = 2\\pi c/\\lambda_0`.
+        if envelope is True, this argument is currently required.
+        if envelope is False, this argument is optional: if not specified, the
+        central wavelength is obtained from the Hilbert transform.
+    """
+
+    def __init__(self, path, iteration, pol, field, coord=None,
+                 envelope=False, wavelength=None):
+
+        ts = OpenPMDTimeSeries(path)
+        F, m = ts.get_field(iteration=iteration, field=field, coord=coord, theta=None)
+        assert m.axes in [
+            {0: 'x', 1: 'y', 2: 'z'},
+            {0: 'z', 1: 'y', 2: 'x'},
+            {0: 'x', 1: 'y', 2: 't'},
+            {0: 't', 1: 'y', 2: 'x'}
+        ]
+
+        if m.axes in [{0: 'z', 1: 'y', 2: 'x'}, {0: 't', 1: 'y', 2: 'x'}]:
+            F = F.swapaxes(0,2)
+
+        if 'z' in m.axes.values():
+            dt = m.dz / c
+            t = (m.z-m.z[0]) / c
+        else:
+            dt = m.dt
+            t = m.t
+        axes = {'x':m.x, 'y':m.y, 't':t}
+
+        # If array does not contain the envelope but the electric field,
+        # extract the envelope with a Hilbert transform
+        if envelope == False:
+
+            # Assumes z is last dimension!
+            h = hilbert(F)
+
+            if 'z' in m.axes.values():
+                # Flip to get complex envelope in t assuming z = -c*t
+                h = np.flip(h, axis=2)
+
+            # Get central wavelength from array
+            phase = np.unwrap(np.angle(h))
+            omg0_h = -np.average(np.diff(phase), weights=\
+                                 .5*(np.abs(h[:,:,1:])+np.abs(h[:,:,:-1])))/dt
+            wavelength_loc = 2*np.pi*c/omg0_h
+            if wavelength is not None:
+                wavelength_loc = wavelength
+            array = h*np.exp(1j*omg0_h*t)
+        else:
+            # in principle, if the openPMD file represents an envelope,
+            # the wavelength should be read from the file directly
+            assert wavelength is not None
+            wavelength_loc = wavelength
+            array = F
+
+        super().__init__(wavelength_loc, pol)
+
+        axes_order = ['x', 'y', 't']
+        self.profile = FromArrayProfile(wavelength=wavelength_loc, pol=pol,
+                                        array=array, axes=axes,
+                                        axes_order=axes_order)
+
+    def evaluate(self, x, y, t):
+        """Return the envelope field of the scaled profile."""
+        envelope = self.profile.evaluate(x, y, t)
+        return envelope

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -46,14 +46,7 @@ class FromOpenPMDProfile(FromArrayProfile):
     """
 
     def __init__(
-        self,
-        path,
-        iteration,
-        pol,
-        field,
-        coord=None,
-        envelope=False,
-        prefix=None
+        self, path, iteration, pol, field, coord=None, envelope=False, prefix=None
     ):
         ts = OpenPMDTimeSeries(path)
         F, m = ts.get_field(iteration=iteration, field=field, coord=coord, theta=None)

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -61,10 +61,8 @@ class FromOpenPMDProfile(FromArrayProfile):
             F = F.swapaxes(0, 2)
 
         if "z" in m.axes.values():
-            dt = m.dz / c
             t = (m.z - m.z[0]) / c
         else:
-            dt = m.dt
             t = m.t
         axes = {"x": m.x, "y": m.y, "t": t}
 

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -80,7 +80,7 @@ class FromOpenPMDProfile(FromArrayProfile):
 
             # Get central wavelength from array
             phase = np.unwrap(np.angle(h))
-            omg0_h = np.average(np.gradient(-phase, t, axis=-1), weights=np.abs(h) )
+            omg0_h = np.average(np.gradient(-phase, t, axis=-1), weights=np.abs(h))
             wavelength = 2 * np.pi * c / omg0_h
             array = h * np.exp(1j * omg0_h * t)
         else:

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -40,7 +40,7 @@ class FromOpenPMDProfile(FromArrayProfile):
         using a Hilbert transform
 
     prefix : string
-        Prefix of the openPMD file from which the envelope is red.
+        Prefix of the openPMD file from which the envelope is read.
         Only used when envelope=True.
         The provided iteration is read from <path>/<prefix>_%T.h5.
 

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -50,10 +50,10 @@ class FromOpenPMDProfile(Profile):
         :math:`\\omega_0`, according to :math:`\\omega_0 = 2\\pi c/\\lambda_0`.
         This argument is optional, and will overwrite the following default
         behavior:
-         - if envelope is True, the central wavelength is read from the openPMD
-           file at openPMD envelope standard.
-         - if envelope is False, the central wavelength is obtained from the
-           Hilbert transform.
+        - if envelope is True, the central wavelength is read from the openPMD
+        file at openPMD envelope standard.
+        - if envelope is False, the central wavelength is obtained from the
+        Hilbert transform.
     """
 
     def __init__(

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -3,11 +3,10 @@ from scipy.signal import hilbert
 from scipy.constants import c
 import openpmd_api as io
 from openpmd_viewer import OpenPMDTimeSeries
-from .profile import Profile
 from .from_array_profile import FromArrayProfile
 
 
-class FromOpenPMDProfile(Profile):
+class FromOpenPMDProfile(FromArrayProfile):
     r"""
     Profile defined from an openPMD file.
 
@@ -120,18 +119,11 @@ class FromOpenPMDProfile(Profile):
                 wavelength_loc = wavelength
             array = F
 
-        super().__init__(wavelength_loc, pol)
-
         axes_order = ["x", "y", "t"]
-        self.profile = FromArrayProfile(
+        super().__init__(
             wavelength=wavelength_loc,
             pol=pol,
             array=array,
             axes=axes,
             axes_order=axes_order,
         )
-
-    def evaluate(self, x, y, t):
-        """Return the envelope field of the scaled profile."""
-        envelope = self.profile.evaluate(x, y, t)
-        return envelope

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -100,8 +100,8 @@ class FromOpenPMDProfile(FromArrayProfile):
             phase = np.unwrap(np.angle(h))
             omg0_h = (
                 -np.average(
-                    np.diff(phase),
-                    weights=0.5 * (np.abs(h[:, :, 1:]) + np.abs(h[:, :, :-1])),
+                    np.gradient(phase, axis=-1),
+                    weights=np.abs(h),
                 )
                 / dt
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 axiprop
 numpy
 openpmd-api
+openpmd-viewer
 scipy


### PR DESCRIPTION
This PR creates a new profile to read a laser pulse from an openPMD file. It derives from `fromArrayProfile`. Works both when the profile read is a laser envelope or the electric field of a laser pulse. in the latter case, the envelope is obtained with a Hilbert transform. Both were tested and give the same result as shown in https://github.com/LASY-org/lasy/pull/141.

## Example
```python
from lasy.profiles.from_openpmd_profile import FromOpenPMDProfile
from lasy.laser import Laser

# Create profile: one of
# - from FBPIC output
profile = FromOpenPMDProfile('lab_diags/hdf5/', 10, (0,1), 'E', 'y')
# - from LASY output
profile = FromOpenPMDProfile('./laserfbpic', 0, (1,0), 'laserEnvelope', envelope=True, prefix='laser3d')

# Create laser
dim = 'xyt'
lo = (-120e-6, -120e-6, -10e-15)
hi = (+120e-6, +120e-6, +60e-15)
npoints=(32,64,128)
laser = Laser(dim, lo, hi, npoints, profile)
laser.write_to_file('./laserfbpic/laser3d')

# Plot
from openpmd_viewer import OpenPMDTimeSeries
import numpy as np
import matplotlib.pyplot as plt
ts = OpenPMDTimeSeries('./laserfbpic')
F, m = ts.get_field(field='laserEnvelope')
F = np.abs(F)
plt.figure(figsize=(8,8))
plt.imshow(F[:,:,F.shape[2]//2], aspect='auto')
plt.colorbar()
```
To do (probably in a separate PR):
 - [ ] Clean up handling of polarisation.
 - [ ] Some functions could be interesting in general, and could be in `tools` or (better IMO) openPMD-viewer.
 - [ ] Make compliant with latest version of the standard.
 - [ ] (only if needed) support all axes ordering.
 - [ ] The phase retrieval is 1D, which may cause problems for more complex laser pulses, so this could be improved.