### PR TITLE
Improvements in the reader from openPMD file

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -8,7 +8,7 @@ from lasy.utils.grid import Grid
 from lasy.utils.laser_utils import (
     normalize_energy,
     normalize_peak_field_amplitude,
-    normalize_peak_intensity,
+    normalize_peak_intensity
 )
 from lasy.utils.openpmd_output import write_to_openpmd_file
 
@@ -398,7 +398,7 @@ class Laser:
             self.grid.field = prop.z2t(transform_data, t_axis, z0=z0, t0=t0).T
             self.grid.field *= np.exp(1j * (z0 / c + t_axis) * omega0)
 
-    def write_to_file(self, file_prefix="laser", file_format="h5"):
+    def write_to_file(self, file_prefix="laser", file_format="h5", use_a0=False):
         """
         Write the laser profile + metadata to file.
 
@@ -417,4 +417,5 @@ class Laser:
             self.grid,
             self.profile.lambda0,
             self.profile.pol,
+            use_a0
         )

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -398,7 +398,9 @@ class Laser:
             self.grid.field = prop.z2t(transform_data, t_axis, z0=z0, t0=t0).T
             self.grid.field *= np.exp(1j * (z0 / c + t_axis) * omega0)
 
-    def write_to_file(self, file_prefix="laser", file_format="h5", save_as_vector_potential=False):
+    def write_to_file(
+        self, file_prefix="laser", file_format="h5", save_as_vector_potential=False
+    ):
         """
         Write the laser profile + metadata to file.
 

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -398,7 +398,7 @@ class Laser:
             self.grid.field = prop.z2t(transform_data, t_axis, z0=z0, t0=t0).T
             self.grid.field *= np.exp(1j * (z0 / c + t_axis) * omega0)
 
-    def write_to_file(self, file_prefix="laser", file_format="h5", use_a0=False):
+    def write_to_file(self, file_prefix="laser", file_format="h5", save_as_vector_potential=False):
         """
         Write the laser profile + metadata to file.
 
@@ -409,6 +409,10 @@ class Laser:
 
         file_format : string
             Format to be used for the output file. Options are ``"h5"`` and ``"bp"``.
+
+        save_as_vector_potential : bool (optional)
+            Whether the envelope is converted to normalized vector potential
+            before writing to file.
         """
         write_to_openpmd_file(
             self.dim,
@@ -417,5 +421,5 @@ class Laser:
             self.grid,
             self.profile.lambda0,
             self.profile.pol,
-            use_a0,
+            save_as_vector_potential,
         )

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -8,7 +8,7 @@ from lasy.utils.grid import Grid
 from lasy.utils.laser_utils import (
     normalize_energy,
     normalize_peak_field_amplitude,
-    normalize_peak_intensity
+    normalize_peak_intensity,
 )
 from lasy.utils.openpmd_output import write_to_openpmd_file
 
@@ -417,5 +417,5 @@ class Laser:
             self.grid,
             self.profile.lambda0,
             self.profile.pol,
-            use_a0
+            use_a0,
         )

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -33,25 +33,52 @@ class FromArrayProfile(Profile):
         ['x', 'y', 't'] and ['t', 'y', 'x'].
     """
 
-    def __init__(self, wavelength, pol, array, axes, axes_order=["x", "y", "t"]):
+    def __init__(self, wavelength, pol, array, dim, axes, axes_order=["x", "y", "t"]):
         super().__init__(wavelength, pol)
 
+        assert dim in ["xyt", "rt"]
         self.axes = axes
-        assert axes_order in [["x", "y", "t"], ["t", "y", "x"]]
+        self.dim = dim
 
-        if axes_order == ["t", "y", "x"]:
-            self.array = np.swapaxes(array, 0, 2)
-        else:
-            self.array = array
+        if dim == "xyt":
+            assert axes_order in [["x", "y", "t"], ["t", "y", "x"]]
 
-        self.field_interp = RegularGridInterpolator(
-            (axes["x"], axes["y"], axes["t"]),
-            array,
-            bounds_error=False,
-            fill_value=0.0,
-        )
+            if axes_order == ["t", "y", "x"]:
+                self.array = np.swapaxes(array, 0, 2)
+            else:
+                self.array = array
+
+            self.field_interp = RegularGridInterpolator(
+                (axes["x"], axes["y"], axes["t"]),
+                array,
+                bounds_error=False,
+                fill_value=0.0,
+            )
+
+        else: # dim = "rt"
+            assert axes_order in [["r", "t"], ["t", "r"]]
+
+            if axes_order == ["t", "r"]:
+                self.array = np.swapaxes(array, 0, 2)
+            else:
+                self.array = array
+
+            # The first point is at dr/2.
+            # To avoid problems within the first cell, fill_value in None,
+            # so the value is interpolated. This might cause issues at the upper
+            # boundary.
+            self.field_interp = RegularGridInterpolator(
+                (axes["r"], axes["t"]),
+                array,
+                bounds_error=False,
+                fill_value=None,
+            )
+
 
     def evaluate(self, x, y, t):
         """Return the envelope field of the scaled profile."""
-        envelope = self.field_interp((x, y, t))
+        if self.dim == "xyt":
+            envelope = self.field_interp((x, y, t))
+        else:
+            envelope = self.field_interp((np.sqrt(x**2+y**2), t))
         return envelope

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -55,7 +55,7 @@ class FromArrayProfile(Profile):
                 fill_value=0.0,
             )
 
-        else: # dim = "rt"
+        else:  # dim = "rt"
             assert axes_order in [["r", "t"], ["t", "r"]]
 
             if axes_order == ["t", "r"]:
@@ -74,11 +74,10 @@ class FromArrayProfile(Profile):
                 fill_value=None,
             )
 
-
     def evaluate(self, x, y, t):
         """Return the envelope field of the scaled profile."""
         if self.dim == "xyt":
             envelope = self.field_interp((x, y, t))
         else:
-            envelope = self.field_interp((np.sqrt(x**2+y**2), t))
+            envelope = self.field_interp((np.sqrt(x**2 + y**2), t))
         return envelope

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -5,6 +5,7 @@ import openpmd_api as io
 from openpmd_viewer import OpenPMDTimeSeries
 from .from_array_profile import FromArrayProfile
 from lasy.utils.laser_utils import get_frequency
+from lasy.utils.grid import Grid
 
 
 class FromOpenPMDProfile(FromArrayProfile):
@@ -109,10 +110,17 @@ class FromOpenPMDProfile(FromArrayProfile):
                     h = np.flip(h, axis=-1)
 
                 # Get central wavelength from array
-                axes_list = [axes[i] for i in axes.keys()]
+                lo = (axes['x'][0], axes['y'][0], axes['t'][0])
+                hi = (axes['x'][-1], axes['y'][-1], axes['t'][-1])
+                npoints = (axes['x'].size, axes['y'].size, axes['t'].size)
+                grid = Grid(dim, lo, hi, npoints)
+                assert np.all(grid.axes[0] == axes['x'])
+                assert np.all(grid.axes[1] == axes['y'])
+                assert np.all(grid.axes[2] == axes['t'])
+                assert grid.field.shape == h.shape
+                grid.field = h
                 omg_h, omg0_h = get_frequency(
-                    h,
-                    axes_list,
+                    grid,
                     dim,
                     is_envelope=False,
                     is_hilbert=True,
@@ -164,10 +172,16 @@ class FromOpenPMDProfile(FromArrayProfile):
                     h = np.flip(h, axis=-1)
 
                 # Get central wavelength from array
-                axes_list = [axes[i] for i in axes.keys()]
+                lo = (axes['r'][0], axes['t'][0])
+                hi = (axes['r'][-1], axes['t'][-1])
+                npoints = (axes['r'].size, axes['t'].size)
+                grid = Grid(dim, lo, hi, npoints, n_azimuthal_modes=1)
+                assert np.all(grid.axes[0] == axes['r'])
+                assert np.allclose(grid.axes[1], axes['t'], rtol=1.e-14)
+                assert grid.field.shape == h[np.newaxis].shape
+                grid.field = h[np.newaxis]
                 omg_h, omg0_h = get_frequency(
-                    h,
-                    axes_list,
+                    grid,
                     dim=dim,
                     is_envelope=False,
                     is_hilbert=True,

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -1,7 +1,6 @@
 import numpy as np
 from scipy.signal import hilbert
 from scipy.constants import c
-from skimage.restoration import unwrap_phase
 import openpmd_api as io
 from openpmd_viewer import OpenPMDTimeSeries
 from .from_array_profile import FromArrayProfile

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -110,13 +110,13 @@ class FromOpenPMDProfile(FromArrayProfile):
                     h = np.flip(h, axis=-1)
 
                 # Get central wavelength from array
-                lo = (axes['x'][0], axes['y'][0], axes['t'][0])
-                hi = (axes['x'][-1], axes['y'][-1], axes['t'][-1])
-                npoints = (axes['x'].size, axes['y'].size, axes['t'].size)
+                lo = (axes["x"][0], axes["y"][0], axes["t"][0])
+                hi = (axes["x"][-1], axes["y"][-1], axes["t"][-1])
+                npoints = (axes["x"].size, axes["y"].size, axes["t"].size)
                 grid = Grid(dim, lo, hi, npoints)
-                assert np.all(grid.axes[0] == axes['x'])
-                assert np.all(grid.axes[1] == axes['y'])
-                assert np.all(grid.axes[2] == axes['t'])
+                assert np.all(grid.axes[0] == axes["x"])
+                assert np.all(grid.axes[1] == axes["y"])
+                assert np.all(grid.axes[2] == axes["t"])
                 assert grid.field.shape == h.shape
                 grid.field = h
                 omg_h, omg0_h = get_frequency(
@@ -172,12 +172,12 @@ class FromOpenPMDProfile(FromArrayProfile):
                     h = np.flip(h, axis=-1)
 
                 # Get central wavelength from array
-                lo = (axes['r'][0], axes['t'][0])
-                hi = (axes['r'][-1], axes['t'][-1])
-                npoints = (axes['r'].size, axes['t'].size)
+                lo = (axes["r"][0], axes["t"][0])
+                hi = (axes["r"][-1], axes["t"][-1])
+                npoints = (axes["r"].size, axes["t"].size)
                 grid = Grid(dim, lo, hi, npoints, n_azimuthal_modes=1)
-                assert np.all(grid.axes[0] == axes['r'])
-                assert np.allclose(grid.axes[1], axes['t'], rtol=1.e-14)
+                assert np.all(grid.axes[0] == axes["r"])
+                assert np.allclose(grid.axes[1], axes["t"], rtol=1.0e-14)
                 assert grid.field.shape == h[np.newaxis].shape
                 grid.field = h[np.newaxis]
                 omg_h, omg0_h = get_frequency(

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -46,7 +46,6 @@ class FromOpenPMDProfile(FromArrayProfile):
         Only used when envelope=True.
         The provided iteration is read from <path>/<prefix>_%T.h5.
 
-
     theta : float or None, optional
         Only used if the openPMD input is in thetaMode geometry.
         Directly passed to openpmd_viewer.OpenPMDTimeSeries.get_field.

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -104,7 +104,7 @@ class FromOpenPMDProfile(FromArrayProfile):
 
             # If array does not contain the envelope but the electric field,
             # extract the envelope with a Hilbert transform
-            if envelope == False:
+            if not envelope:
                 # Assumes z is last dimension!
                 h = hilbert(F)
 
@@ -168,7 +168,7 @@ class FromOpenPMDProfile(FromArrayProfile):
                 phase_unwrap_1d = False
             # If array does not contain the envelope but the electric field,
             # extract the envelope with a Hilbert transform
-            if envelope == False:
+            if not envelope:
                 # Assumes z is last dimension!
                 h = hilbert(F)
 

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -157,7 +157,9 @@ class FromOpenPMDProfile(FromArrayProfile):
             r = m.r[m.r.size // 2 :]
             axes = {"r": r, "t": t}
 
-            F = 0.5 * (F[F.shape[0] // 2 :, :] + np.flip(F[ : F.shape[0] // 2, :], axis=0))
+            F = 0.5 * (
+                F[F.shape[0] // 2 :, :] + np.flip(F[: F.shape[0] // 2, :], axis=0)
+            )
 
             if phase_unwrap_1d is None:
                 phase_unwrap_1d = False

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -62,22 +62,29 @@ class FromOpenPMDProfile(FromArrayProfile):
     """
 
     def __init__(
-        self, path, iteration, pol, field, coord=None, envelope=False,
-            prefix=None, theta=None, phase_unwrap_1d=None
+        self,
+        path,
+        iteration,
+        pol,
+        field,
+        coord=None,
+        envelope=False,
+        prefix=None,
+        theta=None,
+        phase_unwrap_1d=None,
     ):
         ts = OpenPMDTimeSeries(path)
         F, m = ts.get_field(iteration=iteration, field=field, coord=coord, theta=theta)
 
-        if theta is None: # Envelope obtained from the full 3D array
-
+        if theta is None:  # Envelope obtained from the full 3D array
             assert m.axes in [
                 {0: "x", 1: "y", 2: "z"},
                 {0: "z", 1: "y", 2: "x"},
                 {0: "x", 1: "y", 2: "t"},
-                {0: "t", 1: "y", 2: "x"}
+                {0: "t", 1: "y", 2: "x"},
             ]
 
-            dim = 'xyt'
+            dim = "xyt"
 
             if m.axes in [{0: "z", 1: "y", 2: "x"}, {0: "t", 1: "y", 2: "x"}]:
                 F = F.swapaxes(0, 2)
@@ -103,8 +110,14 @@ class FromOpenPMDProfile(FromArrayProfile):
 
                 # Get central wavelength from array
                 axes_list = [axes[i] for i in axes.keys()]
-                omg_h, omg0_h = get_frequency(h, axes_list, dim, is_envelope=False,
-                    is_hilbert=True, phase_unwrap_1d=phase_unwrap_1d)
+                omg_h, omg0_h = get_frequency(
+                    h,
+                    axes_list,
+                    dim,
+                    is_envelope=False,
+                    is_hilbert=True,
+                    phase_unwrap_1d=phase_unwrap_1d,
+                )
                 wavelength = 2 * np.pi * c / omg0_h
                 array = h * np.exp(1j * omg0_h * t)
             else:
@@ -116,15 +129,15 @@ class FromOpenPMDProfile(FromArrayProfile):
 
             axes_order = ["x", "y", "t"]
 
-        else: # Envelope assumes axial symmetry processing RZ data
+        else:  # Envelope assumes axial symmetry processing RZ data
             assert m.axes in [
                 {0: "r", 1: "z"},
                 {0: "z", 1: "r"},
                 {0: "r", 1: "t"},
-                {0: "t", 1: "r"}
+                {0: "t", 1: "r"},
             ]
 
-            dim = 'rt'
+            dim = "rt"
 
             if m.axes in [{0: "z", 1: "r"}, {0: "t", 1: "r"}]:
                 F = F.swapaxes(0, 1)
@@ -133,10 +146,10 @@ class FromOpenPMDProfile(FromArrayProfile):
                 t = (m.z - m.z[0]) / c
             else:
                 t = m.t
-            r = m.r[m.r.size//2:]
+            r = m.r[m.r.size // 2 :]
             axes = {"r": r, "t": t}
 
-            F = F[F.shape[0]//2:,:]
+            F = F[F.shape[0] // 2 :, :]
 
             if phase_unwrap_1d is None:
                 phase_unwrap_1d = False
@@ -152,9 +165,14 @@ class FromOpenPMDProfile(FromArrayProfile):
 
                 # Get central wavelength from array
                 axes_list = [axes[i] for i in axes.keys()]
-                omg_h, omg0_h = get_frequency(h, axes_list, dim=dim,
-                    is_envelope=False, is_hilbert=True,
-                    phase_unwrap_1d=phase_unwrap_1d)
+                omg_h, omg0_h = get_frequency(
+                    h,
+                    axes_list,
+                    dim=dim,
+                    is_envelope=False,
+                    is_hilbert=True,
+                    phase_unwrap_1d=phase_unwrap_1d,
+                )
                 wavelength = 2 * np.pi * c / omg0_h
                 array = h * np.exp(1j * omg0_h * t)
             else:
@@ -166,7 +184,10 @@ class FromOpenPMDProfile(FromArrayProfile):
 
             axes_order = ["r", "t"]
 
-        print("Wavelength used in the definition of the envelope (nm):", wavelength*1.e9)
+        print(
+            "Wavelength used in the definition of the envelope (nm):",
+            wavelength * 1.0e9,
+        )
 
         super().__init__(
             wavelength=wavelength,

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -157,7 +157,7 @@ class FromOpenPMDProfile(FromArrayProfile):
             r = m.r[m.r.size // 2 :]
             axes = {"r": r, "t": t}
 
-            F = F[F.shape[0] // 2 :, :]
+            F = 0.5 * (F[F.shape[0] // 2 :, :] + np.flip(F[ : F.shape[0] // 2, :], axis=0))
 
             if phase_unwrap_1d is None:
                 phase_unwrap_1d = False

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -1,9 +1,11 @@
 import numpy as np
 from scipy.signal import hilbert
 from scipy.constants import c
+from skimage.restoration import unwrap_phase
 import openpmd_api as io
 from openpmd_viewer import OpenPMDTimeSeries
 from .from_array_profile import FromArrayProfile
+from lasy.utils.laser_utils import get_frequency
 
 
 class FromOpenPMDProfile(FromArrayProfile):
@@ -43,56 +45,135 @@ class FromOpenPMDProfile(FromArrayProfile):
         Prefix of the openPMD file from which the envelope is read.
         Only used when envelope=True.
         The provided iteration is read from <path>/<prefix>_%T.h5.
+
+
+    theta : float or None, optional
+        Only used if the openPMD input is in thetaMode geometry.
+        Directly passed to openpmd_viewer.OpenPMDTimeSeries.get_field.
+        The angle of the plane of observation, with respect to the x axis
+        If `theta` is not None, then this function returns a 2D array
+        corresponding to the plane of observation given by `theta`;
+        otherwise it returns a full 3D Cartesian array.
+
+    phase_unwrap_1d : boolean (optional)
+        Whether the phase unwrapping is done in 1D.
+        This is not recommended, as the unwrapping will not be accurate,
+        but it might be the only practical solution when dim is 'xyt'.
+        If None, it is set to False for dim = 'rt' and True for dim = 'xyt'.
     """
 
     def __init__(
-        self, path, iteration, pol, field, coord=None, envelope=False, prefix=None
+        self, path, iteration, pol, field, coord=None, envelope=False,
+            prefix=None, theta=None, phase_unwrap_1d=None
     ):
         ts = OpenPMDTimeSeries(path)
-        F, m = ts.get_field(iteration=iteration, field=field, coord=coord, theta=None)
-        assert m.axes in [
-            {0: "x", 1: "y", 2: "z"},
-            {0: "z", 1: "y", 2: "x"},
-            {0: "x", 1: "y", 2: "t"},
-            {0: "t", 1: "y", 2: "x"},
-        ]
+        F, m = ts.get_field(iteration=iteration, field=field, coord=coord, theta=theta)
 
-        if m.axes in [{0: "z", 1: "y", 2: "x"}, {0: "t", 1: "y", 2: "x"}]:
-            F = F.swapaxes(0, 2)
+        if theta is None: # Envelope obtained from the full 3D array
 
-        if "z" in m.axes.values():
-            t = (m.z - m.z[0]) / c
-        else:
-            t = m.t
-        axes = {"x": m.x, "y": m.y, "t": t}
+            assert m.axes in [
+                {0: "x", 1: "y", 2: "z"},
+                {0: "z", 1: "y", 2: "x"},
+                {0: "x", 1: "y", 2: "t"},
+                {0: "t", 1: "y", 2: "x"}
+            ]
 
-        # If array does not contain the envelope but the electric field,
-        # extract the envelope with a Hilbert transform
-        if envelope == False:
-            # Assumes z is last dimension!
-            h = hilbert(F)
+            dim = 'xyt'
+
+            if m.axes in [{0: "z", 1: "y", 2: "x"}, {0: "t", 1: "y", 2: "x"}]:
+                F = F.swapaxes(0, 2)
 
             if "z" in m.axes.values():
-                # Flip to get complex envelope in t assuming z = -c*t
-                h = np.flip(h, axis=2)
+                t = (m.z - m.z[0]) / c
+            else:
+                t = m.t
+            axes = {"x": m.x, "y": m.y, "t": t}
 
-            # Get central wavelength from array
-            phase = np.unwrap(np.angle(h))
-            omg0_h = np.average(np.gradient(-phase, t, axis=-1), weights=np.abs(h))
-            wavelength = 2 * np.pi * c / omg0_h
-            array = h * np.exp(1j * omg0_h * t)
-        else:
-            s = io.Series(path + "/" + prefix + "_%T.h5", io.Access.read_only)
-            it = s.iterations[iteration]
-            omg0 = it.meshes["laserEnvelope"].get_attribute("angularFrequency")
-            wavelength = 2 * np.pi * c / omg0
-            array = F
+            if phase_unwrap_1d is None:
+                phase_unwrap_1d = True
 
-        axes_order = ["x", "y", "t"]
+            # If array does not contain the envelope but the electric field,
+            # extract the envelope with a Hilbert transform
+            if envelope == False:
+                # Assumes z is last dimension!
+                h = hilbert(F)
+
+                if "z" in m.axes.values():
+                    # Flip to get complex envelope in t assuming z = -c*t
+                    h = np.flip(h, axis=-1)
+
+                # Get central wavelength from array
+                axes_list = [axes[i] for i in axes.keys()]
+                omg_h, omg0_h = get_frequency(h, axes_list, dim, is_envelope=False,
+                    is_hilbert=True, phase_unwrap_1d=phase_unwrap_1d)
+                wavelength = 2 * np.pi * c / omg0_h
+                array = h * np.exp(1j * omg0_h * t)
+            else:
+                s = io.Series(path + "/" + prefix + "_%T.h5", io.Access.read_only)
+                it = s.iterations[iteration]
+                omg0 = it.meshes["laserEnvelope"].get_attribute("angularFrequency")
+                wavelength = 2 * np.pi * c / omg0
+                array = F
+
+            axes_order = ["x", "y", "t"]
+
+        else: # Envelope assumes axial symmetry processing RZ data
+            assert m.axes in [
+                {0: "r", 1: "z"},
+                {0: "z", 1: "r"},
+                {0: "r", 1: "t"},
+                {0: "t", 1: "r"}
+            ]
+
+            dim = 'rt'
+
+            if m.axes in [{0: "z", 1: "r"}, {0: "t", 1: "r"}]:
+                F = F.swapaxes(0, 1)
+
+            if "z" in m.axes.values():
+                t = (m.z - m.z[0]) / c
+            else:
+                t = m.t
+            r = m.r[m.r.size//2:]
+            axes = {"r": r, "t": t}
+
+            F = F[F.shape[0]//2:,:]
+
+            if phase_unwrap_1d is None:
+                phase_unwrap_1d = False
+            # If array does not contain the envelope but the electric field,
+            # extract the envelope with a Hilbert transform
+            if envelope == False:
+                # Assumes z is last dimension!
+                h = hilbert(F)
+
+                if "z" in m.axes.values():
+                    # Flip to get complex envelope in t assuming z = -c*t
+                    h = np.flip(h, axis=-1)
+
+                # Get central wavelength from array
+                axes_list = [axes[i] for i in axes.keys()]
+                omg_h, omg0_h = get_frequency(h, axes_list, dim=dim,
+                    is_envelope=False, is_hilbert=True,
+                    phase_unwrap_1d=phase_unwrap_1d)
+                wavelength = 2 * np.pi * c / omg0_h
+                array = h * np.exp(1j * omg0_h * t)
+            else:
+                s = io.Series(path + "/" + prefix + "_%T.h5", io.Access.read_only)
+                it = s.iterations[iteration]
+                omg0 = it.meshes["laserEnvelope"].get_attribute("angularFrequency")
+                wavelength = 2 * np.pi * c / omg0
+                array = F
+
+            axes_order = ["r", "t"]
+
+        print("Wavelength used in the definition of the envelope (nm):", wavelength*1.e9)
+
         super().__init__(
             wavelength=wavelength,
             pol=pol,
             array=array,
+            dim=dim,
             axes=axes,
             axes_order=axes_order,
         )

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -60,6 +60,9 @@ class FromOpenPMDProfile(FromArrayProfile):
         This is not recommended, as the unwrapping will not be accurate,
         but it might be the only practical solution when dim is 'xyt'.
         If None, it is set to False for dim = 'rt' and True for dim = 'xyt'.
+
+    verbose : boolean (optional)
+        Whether to print extended information.
     """
 
     def __init__(
@@ -73,6 +76,7 @@ class FromOpenPMDProfile(FromArrayProfile):
         prefix=None,
         theta=None,
         phase_unwrap_1d=None,
+        verbose=False,
     ):
         ts = OpenPMDTimeSeries(path)
         F, m = ts.get_field(iteration=iteration, field=field, coord=coord, theta=theta)
@@ -200,10 +204,11 @@ class FromOpenPMDProfile(FromArrayProfile):
 
             axes_order = ["r", "t"]
 
-        print(
-            "Wavelength used in the definition of the envelope (nm):",
-            wavelength * 1.0e9,
-        )
+        if verbose:
+            print(
+                "Wavelength used in the definition of the envelope (nm):",
+                wavelength * 1.0e9,
+            )
 
         super().__init__(
             wavelength=wavelength,

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -29,7 +29,7 @@ class Grid:
         used in order to represent the laser field.
     """
 
-    def __init__(self, dim, lo, hi, npoints, n_azimuthal_modes):
+    def __init__(self, dim, lo, hi, npoints, n_azimuthal_modes=None):
         # Metadata
         ndims = 2 if dim == "rt" else 3
         assert dim in ["rt", "xyt"]

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -267,7 +267,6 @@ def get_frequency(
         Central angular frequency (averaged omega, weighted by the local
         envelope amplitude).
     """
-
     # Assumes t is last dimension!
     if is_envelope:
         assert omega0 is not None

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -326,7 +326,7 @@ def field_to_a0(grid, omega0):
     # Here, we neglect the time derivative of the envelope of E, the first RHS
     # term in: E = -dA/dt + 1j * omega0 * A where E and A are the field and
     # vector potential envelopes, respectively
-    omega, _ = get_frequency(grid.field, grid.axes, is_envelope=True, omega0=omega0)
+    omega, _ = get_frequency(grid, is_envelope=True, omega0=omega0)
     return -1j * e * grid.field / (m_e * omega * c)
 
 
@@ -359,5 +359,5 @@ def a0_to_field(grid, omega0, direct=True):
         )
         return m_e * c / e * A
     else:
-        omega, _ = get_frequency(grid.field, grid.axes, is_envelope=True, omega0=omega0)
+        omega, _ = get_frequency(grid, is_envelope=True, omega0=omega0)
         return 1j * m_e * omega * c * grid.field / e

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -357,5 +357,5 @@ def a0_to_field(grid, omega0, direct=True):
             1j * omega0 * grid.field
         return m_e * c / e * A
     else:
-        omega, _ = get_frequency(grid.field, axes, is_envelope=True, omega0=omega0)
+        omega, _ = get_frequency(grid.field, grid.axes, is_envelope=True, omega0=omega0)
         return 1j * m_e * omega * c * grid.field / e

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -326,11 +326,13 @@ def field_to_a0(field, axes, omega0):
     -------
     Normalized vector potential
     """
+    # Here, we neglect the time derivative of the envelope of E, the first RHS
+    # term in: E = -dA/dt + 1j * omega0 * A where E and A are the field and
+    # vector potential envelopes, respectively
     omega, _ = get_frequency(field, axes, is_envelope=True, omega0=omega0)
-    return e * field / (m_e * omega * c)
+    return -1j * e * field / (m_e * omega * c)
 
-
-def a0_to_field(a0, axes, omega0):
+def a0_to_field(a0, axes, omega0, direct=True):
     """
     Convert envelope from electric field (V/m) to normalized vector potential.
 
@@ -346,9 +348,16 @@ def a0_to_field(a0, axes, omega0):
     omega0 : scalar
         Angular frequency at which the envelope is defined.
 
+    direct : boolean (optional)
+        If true, the conversion is done directly with derivative of vector
+        potential. Otherwise, this is done using the local frequency.
     Returns
     -------
     Envelope of the electric field (V/m).
     """
-    omega, _ = get_frequency(a0, axes, is_envelope=True, omega0=omega0)
-    return m_e * omega * c * a0 / e
+    if direct:
+        A = -np.gradient(a0, axes[-1], axis=-1, edge_order=2) + 1j * omega0 * a0
+        return m_e * c / e * A
+    else:
+        omega, _ = get_frequency(a0, axes, is_envelope=True, omega0=omega0)
+        return 1j *  m_e * omega * c * a0 / e

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -332,6 +332,7 @@ def field_to_a0(field, axes, omega0):
     omega, _ = get_frequency(field, axes, is_envelope=True, omega0=omega0)
     return -1j * e * field / (m_e * omega * c)
 
+
 def a0_to_field(a0, axes, omega0, direct=True):
     """
     Convert envelope from electric field (V/m) to normalized vector potential.
@@ -360,4 +361,4 @@ def a0_to_field(a0, axes, omega0, direct=True):
         return m_e * c / e * A
     else:
         omega, _ = get_frequency(a0, axes, is_envelope=True, omega0=omega0)
-        return 1j *  m_e * omega * c * a0 / e
+        return 1j * m_e * omega * c * a0 / e

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -218,52 +218,52 @@ def get_frequency(
     phase_unwrap_1d=None,
 ):
     """
-     Get the local and average frequency of a signal, either electric field or envelope.
+    Get the local and average frequency of a signal, either electric field or envelope.
 
-     Parameters
-     ----------
-     grid : a Grid object.
-         It contains a ndarrays with the field data from which the
-         frequency is computed, and the associated metadata. The last axis must
-         be the longitudinal dimension.
-         Can be the full electric field or the envelope.
+    Parameters
+    ----------
+    grid : a Grid object.
+        It contains a ndarrays with the field data from which the
+        frequency is computed, and the associated metadata. The last axis must
+        be the longitudinal dimension.
+        Can be the full electric field or the envelope.
 
     dim : string (optional)
-         Dimensionality of the array. Only used if is_envelope is False.
-         Options are:
+        Dimensionality of the array. Only used if is_envelope is False.
+        Options are:
 
-         - 'xyt': The laser pulse is represented on a 3D grid:
-                  Cartesian (x,y) transversely, and temporal (t) longitudinally.
-         - 'rt' : The laser pulse is represented on a 2D grid:
-                  Cylindrical (r) transversely, and temporal (t) longitudinally.
+        - 'xyt': The laser pulse is represented on a 3D grid:
+                 Cartesian (x,y) transversely, and temporal (t) longitudinally.
+        - 'rt' : The laser pulse is represented on a 2D grid:
+                 Cylindrical (r) transversely, and temporal (t) longitudinally.
 
-     is_envelope : bool (optional)
-         Whether the field provided uses the envelope representation, as used
-         internally in lasy. If False, field is assumed to represent the
-         electric field.
+    is_envelope : bool (optional)
+        Whether the field provided uses the envelope representation, as used
+        internally in lasy. If False, field is assumed to represent the
+        electric field.
 
-     omega0 : scalar
-         Angular frequency at which the envelope is defined.
-         Required if an only if is_envelope is True.
+    omega0 : scalar
+        Angular frequency at which the envelope is defined.
+        Required if an only if is_envelope is True.
 
-     is_hilbert : boolean (optional)
-         If True, the field argument is assumed to be a Hilbert transform, and
-         is used through the computation. Otherwise, the Hilbert transform is
-         calculated in the function.
+    is_hilbert : boolean (optional)
+        If True, the field argument is assumed to be a Hilbert transform, and
+        is used through the computation. Otherwise, the Hilbert transform is
+        calculated in the function.
 
-     phase_unwrap_1d : boolean (optional)
-         Whether the phase unwrapping is done in 1D.
-         This is not recommended, as the unwrapping will not be accurate,
-         but it might be the only practical solution when dim is 'xyt'.
+    phase_unwrap_1d : boolean (optional)
+        Whether the phase unwrapping is done in 1D.
+        This is not recommended, as the unwrapping will not be accurate,
+        but it might be the only practical solution when dim is 'xyt'.
 
-     Returns
-     -------
-     omega : nd array of doubles
-         local angular frequency.
+    Returns
+    -------
+    omega : nd array of doubles
+        local angular frequency.
 
-     central_omega : scalar
-         Central angular frequency (averaged omega, weighted by the local
-         envelope amplitude).
+    central_omega : scalar
+        Central angular frequency (averaged omega, weighted by the local
+        envelope amplitude).
     """
     # Assumes t is last dimension!
     if is_envelope:

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -285,7 +285,6 @@ def get_frequency(
             h = np.squeeze(hilbert(grid.field))
         else:
             h = np.squeeze(grid.field)
-        print(h.shape)
         if phase_unwrap_1d:
             phase = np.unwrap(np.angle(h))
         else:

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -218,52 +218,52 @@ def get_frequency(
     phase_unwrap_1d=None,
 ):
     """
-    Get the local and average frequency of a signal, either electric field or envelope.
+     Get the local and average frequency of a signal, either electric field or envelope.
 
-    Parameters
-    ----------
-    grid : a Grid object.
-        It contains a ndarrays with the field data from which the
-        frequency is computed, and the associated metadata. The last axis must
-        be the longitudinal dimension.
-        Can be the full electric field or the envelope.
+     Parameters
+     ----------
+     grid : a Grid object.
+         It contains a ndarrays with the field data from which the
+         frequency is computed, and the associated metadata. The last axis must
+         be the longitudinal dimension.
+         Can be the full electric field or the envelope.
 
-   dim : string (optional)
-        Dimensionality of the array. Only used if is_envelope is False.
-        Options are:
+    dim : string (optional)
+         Dimensionality of the array. Only used if is_envelope is False.
+         Options are:
 
-        - 'xyt': The laser pulse is represented on a 3D grid:
-                 Cartesian (x,y) transversely, and temporal (t) longitudinally.
-        - 'rt' : The laser pulse is represented on a 2D grid:
-                 Cylindrical (r) transversely, and temporal (t) longitudinally.
+         - 'xyt': The laser pulse is represented on a 3D grid:
+                  Cartesian (x,y) transversely, and temporal (t) longitudinally.
+         - 'rt' : The laser pulse is represented on a 2D grid:
+                  Cylindrical (r) transversely, and temporal (t) longitudinally.
 
-    is_envelope : bool (optional)
-        Whether the field provided uses the envelope representation, as used
-        internally in lasy. If False, field is assumed to represent the
-        electric field.
+     is_envelope : bool (optional)
+         Whether the field provided uses the envelope representation, as used
+         internally in lasy. If False, field is assumed to represent the
+         electric field.
 
-    omega0 : scalar
-        Angular frequency at which the envelope is defined.
-        Required if an only if is_envelope is True.
+     omega0 : scalar
+         Angular frequency at which the envelope is defined.
+         Required if an only if is_envelope is True.
 
-    is_hilbert : boolean (optional)
-        If True, the field argument is assumed to be a Hilbert transform, and
-        is used through the computation. Otherwise, the Hilbert transform is
-        calculated in the function.
+     is_hilbert : boolean (optional)
+         If True, the field argument is assumed to be a Hilbert transform, and
+         is used through the computation. Otherwise, the Hilbert transform is
+         calculated in the function.
 
-    phase_unwrap_1d : boolean (optional)
-        Whether the phase unwrapping is done in 1D.
-        This is not recommended, as the unwrapping will not be accurate,
-        but it might be the only practical solution when dim is 'xyt'.
+     phase_unwrap_1d : boolean (optional)
+         Whether the phase unwrapping is done in 1D.
+         This is not recommended, as the unwrapping will not be accurate,
+         but it might be the only practical solution when dim is 'xyt'.
 
-    Returns
-    -------
-    omega : nd array of doubles
-        local angular frequency.
+     Returns
+     -------
+     omega : nd array of doubles
+         local angular frequency.
 
-    central_omega : scalar
-        Central angular frequency (averaged omega, weighted by the local
-        envelope amplitude).
+     central_omega : scalar
+         Central angular frequency (averaged omega, weighted by the local
+         envelope amplitude).
     """
     # Assumes t is last dimension!
     if is_envelope:
@@ -353,8 +353,10 @@ def a0_to_field(grid, omega0, direct=True):
     Envelope of the electric field (V/m).
     """
     if direct:
-        A = -np.gradient(grid.field, grid.axes[-1], axis=-1, edge_order=2) + \
-            1j * omega0 * grid.field
+        A = (
+            -np.gradient(grid.field, grid.axes[-1], axis=-1, edge_order=2)
+            + 1j * omega0 * grid.field
+        )
         return m_e * c / e * A
     else:
         omega, _ = get_frequency(grid.field, axes, is_envelope=True, omega0=omega0)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -351,6 +351,7 @@ def a0_to_field(a0, axes, omega0, direct=True):
     direct : boolean (optional)
         If true, the conversion is done directly with derivative of vector
         potential. Otherwise, this is done using the local frequency.
+
     Returns
     -------
     Envelope of the electric field (V/m).

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -208,9 +208,16 @@ def get_full_field(laser, theta=0, slice=0, slice_axis="x", Nt=None):
 
     return env, ext
 
-def get_frequency(field, axes, dim=None,
-                  is_envelope=True, omega0=None, is_hilbert=False,
-                  phase_unwrap_1d=None):
+
+def get_frequency(
+    field,
+    axes,
+    dim=None,
+    is_envelope=True,
+    omega0=None,
+    is_hilbert=False,
+    phase_unwrap_1d=None,
+):
     """
     Get the local and average frequency of a signal, either electric field or envelope.
 
@@ -265,16 +272,16 @@ def get_frequency(field, axes, dim=None,
     if is_envelope:
         assert omega0 is not None
         phase = np.unwrap(np.angle(field))
-        omega = omega0 + np.gradient(-phase, axes[-1],
-                                     axis=-1, edge_order=2)
+        omega = omega0 + np.gradient(-phase, axes[-1], axis=-1, edge_order=2)
         central_omega = np.average(omega, weights=np.abs(field))
 
         # Clean-up to avoid large errors where the signal is tiny
-        omega = np.where(np.abs(field) > np.max(np.abs(field))/100,
-                         omega, central_omega)
+        omega = np.where(
+            np.abs(field) > np.max(np.abs(field)) / 100, omega, central_omega
+        )
     else:
-        assert dim in ['xyt', 'rt']
-        if dim == 'xyt' and not phase_unwrap_1d:
+        assert dim in ["xyt", "rt"]
+        if dim == "xyt" and not phase_unwrap_1d:
             print("WARNING: using 3D phase unwrapping, this can be expensive")
 
         if not is_hilbert:
@@ -285,23 +292,22 @@ def get_frequency(field, axes, dim=None,
             phase = np.unwrap(np.angle(h))
         else:
             phase = unwrap_phase(np.angle(h))
-        omega = np.gradient(-phase, axes[-1],
-                            axis=-1, edge_order=2)
+        omega = np.gradient(-phase, axes[-1], axis=-1, edge_order=2)
 
-        if dim == 'xyt':
-            weights=np.abs(h)
+        if dim == "xyt":
+            weights = np.abs(h)
         else:
-            r = axes[0].reshape((axes[0].size,1))
-            weights=r*np.abs(h)
+            r = axes[0].reshape((axes[0].size, 1))
+            weights = r * np.abs(h)
         central_omega = np.average(omega, weights=weights)
 
         # Clean-up to avoid large errors where the signal is tiny
-        omega = np.where(np.abs(h) > np.max(np.abs(h))/100,
-                         omega, central_omega)
+        omega = np.where(np.abs(h) > np.max(np.abs(h)) / 100, omega, central_omega)
 
     return omega, central_omega
 
-def field_to_a0 (field, axes, omega0):
+
+def field_to_a0(field, axes, omega0):
     """
     Convert envelope from electric field (V/m) to normalized vector potential.
 
@@ -324,7 +330,8 @@ def field_to_a0 (field, axes, omega0):
     omega, _ = get_frequency(field, axes, is_envelope=True, omega0=omega0)
     return e * field / (m_e * omega * c)
 
-def a0_to_field (a0, axes, omega0):
+
+def a0_to_field(a0, axes, omega0):
     """
     Convert envelope from electric field (V/m) to normalized vector potential.
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -313,7 +313,7 @@ def get_frequency(
     return omega, central_omega
 
 
-def field_to_a0(grid, omega0):
+def field_to_vector_potential(grid, omega0):
     """
     Convert envelope from electric field (V/m) to normalized vector potential.
 
@@ -338,7 +338,7 @@ def field_to_a0(grid, omega0):
     return -1j * e * grid.field / (m_e * omega * c)
 
 
-def a0_to_field(grid, omega0, direct=True):
+def vector_potential_to_field(grid, omega0, direct=True):
     """
     Convert envelope from electric field (V/m) to normalized vector potential.
 

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -5,8 +5,7 @@ from .laser_utils import field_to_a0
 
 
 def write_to_openpmd_file(
-    dim, file_prefix, file_format, grid, wavelength, pol,
-    save_as_vector_potential=False
+    dim, file_prefix, file_format, grid, wavelength, pol, save_as_vector_potential=False
 ):
     """
     Write the laser field into an openPMD file.

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -1,7 +1,7 @@
 import numpy as np
 import openpmd_api as io
 from scipy.constants import c
-from .laser_utils import field_to_a0
+from .laser_utils import field_to_vector_potential
 
 
 def write_to_openpmd_file(
@@ -73,7 +73,7 @@ def write_to_openpmd_file(
     m.set_attribute("isLaserEnvelope", True)
 
     if save_as_vector_potential:
-        array = field_to_a0(grid, 2 * np.pi * c / wavelength)
+        array = field_to_vector_potential(grid, 2 * np.pi * c / wavelength)
 
     # Pick the correct field
     if dim == "xyt":

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -3,8 +3,10 @@ import openpmd_api as io
 from scipy.constants import c
 from .laser_utils import field_to_a0
 
-def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength,
-                          pol, use_a0=False):
+
+def write_to_openpmd_file(
+    dim, file_prefix, file_format, grid, wavelength, pol, use_a0=False
+):
     """
     Write the laser field into an openPMD file.
 

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -70,7 +70,7 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength,
     m.set_attribute("isLaserEnvelope", True)
 
     if use_a0:
-        array = field_to_a0(array, grid.axes[-1], 2 * np.pi * c / wavelength)
+        array = field_to_a0(array, grid.axes, 2 * np.pi * c / wavelength)
 
     # Pick the correct field
     if dim == "xyt":

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -72,7 +72,7 @@ def write_to_openpmd_file(
     m.set_attribute("isLaserEnvelope", True)
 
     if use_a0:
-        array = field_to_a0(array, grid.axes, 2 * np.pi * c / wavelength)
+        array = field_to_a0(grid, 2 * np.pi * c / wavelength)
 
     # Pick the correct field
     if dim == "xyt":

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -1,9 +1,10 @@
 import numpy as np
 import openpmd_api as io
 from scipy.constants import c
+from .laser_utils import field_to_a0
 
-
-def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
+def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength,
+                          pol, use_a0=False):
     """
     Write the laser field into an openPMD file.
 
@@ -32,6 +33,10 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
 
     pol : list of 2 complex numbers
         Polarization vector that multiplies array to get the Ex and Ey arrays.
+
+    use_a0 : bool (optional)
+        Whether the envelope is converted to normalized vector potential
+        before writing to file.
     """
     array = grid.field
 
@@ -63,6 +68,9 @@ def write_to_openpmd_file(dim, file_prefix, file_format, grid, wavelength, pol):
     m.set_attribute("angularFrequency", 2 * np.pi * c / wavelength)
     m.set_attribute("polarization", pol)
     m.set_attribute("isLaserEnvelope", True)
+
+    if use_a0:
+        array = field_to_a0(array, grid.axes[-1], 2 * np.pi * c / wavelength)
 
     # Pick the correct field
     if dim == "xyt":

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -5,7 +5,8 @@ from .laser_utils import field_to_a0
 
 
 def write_to_openpmd_file(
-    dim, file_prefix, file_format, grid, wavelength, pol, use_a0=False
+    dim, file_prefix, file_format, grid, wavelength, pol,
+    save_as_vector_potential=False
 ):
     """
     Write the laser field into an openPMD file.
@@ -36,7 +37,7 @@ def write_to_openpmd_file(
     pol : list of 2 complex numbers
         Polarization vector that multiplies array to get the Ex and Ey arrays.
 
-    use_a0 : bool (optional)
+    save_as_vector_potential : bool (optional)
         Whether the envelope is converted to normalized vector potential
         before writing to file.
     """
@@ -71,7 +72,7 @@ def write_to_openpmd_file(
     m.set_attribute("polarization", pol)
     m.set_attribute("isLaserEnvelope", True)
 
-    if use_a0:
+    if save_as_vector_potential:
         array = field_to_a0(grid, 2 * np.pi * c / wavelength)
 
     # Pick the correct field

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 openpmd-api
 openpmd-viewer
 scipy
+scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ axiprop
 numpy
 openpmd-api
 openpmd-viewer
-scipy
 scikit-image
+scipy

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -178,7 +178,8 @@ def test_from_array_profile():
     axes = {"x": x, "y": y, "t": t}
     dim = "xyt"
 
-    profile = FromArrayProfile(wavelength=wavelength, pol=pol, array=E, axes=axes)
+    profile = FromArrayProfile(wavelength=wavelength, pol=pol,
+                               array=E, dim=dim, axes=axes)
     laser = Laser(dim, lo, hi, npoints, profile)
     laser.write_to_file("fromArray")
 

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -178,8 +178,9 @@ def test_from_array_profile():
     axes = {"x": x, "y": y, "t": t}
     dim = "xyt"
 
-    profile = FromArrayProfile(wavelength=wavelength, pol=pol,
-                               array=E, dim=dim, axes=axes)
+    profile = FromArrayProfile(
+        wavelength=wavelength, pol=pol, array=E, dim=dim, axes=axes
+    )
     laser = Laser(dim, lo, hi, npoints, profile)
     laser.write_to_file("fromArray")
 


### PR DESCRIPTION
This PR proposes the following improvements, all meant to achieve #127:
- The option to output the normalized vector potential instead of the electric field is implemented. For the rationale, see https://github.com/openPMD/openPMD-standard/pull/281. This is certainly open for discussion. Converters from E to a0 and reverse are implemented in utils (it is a very vanilla version, definitely room for improvement there).
- The calculation of local and average frequency is in a separate function. This way, we can implement different methods to do this operation (e.g. FFT-based) easily.
- profile from_array and from_openPMD now also support RZ representation. Without this, operating on the 3D data was not practical. Again, very vanilla implementation, the implementation assumes axial symmetry for the envelope, the mode decomposition is not included in this PR.

With these changes, the output of an FBPIC simulation can be sent as the input of a HiPACE++ simulation. The figure below shows, for a laser pulse in a parabolic channel, the pulse width during propagation, when starting the HiPACE++ simulation from the output of the FBPIC simulation at different times. Significant differences can be observed, which could very much come from differences between the two codes: even without using LASY the two codes give slightly different results for this case. This is probably a matter of tuning the resolution, box size, time step etc., so I do not think it is necessarily a problem.
![laser_width_hipace_fbpic](https://github.com/LASY-org/lasy/assets/26292713/9488f7b3-3a4d-4d35-81d2-4ffb45c85030)
[laser_width_hipace_fbpic.pdf](https://github.com/LASY-org/lasy/files/12252598/laser_width_hipace_fbpic.pdf)

The scripts I used are posted below, so we can later work on the agreement. I had to add some .txt to upload the files.

[inputs_fbpic.py.txt](https://github.com/LASY-org/lasy/files/12252686/inputs_fbpic.py.txt)
[inputs_hipace.txt](https://github.com/LASY-org/lasy/files/12252687/inputs_hipace.txt)
[script_fbpic.sh.txt](https://github.com/LASY-org/lasy/files/12252689/script_fbpic.sh.txt)
[script_hipace.sh.txt](https://github.com/LASY-org/lasy/files/12252690/script_hipace.sh.txt)

The lasy handling was done using:
```python
from lasy.profiles.from_openpmd_profile import FromOpenPMDProfile
from lasy.laser import Laser
import matplotlib.pyplot as plt
from openpmd_viewer.addons import LpaDiagnostics
import scipy.constants as scc

profile2 = FromOpenPMDProfile('./DATA', 26, (0,1), 'E', 'y', theta=0)

dim = 'xyt'
lo = (-100e-6, -100e-6, 0)
hi = (+100e-6, +100e-6, (m0.zmax-m0.zmin)/scc.c)
npoints=(128, 128, 500)
## Tested, also works with
# dim = 'rt'
# lo = (0, 0)
# hi = (+100e-6, (m0.zmax-m0.zmin)/scc.c)
# npoints=(300, 600)
laser = Laser(dim, lo, hi, npoints, profile2)
laser.write_to_file('./lasy_t3/laser3d', use_a0=True)
```