### PR TITLE
Add new utils and reimplement `FromOpenPMDProfile`

### DIFF
--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -36,11 +36,6 @@ class FromOpenPMDProfile(FromArrayProfile):
         Name of the field containing the laser pulse
         Passed directly OpenPMDTimeSeries.
 
-    envelope : boolean
-        Whether the file represents a laser envelope.
-        If not, the envelope is obtained from the electric field
-        using a Hilbert transform
-
     prefix : string
         Prefix of the openPMD file from which the envelope is read.
         Only used when envelope=True.
@@ -71,7 +66,6 @@ class FromOpenPMDProfile(FromArrayProfile):
         pol,
         field,
         coord=None,
-        envelope=False,
         prefix=None,
         theta=None,
         phase_unwrap_1d=None,
@@ -96,7 +90,7 @@ class FromOpenPMDProfile(FromArrayProfile):
 
         # If array does not contain the envelope but the electric field,
         # extract the envelope with a Hilbert transform
-        if not envelope:
+        if not np.iscomplexobj(F):
             grid = create_grid(F, axes, dim)
             grid, omg0 = field_to_envelope(grid, dim, phase_unwrap_1d)
             array = grid.field[0]

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -85,7 +85,7 @@ class FromOpenPMDProfile(FromArrayProfile):
             if phase_unwrap_1d is None:
                 phase_unwrap_1d = False
             axes_order = ["r", "t"]
-        
+
         F, axes = reorder_array(F, m, dim)
 
         # If array does not contain the envelope but the electric field,

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy.signal import hilbert
 from scipy.constants import c
 import openpmd_api as io
 from openpmd_viewer import OpenPMDTimeSeries

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -3,8 +3,8 @@ from scipy.constants import c
 import openpmd_api as io
 from openpmd_viewer import OpenPMDTimeSeries
 from .from_array_profile import FromArrayProfile
-from lasy.utils.laser_utils import field_to_envelope
-from lasy.utils.openpmd_input import reorder_array, create_grid
+from lasy.utils.laser_utils import field_to_envelope, create_grid
+from lasy.utils.openpmd_input import reorder_array
 
 
 class FromOpenPMDProfile(FromArrayProfile):

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -382,7 +382,7 @@ def field_to_envelope(grid, dim, phase_unwrap_1d):
         A tuple with the envelope array and the central wavelength.
     """
     # hilbert transform needs inverted time axis.
-    grid.field = hilbert(grid.field[:,:,::-1])[:,:,::-1]
+    grid.field = hilbert(grid.field[:, :, ::-1])[:, :, ::-1]
 
     # Get central wavelength from array
     omg_h, omg0_h = get_frequency(

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -363,7 +363,7 @@ def vector_potential_to_field(grid, omega0, direct=True):
 
 
 def field_to_envelope(grid, dim, phase_unwrap_1d):
-    """Get the complex envelope of a filed by applying a Hilbert transform.
+    """Get the complex envelope of a field by applying a Hilbert transform.
 
     Parameters
     ----------

--- a/lasy/utils/openpmd_input.py
+++ b/lasy/utils/openpmd_input.py
@@ -1,8 +1,6 @@
 import numpy as np
 import scipy.constants as ct
 
-from .grid import Grid
-
 
 def reorder_array(array, md, dim):
     """Reorder an openPMD array to the lasy representation.
@@ -107,43 +105,3 @@ def reorder_array_rt(array, md):
         + np.flip(array[: array.shape[0] // 2, :], axis=0)
     )
     return array, axes
-
-
-def create_grid(array, axes, dim):
-    """Create a lasy grid from a numpy array.
-
-    Parameters
-    ----------
-    array : ndarray
-        The input field array.
-    axes : dict
-        Dictionary with the information of the array axes.
-    dim : {'xyt, 'rt'}
-        The dimensionality of the array.
-
-    Returns
-    -------
-    grid : Grid
-        A lasy grid containing the input array.
-    """
-    # Create grid.
-    if dim == "xyt":
-        lo = (axes["x"][0], axes["y"][0], axes["t"][0])
-        hi = (axes["x"][-1], axes["y"][-1], axes["t"][-1])
-        npoints = (axes["x"].size, axes["y"].size, axes["t"].size)
-        grid = Grid(dim, lo, hi, npoints)
-        assert np.all(grid.axes[0] == axes["x"])
-        assert np.all(grid.axes[1] == axes["y"])
-        assert np.all(grid.axes[2] == axes["t"])
-        assert grid.field.shape == array.shape
-        grid.field = array
-    else:  # dim == "rt":
-        lo = (axes["r"][0], axes["t"][0])
-        hi = (axes["r"][-1], axes["t"][-1])
-        npoints = (axes["r"].size, axes["t"].size)
-        grid = Grid(dim, lo, hi, npoints, n_azimuthal_modes=1)
-        assert np.all(grid.axes[0] == axes["r"])
-        assert np.allclose(grid.axes[1], axes["t"], rtol=1.0e-14)
-        assert grid.field.shape == array[np.newaxis].shape
-        grid.field = array[np.newaxis]
-    return grid

--- a/lasy/utils/openpmd_input.py
+++ b/lasy/utils/openpmd_input.py
@@ -137,7 +137,7 @@ def create_grid(array, axes, dim):
         assert np.all(grid.axes[2] == axes["t"])
         assert grid.field.shape == array.shape
         grid.field = array
-    elif dim == "rt":
+    else:  # dim == "rt":
         lo = (axes["r"][0], axes["t"][0])
         hi = (axes["r"][-1], axes["t"][-1])
         npoints = (axes["r"].size, axes["t"].size)

--- a/lasy/utils/openpmd_input.py
+++ b/lasy/utils/openpmd_input.py
@@ -1,0 +1,149 @@
+import numpy as np
+import scipy.constants as ct
+
+from .grid import Grid
+
+
+def reorder_array(array, md, dim):
+    """Reorder an openPMD array to the lasy representation.
+
+    Parameters
+    ----------
+    array : ndarray
+        The field array to be reordered.
+    md : FieldMetaInformation
+        The openPMD metadata of the field.
+    dim : {'xyt, 'rt'}
+        The dimensionality of the array.
+
+    Returns
+    -------
+    array : ndarray
+        The reordered array.
+    axes : dict
+        A dictionary with the lasy axes information for the array.
+    """
+    if dim == 'xyt':
+        return reorder_array_xyt(array, md)
+    else:
+        return reorder_array_rt(array, md)
+
+
+def reorder_array_xyt(array, md):
+    """Reorder an openPMD array to the lasy representation in `xyt` geometry.
+
+    Parameters
+    ----------
+    array : ndarray
+        The field array to be reordered.
+    md : FieldMetaInformation
+        The openPMD metadata of the field.
+
+    Returns
+    -------
+    array : ndarray
+        The reordered array.
+    axes : dict
+        A dictionary with the lasy axes information for the array.
+    """
+    assert md.axes in [
+        {0: "x", 1: "y", 2: "z"},
+        {0: "z", 1: "y", 2: "x"},
+        {0: "x", 1: "y", 2: "t"},
+        {0: "t", 1: "y", 2: "x"},
+    ]
+
+    if md.axes in [{0: "z", 1: "y", 2: "x"}, {0: "t", 1: "y", 2: "x"}]:
+        array = array.swapaxes(0, 2)
+
+    if "z" in md.axes.values():
+        t = (md.z - md.z[0]) / ct.c
+        # Flip to get complex envelope in t assuming z = -c*t
+        array = np.flip(array, axis=-1)
+    else:
+        t = md.t
+    axes = {"x": md.x, "y": md.y, "t": t}
+    return array, axes
+
+
+def reorder_array_rt(array, md):
+    """Reorder an openPMD array to the lasy representation in `rt` geometry.
+
+    Parameters
+    ----------
+    array : ndarray
+        The field array to be reordered.
+    md : FieldMetaInformation
+        The openPMD metadata of the field.
+
+    Returns
+    -------
+    array : ndarray
+        The reordered array.
+    axes : dict
+        A dictionary with the lasy axes information for the array.
+    """
+    assert md.axes in [
+        {0: "r", 1: "z"},
+        {0: "z", 1: "r"},
+        {0: "r", 1: "t"},
+        {0: "t", 1: "r"},
+    ]
+
+    if md.axes in [{0: "z", 1: "r"}, {0: "t", 1: "r"}]:
+        array = array.swapaxes(0, 1)
+
+    if "z" in md.axes.values():
+        t = (md.z - md.z[0]) / ct.c
+        # Flip to get complex envelope in t assuming z = -c*t
+        array = np.flip(array, axis=-1)
+    else:
+        t = md.t
+    r = md.r[md.r.size // 2 :]
+    axes = {"r": r, "t": t}
+
+    array = 0.5 * (
+        array[array.shape[0] // 2 :, :] +
+        np.flip(array[: array.shape[0] // 2, :], axis=0)
+    )
+    return array, axes
+
+
+def create_grid(array, axes, dim):
+    """Create a lasy grid from a numpy array.
+
+    Parameters
+    ----------
+    array : ndarray
+        The input field array.
+    axes : dict
+        Dictionary with the information of the array axes.
+    dim : {'xyt, 'rt'}
+        The dimensionality of the array.
+
+    Returns
+    -------
+    grid : Grid
+        A lasy grid containing the input array.
+    """
+    # Create grid.
+    if dim == 'xyt':
+        lo = (axes["x"][0], axes["y"][0], axes["t"][0])
+        hi = (axes["x"][-1], axes["y"][-1], axes["t"][-1])
+        npoints = (axes["x"].size, axes["y"].size, axes["t"].size)
+        grid = Grid(dim, lo, hi, npoints)
+        assert np.all(grid.axes[0] == axes["x"])
+        assert np.all(grid.axes[1] == axes["y"])
+        assert np.all(grid.axes[2] == axes["t"])
+        assert grid.field.shape == array.shape
+        grid.field = array
+    elif dim == 'rt':
+        lo = (axes["r"][0], axes["t"][0])
+        hi = (axes["r"][-1], axes["t"][-1])
+        npoints = (axes["r"].size, axes["t"].size)
+        grid = Grid(dim, lo, hi, npoints, n_azimuthal_modes=1)
+        assert np.all(grid.axes[0] == axes["r"])
+        assert np.allclose(grid.axes[1], axes["t"], rtol=1.0e-14)
+        assert grid.field.shape == array[np.newaxis].shape
+        grid.field = array[np.newaxis]
+    return grid

--- a/lasy/utils/openpmd_input.py
+++ b/lasy/utils/openpmd_input.py
@@ -23,7 +23,7 @@ def reorder_array(array, md, dim):
     axes : dict
         A dictionary with the lasy axes information for the array.
     """
-    if dim == 'xyt':
+    if dim == "xyt":
         return reorder_array_xyt(array, md)
     else:
         return reorder_array_rt(array, md)
@@ -103,8 +103,8 @@ def reorder_array_rt(array, md):
     axes = {"r": r, "t": t}
 
     array = 0.5 * (
-        array[array.shape[0] // 2 :, :] +
-        np.flip(array[: array.shape[0] // 2, :], axis=0)
+        array[array.shape[0] // 2 :, :]
+        + np.flip(array[: array.shape[0] // 2, :], axis=0)
     )
     return array, axes
 
@@ -127,7 +127,7 @@ def create_grid(array, axes, dim):
         A lasy grid containing the input array.
     """
     # Create grid.
-    if dim == 'xyt':
+    if dim == "xyt":
         lo = (axes["x"][0], axes["y"][0], axes["t"][0])
         hi = (axes["x"][-1], axes["y"][-1], axes["t"][-1])
         npoints = (axes["x"].size, axes["y"].size, axes["t"].size)
@@ -137,7 +137,7 @@ def create_grid(array, axes, dim):
         assert np.all(grid.axes[2] == axes["t"])
         assert grid.field.shape == array.shape
         grid.field = array
-    elif dim == 'rt':
+    elif dim == "rt":
         lo = (axes["r"][0], axes["t"][0])
         hi = (axes["r"][-1], axes["t"][-1])
         npoints = (axes["r"].size, axes["t"].size)


### PR DESCRIPTION
This PR adds a few handy utilities to process arrays from openPMD (actually, from the openPMD-viewer) and a new `field_to_envelope` method. With these new utilities, the implementation of `FromOpenPMDProfile` can be greatly simplified.

In addition, the `envelope` parameter of `FromOpenPMDProfile` has been removed. The class itself will determine whether the input field is an envelope by checking whether the array is complex.