### PR TITLE
Add new `get_spectrum` and `get_duration` utils

### DIFF
--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -44,7 +44,7 @@ def compute_laser_energy(dim, grid):
 
     if dim == "xyt":
         energy = ((dV * epsilon_0 * 0.5) * abs(envelope) ** 2).sum()
-    elif dim == "rt":
+    else:  # dim == "rt":
         energy = (
             dV[np.newaxis, :, np.newaxis]
             * epsilon_0
@@ -263,7 +263,7 @@ def get_spectrum(grid, dim, bins=20, range=None, omega0=None, phase_unwrap_1d=No
     dV = get_grid_cell_volume(grid, dim)
     if dim == "xyt":
         weights = np.abs(grid.field) * dV
-    elif dim == "rt":
+    else:  # dim == "rt":
         weights = np.abs(grid.field) * dV[np.newaxis, :, np.newaxis]
     # Get weighted spectrum.
     # Neglects the 2 first and last time slices, whose values seems to be
@@ -399,7 +399,7 @@ def get_duration(grid, dim):
     dV = get_grid_cell_volume(grid, dim)
     if dim == "xyt":
         weights = np.abs(grid.field) * dV
-    elif dim == "rt":
+    else:  # dim == "rt":
         weights = np.abs(grid.field) * dV[np.newaxis, :, np.newaxis]
     # project weights to longitudinal axes
     weights = np.sum(weights, axis=(0, 1))
@@ -533,7 +533,7 @@ def get_grid_cell_volume(grid, dim):
     dz = grid.dx[-1] * c
     if dim == "xyt":
         dV = grid.dx[0] * grid.dx[1] * dz
-    elif dim == "rt":
+    else:  # dim == "rt":
         r = grid.axes[0]
         dr = grid.dx[0]
         # 1D array that computes the volume of radial cells

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -321,7 +321,7 @@ def get_spectrum(
         # Keep only positive frequencies.
         i_keep = spectrum.shape[-1] // 2
         omega = omega[:i_keep]
-        spectrum = spectrum[:i_keep]
+        spectrum = spectrum[..., :i_keep]
 
     # Convert to spectral energy density (J/(m^2 rad Hz)).
     if method != "raw":
@@ -337,7 +337,7 @@ def get_spectrum(
             spectrum = np.sum(spectrum[0] * dV[:, np.newaxis] / dz, axis=0)
 
     # If the user specified a frequency range, interpolate into it.
-    if range is not None:
+    if method in ["sum", "on_axis"] and range is not None:
         omega_interp = np.linspace(*range, bins)
         spectrum = np.interp(omega_interp, omega, spectrum)
         omega = omega_interp

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -206,7 +206,16 @@ def get_full_field(laser, theta=0, slice=0, slice_axis="x", Nt=None):
     return env, ext
 
 
-def get_spectrum(grid, dim, bins=20, range=None, omega0=None, phase_unwrap_1d=None, is_envelope=True, method='fft'):
+def get_spectrum(
+    grid,
+    dim,
+    bins=20,
+    range=None,
+    omega0=None,
+    phase_unwrap_1d=None,
+    is_envelope=True,
+    method="fft",
+):
     """
     Get the the frequency spectrum of an envelope.
 
@@ -249,19 +258,22 @@ def get_spectrum(grid, dim, bins=20, range=None, omega0=None, phase_unwrap_1d=No
     omega_spectrum : scalar
         Array with the frequencies of the spectrum.
     """
-    if method == 'fft':
-
+    if method == "fft":
         # spectrum = np.fft.fft(grid.field[0, 0]) * grid.dx[-1]
         spectrum = np.fft.fft(grid.field) * grid.dx[-1]
         dV = get_grid_cell_volume(grid, dim)
         if dim == "xyt":
             spectrum = np.sum(spectrum, axis=(0, 1))
         else:
-            spectrum = np.sum(spectrum * dV[np.newaxis, :, np.newaxis] / dV[0], axis=1)[0]
+            spectrum = np.sum(spectrum * dV[np.newaxis, :, np.newaxis] / dV[0], axis=1)[
+                0
+            ]
         # spectrum = np.abs(spectrum[:int(len(spectrum) / 2)])
-        freq = np.fft.fftfreq(spectrum.shape[-1], d=(grid.axes[-1][1] - grid.axes[-1][0]))
+        freq = np.fft.fftfreq(
+            spectrum.shape[-1], d=(grid.axes[-1][1] - grid.axes[-1][0])
+        )
         omega_spectrum = 2 * np.pi * freq
-        
+
         if is_envelope:
             omega_spectrum = omega0 - omega_spectrum
 
@@ -269,7 +281,7 @@ def get_spectrum(grid, dim, bins=20, range=None, omega0=None, phase_unwrap_1d=No
         omega_spectrum = omega_spectrum[i_sort]
         spectrum = np.abs(spectrum[i_sort])
 
-        i_keep = omega_spectrum >= 0.
+        i_keep = omega_spectrum >= 0.0
         omega_spectrum = omega_spectrum[i_keep]
         spectrum = spectrum[i_keep]
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -325,7 +325,7 @@ def get_spectrum(
 
     # Convert to spectral energy density (J/(m^2 rad Hz)).
     if method != "raw":
-        spectrum = np.abs(spectrum)**2 * epsilon_0 * c / np.pi
+        spectrum = np.abs(spectrum) ** 2 * epsilon_0 * c / np.pi
 
     # Integrate transversely.
     if method == "sum":

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -263,7 +263,7 @@ def get_spectrum(
         will be returned using interpolation.
 
     bins : int (optional)
-        Number of bins of to which to interpolate the spectrum if a `range`
+        Number of bins into which to interpolate the spectrum if a `range`
         is given.
 
     is_envelope : bool (optional)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -291,6 +291,9 @@ def get_spectrum(
         spectrum = np.abs(spectrum[:i_keep])
         omega_spectrum = omega_spectrum[:i_keep]
 
+    # Square to get energy-like spectrum (check if appropriate).
+    spectrum = spectrum ** 2
+
     # Sum spectrum transversely.
     if not on_axis:
         dV = get_grid_cell_volume(grid, dim)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -210,7 +210,7 @@ def get_spectrum(
     grid, dim, range=None, bins=20, is_envelope=True, omega0=None, method="sum"
 ):
     r"""
-    Get the the frequency spectrum of an envelope or electric field.
+    Get the frequency spectrum of an envelope or electric field.
 
     The spectrum can be calculated in three different ways, depending on the
     `method` specified by the user:

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -269,7 +269,7 @@ def get_spectrum(
     is_envelope : bool (optional)
         Whether the field provided uses the envelope representation, as used
         internally in lasy. If False, field is assumed to represent the
-        the electric field.
+        the full electric field (with fast oscillations).
 
     omega0 : scalar (optional)
         Angular frequency at which the envelope is defined. Required if

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -206,14 +206,7 @@ def get_full_field(laser, theta=0, slice=0, slice_axis="x", Nt=None):
     return env, ext
 
 
-def get_spectrum(
-    grid,
-    dim,
-    bins=20,
-    range=None,
-    omega0=None,
-    phase_unwrap_1d=None
-):
+def get_spectrum(grid, dim, bins=20, range=None, omega0=None, phase_unwrap_1d=None):
     """
     Get the the frequency spectrum of an envelope.
 
@@ -264,7 +257,7 @@ def get_spectrum(
         dim=dim,
         is_envelope=True,
         omega0=omega0,
-        phase_unwrap_1d=phase_unwrap_1d
+        phase_unwrap_1d=phase_unwrap_1d,
     )
     # Calculate weights of each frequency (amplitude of the field).
     dV = get_grid_cell_volume(grid, dim)
@@ -279,7 +272,7 @@ def get_spectrum(
         a=np.squeeze(omega)[..., 2:-2],
         weights=np.squeeze(weights[..., 2:-2]),
         bins=bins,
-        range=range
+        range=range,
     )
     omega_spectrum = edges[1:] - (edges[1] - edges[0]) / 2
     return spectrum, omega_spectrum
@@ -564,7 +557,7 @@ def weighted_std(values, weights=None):
     A float with the value of the standard deviation
     """
     mean_val = np.average(values, weights=weights)
-    std = np.sqrt(np.average((values-mean_val)**2, weights=weights))
+    std = np.sqrt(np.average((values - mean_val) ** 2, weights=weights))
     return std
 
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -530,12 +530,12 @@ def get_grid_cell_volume(grid, dim):
         A float with the cell volume (if dim=='xyt') or a numpy array with the
         radial distribution of cell volumes (if dim=='rt').
     """
+    dz = grid.dx[-1] * c
     if dim == "xyt":
         dV = grid.dx[0] * grid.dx[1] * dz
     elif dim == "rt":
         r = grid.axes[0]
         dr = grid.dx[0]
-        dz = grid.dx[-1] * c
         # 1D array that computes the volume of radial cells
         dV = np.pi * ((r + 0.5 * dr) ** 2 - (r - 0.5 * dr) ** 2) * dz
     return dV

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -265,16 +265,14 @@ def get_spectrum(
         Array with the frequencies of the spectrum.
     """
     # Get the frequencies of the fft output.
-    freq = np.fft.fftfreq(
-        grid.field.shape[-1], d=(grid.axes[-1][1] - grid.axes[-1][0])
-    )
+    freq = np.fft.fftfreq(grid.field.shape[-1], d=(grid.axes[-1][1] - grid.axes[-1][0]))
     omega_spectrum = 2 * np.pi * freq
 
     # Get on axis or full field.
     if on_axis:
         if dim == "xyt":
             nx, ny, nt = grid.field.shape
-            field = grid.field[nx//2, ny//2]
+            field = grid.field[nx // 2, ny // 2]
         else:
             field = grid.field[0, 0]
     else:
@@ -300,10 +298,9 @@ def get_spectrum(
         if dim == "xyt":
             spectrum = np.sum(spectrum, axis=(0, 1))
         else:
-            spectrum = np.sum(
-                spectrum * dV[np.newaxis, :, np.newaxis] / dV[0],
-                axis=1
-            )[0]
+            spectrum = np.sum(spectrum * dV[np.newaxis, :, np.newaxis] / dV[0], axis=1)[
+                0
+            ]
 
     # Sort freqency array (and the spectrum accordingly).
     i_sort = np.argsort(omega_spectrum)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -273,9 +273,10 @@ def get_spectrum(grid, dim, bins=20, range=None, omega0=None, phase_unwrap_1d=No
         omega_spectrum = omega_spectrum[i_keep]
         spectrum = spectrum[i_keep]
 
-        omega_interp = np.linspace(*range, bins)
-        spectrum = np.interp(omega_interp, omega_spectrum, spectrum)
-        omega_spectrum = omega_interp
+        if range is not None:
+            omega_interp = np.linspace(*range, bins)
+            spectrum = np.interp(omega_interp, omega_spectrum, spectrum)
+            omega_spectrum = omega_interp
 
         # spectrum = np.fft.fft(grid.field) * grid.dx[-1]
         # spectrum = np.abs(spectrum[..., :int(spectrum.shape[-1] / 2)])

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -292,7 +292,7 @@ def get_spectrum(
         omega_spectrum = omega_spectrum[:i_keep]
 
     # Square to get energy-like spectrum (check if appropriate).
-    spectrum = spectrum ** 2
+    spectrum = spectrum**2
 
     # Sum spectrum transversely.
     if not on_axis:

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -264,6 +264,7 @@ def get_spectrum(grid, dim, bins=20, range=None, omega0=None, phase_unwrap_1d=No
         
         if is_envelope:
             omega_spectrum = omega0 - omega_spectrum
+            spectrum /= 2
 
         i_sort = np.argsort(omega_spectrum)
         omega_spectrum = omega_spectrum[i_sort]

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -436,7 +436,7 @@ def get_duration(grid, dim):
     float
         RMS duration of the envelope in seconds.
     """
-    # Calculate weights of each frequency (amplitude of the field).
+    # Calculate weights of each grid cell (amplitude of the field).
     dV = get_grid_cell_volume(grid, dim)
     if dim == "xyt":
         weights = np.abs(grid.field) * dV

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -216,18 +216,17 @@ def get_spectrum(
     on_axis=False,
 ):
     """
-    Get the the frequency spectrum of an envelope.
+    Get the the frequency spectrum of an envelope or electric field.
 
     Parameters
     ----------
     grid : a Grid object.
-        It contains a ndarrays with the field data from which the
+        It contains an ndarray with the field data from which the
         spectrum is computed, and the associated metadata. The last axis must
         be the longitudinal dimension.
 
     dim : string (optional)
-        Dimensionality of the array. Only used if is_envelope is False.
-        Options are:
+        Dimensionality of the array. Options are:
 
         - 'xyt': The laser pulse is represented on a 3D grid:
                  Cartesian (x,y) transversely, and temporal (t) longitudinally.

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -542,7 +542,7 @@ def get_grid_cell_volume(grid, dim):
 
 
 def weighted_std(values, weights=None):
-    """Calculates the weighted standard deviation of the given values
+    """Calculate the weighted standard deviation of the given values.
 
     Parameters
     ----------

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -297,9 +297,7 @@ def get_spectrum(
         if dim == "xyt":
             spectrum = np.sum(spectrum, axis=(0, 1))
         else:
-            spectrum = np.sum(spectrum * dV[np.newaxis, :, np.newaxis] / dV[0], axis=1)[
-                0
-            ]
+            spectrum = np.sum(spectrum[0] * dV[:, np.newaxis] / dV[0], axis=0)
 
     # Sort freqency array (and the spectrum accordingly).
     i_sort = np.argsort(omega_spectrum)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -207,13 +207,7 @@ def get_full_field(laser, theta=0, slice=0, slice_axis="x", Nt=None):
 
 
 def get_spectrum(
-    grid,
-    dim,
-    range=None,
-    bins=20,
-    is_envelope=True,
-    omega0=None,
-    mode='sum'
+    grid, dim, range=None, bins=20, is_envelope=True, omega0=None, mode="sum"
 ):
     """
     Get the the frequency spectrum of an envelope or electric field.
@@ -269,7 +263,7 @@ def get_spectrum(
     omega_spectrum = 2 * np.pi * freq
 
     # Get on axis or full field.
-    if mode == 'on_axis':
+    if mode == "on_axis":
         if dim == "xyt":
             nx, ny, nt = grid.field.shape
             field = grid.field[nx // 2, ny // 2]
@@ -297,7 +291,7 @@ def get_spectrum(
 
     # Sum spectrum transversely.
     dV = get_grid_cell_volume(grid, dim)
-    if mode == 'on_axis':
+    if mode == "on_axis":
         if dim == "xyt":
             spectrum *= dV
         else:
@@ -307,7 +301,7 @@ def get_spectrum(
             spectrum = spectrum * dV
         else:
             spectrum = spectrum[0] * dV[:, np.newaxis]
-        if mode == 'sum':
+        if mode == "sum":
             if dim == "xyt":
                 spectrum = np.sum(spectrum, axis=(0, 1))
             else:
@@ -448,9 +442,9 @@ def get_duration(grid, dim):
     # Calculate weights of each grid cell (amplitude of the field).
     dV = get_grid_cell_volume(grid, dim)
     if dim == "xyt":
-        weights = np.abs(grid.field)**2 * dV
+        weights = np.abs(grid.field) ** 2 * dV
     else:  # dim == "rt":
-        weights = np.abs(grid.field)**2 * dV[np.newaxis, :, np.newaxis]
+        weights = np.abs(grid.field) ** 2 * dV[np.newaxis, :, np.newaxis]
     # project weights to longitudinal axes
     weights = np.sum(weights, axis=(0, 1))
     return weighted_std(grid.axes[-1], weights)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -216,7 +216,6 @@ def get_spectrum(grid, dim, bins=20, range=None, omega0=None, phase_unwrap_1d=No
         It contains a ndarrays with the field data from which the
         spectrum is computed, and the associated metadata. The last axis must
         be the longitudinal dimension.
-        Can be the full electric field or the envelope.
 
     dim : string (optional)
         Dimensionality of the array. Only used if is_envelope is False.
@@ -236,7 +235,6 @@ def get_spectrum(grid, dim, bins=20, range=None, omega0=None, phase_unwrap_1d=No
 
     omega0 : scalar
         Angular frequency at which the envelope is defined.
-        Required if an only if is_envelope is True.
 
     phase_unwrap_1d : boolean (optional)
         Whether the phase unwrapping is done in 1D.
@@ -251,7 +249,7 @@ def get_spectrum(grid, dim, bins=20, range=None, omega0=None, phase_unwrap_1d=No
     omega_spectrum : scalar
         Array with the frequencies of the spectrum.
     """
-    # Get frequency array.
+    # Get the array of angular frequency.
     omega, central_omega = get_frequency(
         grid=grid,
         dim=dim,
@@ -267,7 +265,7 @@ def get_spectrum(grid, dim, bins=20, range=None, omega0=None, phase_unwrap_1d=No
         weights = np.abs(grid.field) * dV[np.newaxis, :, np.newaxis]
     # Get weighted spectrum.
     # Neglects the 2 first and last time slices, whose values seems to be
-    # slightly off (maybe due to lower order derivative at the edges).
+    # slightly off (maybe due to lower-order derivative at the edges).
     spectrum, edges = np.histogram(
         a=np.squeeze(omega)[..., 2:-2],
         weights=np.squeeze(weights[..., 2:-2]),

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -1,0 +1,71 @@
+import numpy as np
+
+from lasy.laser import Laser
+from lasy.profiles.gaussian_profile import GaussianProfile
+from lasy.utils.laser_utils import (get_spectrum, compute_laser_energy, get_duration)
+
+
+def get_gaussian_profile():
+    # Cases with Gaussian laser
+    wavelength = 0.8e-6
+    pol = (1, 0)
+    laser_energy = 1.0  # J
+    t_peak = 0.0e-15  # s
+    tau = 30.0e-15  # s
+    w0 = 5.0e-6  # m
+    profile = GaussianProfile(wavelength, pol, laser_energy, w0, tau, t_peak)
+
+    return profile
+
+
+def get_gaussian_laser(dim):
+    # - Cylindrical case
+    if dim == "rt":
+        lo = (0e-6, -60e-15)
+        hi = (25e-6, +60e-15)
+        npoints = (100, 100)
+    elif dim == "xyt":
+        lo = (-25e-6, -25e-6, -60e-15)
+        hi = (+25e-6, +25e-6, +60e-15)
+        npoints = (100, 100, 100)
+    return Laser(dim, lo, hi, npoints, get_gaussian_profile())
+
+
+def test_laser_analysis_utils():
+    """Test the different laser analysis utilities in both geometries."""
+    for dim in ["xyt", 'rt']:
+        laser = get_gaussian_laser(dim)
+
+        # Check that energy computed from spectrum agrees with `compute_laser_energy`.
+        spectrum, omega = get_spectrum(laser.grid, dim, is_envelope=True,
+                                       omega0=laser.profile.omega0)
+        d_omega = omega[1] - omega[0]
+        spectrum_energy = np.sum(spectrum) * d_omega
+        energy = compute_laser_energy(dim, laser.grid)
+        np.testing.assert_approx_equal(spectrum_energy, energy, significant=14)
+
+        # Check that:
+        # 1. The on-axis spectrum agrees with the on-axis value of the full spectrum
+        # 2. The summed full spectrum agrees with the summed spectrum.
+        spectrum_oa, omega = get_spectrum(laser.grid, dim, is_envelope=True,
+                                          omega0=laser.profile.omega0, mode='on_axis')
+        spectrum_full, omega = get_spectrum(laser.grid, dim, is_envelope=True,
+                                            omega0=laser.profile.omega0, mode='full')
+        if dim == "xyt":
+            nx, ny, nt = laser.grid.field.shape
+            spectrum_oa_from_full = spectrum_full[nx // 2, ny // 2]
+            spectrum_sum_from_full = np.sum(spectrum_full, axis=(0, 1))
+        else:
+            spectrum_oa_from_full = spectrum_full[0, 0]
+            spectrum_sum_from_full = np.sum(spectrum_full, axis=(0))
+        np.testing.assert_allclose(spectrum_oa_from_full, spectrum_oa, rtol=1e-13)
+        np.testing.assert_allclose(spectrum_sum_from_full, spectrum, rtol=1e-13)
+
+        # Check that laser duration agrees with the given one.
+        tau_rms = get_duration(laser.grid, dim)
+        np.testing.assert_approx_equal(2*tau_rms, laser.profile.long_profile.tau, significant=3)
+        
+
+
+if __name__ == "__main__":
+    test_laser_analysis_utils()

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from lasy.laser import Laser
 from lasy.profiles.gaussian_profile import GaussianProfile
-from lasy.utils.laser_utils import (get_spectrum, compute_laser_energy, get_duration)
+from lasy.utils.laser_utils import get_spectrum, compute_laser_energy, get_duration
 
 
 def get_gaussian_profile():
@@ -33,12 +33,13 @@ def get_gaussian_laser(dim):
 
 def test_laser_analysis_utils():
     """Test the different laser analysis utilities in both geometries."""
-    for dim in ["xyt", 'rt']:
+    for dim in ["xyt", "rt"]:
         laser = get_gaussian_laser(dim)
 
         # Check that energy computed from spectrum agrees with `compute_laser_energy`.
-        spectrum, omega = get_spectrum(laser.grid, dim, is_envelope=True,
-                                       omega0=laser.profile.omega0)
+        spectrum, omega = get_spectrum(
+            laser.grid, dim, is_envelope=True, omega0=laser.profile.omega0
+        )
         d_omega = omega[1] - omega[0]
         spectrum_energy = np.sum(spectrum) * d_omega
         energy = compute_laser_energy(dim, laser.grid)
@@ -47,10 +48,16 @@ def test_laser_analysis_utils():
         # Check that:
         # 1. The on-axis spectrum agrees with the on-axis value of the full spectrum
         # 2. The summed full spectrum agrees with the summed spectrum.
-        spectrum_oa, omega = get_spectrum(laser.grid, dim, is_envelope=True,
-                                          omega0=laser.profile.omega0, mode='on_axis')
-        spectrum_full, omega = get_spectrum(laser.grid, dim, is_envelope=True,
-                                            omega0=laser.profile.omega0, mode='full')
+        spectrum_oa, omega = get_spectrum(
+            laser.grid,
+            dim,
+            is_envelope=True,
+            omega0=laser.profile.omega0,
+            mode="on_axis",
+        )
+        spectrum_full, omega = get_spectrum(
+            laser.grid, dim, is_envelope=True, omega0=laser.profile.omega0, mode="full"
+        )
         if dim == "xyt":
             nx, ny, nt = laser.grid.field.shape
             spectrum_oa_from_full = spectrum_full[nx // 2, ny // 2]
@@ -63,8 +70,9 @@ def test_laser_analysis_utils():
 
         # Check that laser duration agrees with the given one.
         tau_rms = get_duration(laser.grid, dim)
-        np.testing.assert_approx_equal(2*tau_rms, laser.profile.long_profile.tau, significant=3)
-        
+        np.testing.assert_approx_equal(
+            2 * tau_rms, laser.profile.long_profile.tau, significant=3
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -23,8 +23,8 @@ def get_gaussian_laser(dim):
     if dim == "rt":
         lo = (0e-6, -60e-15)
         hi = (25e-6, +60e-15)
-        npoints = (100, 100)
-    elif dim == "xyt":
+        npoints = (100, 100)    
+    else:  # dim == "xyt":
         lo = (-25e-6, -25e-6, -60e-15)
         hi = (+25e-6, +25e-6, +60e-15)
         npoints = (100, 100, 100)

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -23,7 +23,7 @@ def get_gaussian_laser(dim):
     if dim == "rt":
         lo = (0e-6, -60e-15)
         hi = (25e-6, +60e-15)
-        npoints = (100, 100)    
+        npoints = (100, 100)
     else:  # dim == "xyt":
         lo = (-25e-6, -25e-6, -60e-15)
         hi = (+25e-6, +25e-6, +60e-15)

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -43,30 +43,7 @@ def test_laser_analysis_utils():
         d_omega = omega[1] - omega[0]
         spectrum_energy = np.sum(spectrum) * d_omega
         energy = compute_laser_energy(dim, laser.grid)
-        np.testing.assert_approx_equal(spectrum_energy, energy, significant=14)
-
-        # Check that:
-        # 1. The on-axis spectrum agrees with the on-axis value of the full spectrum
-        # 2. The summed full spectrum agrees with the summed spectrum.
-        spectrum_oa, omega = get_spectrum(
-            laser.grid,
-            dim,
-            is_envelope=True,
-            omega0=laser.profile.omega0,
-            mode="on_axis",
-        )
-        spectrum_full, omega = get_spectrum(
-            laser.grid, dim, is_envelope=True, omega0=laser.profile.omega0, mode="full"
-        )
-        if dim == "xyt":
-            nx, ny, nt = laser.grid.field.shape
-            spectrum_oa_from_full = spectrum_full[nx // 2, ny // 2]
-            spectrum_sum_from_full = np.sum(spectrum_full, axis=(0, 1))
-        else:
-            spectrum_oa_from_full = spectrum_full[0, 0]
-            spectrum_sum_from_full = np.sum(spectrum_full, axis=(0))
-        np.testing.assert_allclose(spectrum_oa_from_full, spectrum_oa, rtol=1e-13)
-        np.testing.assert_allclose(spectrum_sum_from_full, spectrum, rtol=1e-13)
+        np.testing.assert_approx_equal(spectrum_energy, energy, significant=10)
 
         # Check that laser duration agrees with the given one.
         tau_rms = get_duration(laser.grid, dim)


### PR DESCRIPTION
As the title says, this PR adds two new laser analysis methods. They currently support grids that contain an envelope. In addition to them, a new convenience method to get the grid cell volume has also been implemented.