### PR TITLE
Make `axiprop` optional

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -4,6 +4,7 @@ from scipy.constants import c
 try:
     from axiprop.lib import PropagatorFFT2, PropagatorResampling
     from axiprop.containers import ScalarFieldEnvelope
+
     axiprop_installed = True
 except ImportError:
     axiprop_installed = False
@@ -276,7 +277,7 @@ class Laser:
 
         backend : string (optional)
             Backend used by axiprop (see axiprop documentation).
-        """        
+        """
         assert axiprop_installed, (
             "`export_to_z` requires `axiprop` to be installed."
             "You can install it with `pip install axiprop`."

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -1,8 +1,12 @@
 import numpy as np
 from scipy.constants import c
 
-from axiprop.lib import PropagatorFFT2, PropagatorResampling
-from axiprop.containers import ScalarFieldEnvelope
+try:
+    from axiprop.lib import PropagatorFFT2, PropagatorResampling
+    from axiprop.containers import ScalarFieldEnvelope
+    axiprop_installed = True
+except ImportError:
+    axiprop_installed = False
 
 from lasy.utils.grid import Grid
 from lasy.utils.laser_utils import (
@@ -156,6 +160,10 @@ class Laser:
         backend : string (optional)
             Backend used by axiprop (see axiprop documentation).
         """
+        assert axiprop_installed, (
+            "Laser propagation requires `axiprop` to be installed."
+            "You can install it with `pip install axiprop`."
+        )
         time_axis_indx = -1
 
         # apply boundary "absorption" if required
@@ -268,7 +276,11 @@ class Laser:
 
         backend : string (optional)
             Backend used by axiprop (see axiprop documentation).
-        """
+        """        
+        assert axiprop_installed, (
+            "`export_to_z` requires `axiprop` to be installed."
+            "You can install it with `pip install axiprop`."
+        )
         time_axis_indx = -1
 
         t_axis = self.grid.axes[time_axis_indx]
@@ -343,6 +355,10 @@ class Laser:
         backend : string (optional)
             Backend used by axiprop (see axiprop documentation).
         """
+        assert axiprop_installed, (
+            "`import_from_z` requires `axiprop` to be installed."
+            "You can install it with `pip install axiprop`."
+        )
         z_axis_indx = -1
         t_axis = self.grid.axes[z_axis_indx]
         dz = z_axis[1] - z_axis[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-axiprop
 numpy
 openpmd-api
 openpmd-viewer

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
+axiprop
 openpmd-viewer
 pytest
-axiprop

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 openpmd-viewer
 pytest
+axiprop


### PR DESCRIPTION
This PR proposes making `axiprop` an optional dependency, since it is only needed for the laser propagation features. This would make `lasy` a lighter dependency for other libraries or codes that only need the basic lasy features (e.g., laser profile generation, openPMD readers, laser analysis, etc.).