### PR TITLE
Docs: Made clear-cut usage of laser.propagate

### DIFF
--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -53,8 +53,7 @@ Lets generate a Gaussian pulse at focus, propagate it backwards by one Rayeligh 
    laser = Laser(dimensions,lo,hi,num_points,laser_profile)
 
 ..  code-block:: python
-   :caption: By default, the laser antenna will emit on the focal plan.
-   (Optional) Make the laser antenna emit outside the focal plan by one Rayleigh length.
+   :caption: By default, the laser antenna will emit on the focal plan. (Optional) Make the laser antenna emit outside the focal plan by one Rayleigh length.
 
    z_R            = 3.14159*spot_size**2/wavelength    # The Rayleigh length.
    laser.propagate(-z_R)                               # The laser antenna emits behind the focal plane

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -21,7 +21,7 @@ First Example
 #############
 
 We will try a simple example to get familiar with the code structure and to verify the installation was successful.
-Let's generate a Gaussian pulse at focus, propagate it backwards by one Rayleigh length (the pulse is then located ahead of the focal plane) and then output it to a file.
+Let's generate a Gaussian pulse at focus, propagate it backwards by one Rayleigh length (the pulse is then located upstream of the focal plane) and then output it to a file.
 
 ..  code-block:: python
    :caption: First lets load in the required functions from the library.
@@ -56,7 +56,7 @@ Let's generate a Gaussian pulse at focus, propagate it backwards by one Rayleigh
    :caption: By default, the values of the laser envelope are injected on the focal plan. One can propagate it backwards by one Rayleigh length (optional).
 
    z_R            = 3.14159*spot_size**2/wavelength    # The Rayleigh length
-   laser.propagate(-z_R)                               # Propagate the pulse ahead of the focal plane
+   laser.propagate(-z_R)                               # Propagate the pulse upstream of the focal plane
 
 ..  code-block:: python
    :caption: Output the result to a file. Here we utilise the openPMD standard.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -53,10 +53,11 @@ Lets generate a Gaussian pulse at focus, propagate it backwards by one Rayeligh 
    laser = Laser(dimensions,lo,hi,num_points,laser_profile)
 
 ..  code-block:: python
-   :caption: Propagate the laser pulse backwards by one Rayeligh length.
+   :caption: By default, the laser antenna will emit on the focal plan. 
+   (Optional) Make the laser antenna emit outside the focal plan by one Rayleigh length.
 
    z_R            = 3.14159*spot_size**2/wavelength    # The Rayleigh length.
-   laser.propagate(-z_R)
+   laser.propagate(-z_R)                               # The laser antenna emits behind the focal plane
 
 ..  code-block:: python
    :caption: Output the result to file. Here we utilise the openPMD standard.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -21,7 +21,7 @@ First Example
 #############
 
 We will try a simple example to get familiar with the code structure and to verify the installation was successful.
-Lets generate a Gaussian pulse at focus, propagate it backwards by one Rayeligh Length and then output it to file.
+Lets generate a Gaussian pulse at focus, emit it behind the focal plan by one Rayleigh length and then output it to a file.
 
 ..  code-block:: python
    :caption: First lets load in the required functions from the library.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -53,7 +53,7 @@ Lets generate a Gaussian pulse at focus, propagate it backwards by one Rayeligh 
    laser = Laser(dimensions,lo,hi,num_points,laser_profile)
 
 ..  code-block:: python
-   :caption: By default, the laser antenna will emit on the focal plan. 
+   :caption: By default, the laser antenna will emit on the focal plan.
    (Optional) Make the laser antenna emit outside the focal plan by one Rayleigh length.
 
    z_R            = 3.14159*spot_size**2/wavelength    # The Rayleigh length.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -21,7 +21,7 @@ First Example
 #############
 
 We will try a simple example to get familiar with the code structure and to verify the installation was successful.
-Lets generate a Gaussian pulse at focus, emit it behind the focal plan by one Rayleigh length and then output it to a file.
+Let's generate a Gaussian pulse at focus, propagate it backwards by one Rayleigh length (the pulse is then located ahead of the focal plane) and then output it to a file.
 
 ..  code-block:: python
    :caption: First lets load in the required functions from the library.
@@ -53,17 +53,17 @@ Lets generate a Gaussian pulse at focus, emit it behind the focal plan by one Ra
    laser = Laser(dimensions,lo,hi,num_points,laser_profile)
 
 ..  code-block:: python
-   :caption: By default, the laser antenna will emit on the focal plan. (Optional) Make the laser antenna emit outside the focal plan by one Rayleigh length.
+   :caption: By default, the values of the laser envelope are injected on the focal plan. One can propagate it backwards by one Rayleigh length (optional).
 
-   z_R            = 3.14159*spot_size**2/wavelength    # The Rayleigh length.
-   laser.propagate(-z_R)                               # The laser antenna emits behind the focal plane
+   z_R            = 3.14159*spot_size**2/wavelength    # The Rayleigh length
+   laser.propagate(-z_R)                               # Propagate the pulse ahead of the focal plane
 
 ..  code-block:: python
-   :caption: Output the result to file. Here we utilise the openPMD standard.
+   :caption: Output the result to a file. Here we utilise the openPMD standard.
 
    file_prefix    = 'test_output' # The file name will start with this prefix
    file_format    = 'h5'          # Format to be used for the output file
 
    laser.write_to_file(file_prefix, file_format)
 
-This file may now be viewed, copied, shared or used as an input to a variety of other simulation tools.
+The generated file may now be viewed or used as a laser input to a variety of other simulation tools.


### PR DESCRIPTION
I think using 'propagate' can lead to confusion as it controls the position of emission and not the direction of propagation.