### PR TITLE
Update docs to use `sphinx_design`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@
 matplotlib
 numpydoc
 pydata-sphinx-theme
-sphinx-gallery
 sphinx-design
+sphinx-gallery

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,5 @@
 matplotlib
 numpydoc
 pydata-sphinx-theme
-pydata-sphinx-theme
 sphinx-gallery
-sphinx-panels
+sphinx-design

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,7 +75,7 @@ html_theme_options = {
         {
             "name": "GitHub",
             "url": "https://github.com/LASY-org/lasy",
-            "icon": "fab fa-github-square",
+            "icon": "fa-brands fa-github",
         },
     ],
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.autosummary",
     "sphinx.ext.viewcode",
-    "sphinx_panels",
+    "sphinx_design",
     "numpydoc",
     "matplotlib.sphinxext.plot_directive",
 ]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,66 +17,64 @@ The laser field is then exported in a standardized file, that can be read by ext
 
 The code is open-source and hosted on `github <https://github.com/LASY-org/lasy>`__. Contributions are welcome!
 
-.. panels::
-    :card: + intro-card text-center
-    :column: col-lg-6 col-md-6 col-sm-6 col-xs-12 p-2 d-flex
+.. grid:: 1 1 2 2
+    :gutter: 2
 
-    ---
+    .. grid-item-card:: Getting Started
+        :text-align: center
 
-    **Getting Started**
-    ^^^^^^^^^^^^^^
+        New to ``lasy``? Check this out for installation instructions and a first example.
 
+        +++
 
-    New to ``lasy``? Check this out for installation instructions and a first example.
+        .. button-ref:: user_guide/index
+                :expand:
+                :color: primary
+                :click-parent:
 
-    +++
+                More Information
 
-    .. link-button:: user_guide/index
-            :type: ref
-            :text: More Information
-            :classes: btn-outline-primary btn-block stretched-link
+    .. grid-item-card:: Overview of the Code
+        :text-align: center
 
-    ---
+        An overview of the key concepts and functionality of the code.
 
-    **Overview of the Code**
-    ^^^^^^^^^^^^^^^^^^^^^^^^
+        +++
 
-    An overview of the key concepts and functionality of the code.
+        .. button-ref:: code_overview/index
+                :expand:
+                :color: primary
+                :click-parent:
 
-    +++
+                Get an overview of the code
 
-    .. link-button:: code_overview/index
-            :type: ref
-            :text: Get an overview of the code
-            :classes: btn-outline-primary btn-block stretched-link
+    .. grid-item-card:: API Reference
+        :text-align: center
 
-    ---
+        Get into the nuts and bolts of the ``lasy`` API with the documentation here.
 
-    **API Reference**
-    ^^^^^^^^^^^^^^^^^
+        +++
 
-    Get into the nuts and bolts of the ``lasy`` API with the documentation here.
+        .. button-ref:: api/index
+                :expand:
+                :color: primary
+                :click-parent:
 
-    +++
+                Take a look at the API Reference
 
-    .. link-button:: api/index
-            :type: ref
-            :text: Take a look at the API Reference
-            :classes: btn-outline-primary btn-block stretched-link
+    .. grid-item-card:: Tutorials
+        :text-align: center
 
-    ---
+        Some step-by-step guides to using the code and some common examples which you might find useful.
 
-    **Tutorials**
-    ^^^^^^^^^^^^^
+        +++
 
-    Some step-by-step guides to using the code and some common examples which you might find useful.
-
-    +++
-
-    .. link-button:: tutorials/index
-            :type: ref
-            :text: Show me some tutorials
-            :classes: btn-outline-primary btn-block stretched-link
+        .. button-ref:: tutorials/index
+                :expand:
+                :color: primary
+                :click-parent:
+                
+                Show me some Tutorials
 
 .. toctree::
    :hidden:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,7 +73,7 @@ The code is open-source and hosted on `github <https://github.com/LASY-org/lasy>
                 :expand:
                 :color: primary
                 :click-parent:
-                
+
                 Show me some Tutorials
 
 .. toctree::


### PR DESCRIPTION
This PR updates the grid we show in the home page of the documentation. It was using a package (`sphinx_panels`) that is now deprecated in favor of `sphinx_design`. This fixes an issue where the dark color scheme was not properly working.

Before:
![image](https://github.com/LASY-org/lasy/assets/20479420/9c43ba5f-79e4-4fed-b486-9655d248a3ba)

Now:
![image](https://github.com/LASY-org/lasy/assets/20479420/3af7c076-5a0a-4a3e-a1b3-c2621261c4b4)
