### PR TITLE
Make scikit-image an optional dependency, and change default for phase unwrapping

### DIFF
--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -57,7 +57,7 @@ class FromOpenPMDProfile(FromArrayProfile):
 
     phase_unwrap_nd : boolean (optional)
         If True, the phase unwrapping is n-dimensional (2- or 3-D depending on dim).
-        If False, the phase unwrapping is done in z, treating each transverse cell
+        If False, the phase unwrapping is done in t, treating each transverse cell
         separately. This should be less accurate but faster.
         If set to True, scikit-image must be installed.
 

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -55,11 +55,11 @@ class FromOpenPMDProfile(FromArrayProfile):
         corresponding to the plane of observation given by `theta`;
         otherwise it returns a full 3D Cartesian array.
 
-    phase_unwrap_1d : boolean (optional)
-        Whether the phase unwrapping is done in 1D.
-        This is not recommended, as the unwrapping will not be accurate,
-        but it might be the only practical solution when dim is 'xyt'.
-        If None, it is set to False for dim = 'rt' and True for dim = 'xyt'.
+    phase_unwrap_nd : boolean (optional)
+        If True, the phase unwrapping is n-dimensional (2- or 3-D depending on dim).
+        If False, the phase unwrapping is done in z, treating each transverse cell
+        separately. This should be less accurate but faster.
+        If set to True, scikit-image must be installed.
 
     verbose : boolean (optional)
         Whether to print extended information.
@@ -75,7 +75,7 @@ class FromOpenPMDProfile(FromArrayProfile):
         is_envelope=None,
         prefix=None,
         theta=None,
-        phase_unwrap_1d=None,
+        phase_unwrap_nd=False,
         verbose=False,
     ):
         ts = OpenPMDTimeSeries(path)
@@ -87,14 +87,10 @@ class FromOpenPMDProfile(FromArrayProfile):
 
         if theta is None:  # Envelope obtained from the full 3D array
             dim = "xyt"
-            if phase_unwrap_1d is None:
-                phase_unwrap_1d = True
             axes_order = ["x", "y", "t"]
 
         else:  # Envelope assumes axial symmetry processing RZ data
             dim = "rt"
-            if phase_unwrap_1d is None:
-                phase_unwrap_1d = False
             axes_order = ["r", "t"]
 
         F, axes = reorder_array(F, m, dim)
@@ -103,7 +99,7 @@ class FromOpenPMDProfile(FromArrayProfile):
         # extract the envelope with a Hilbert transform
         if not is_envelope:
             grid = create_grid(F, axes, dim)
-            grid, omg0 = field_to_envelope(grid, dim, phase_unwrap_1d)
+            grid, omg0 = field_to_envelope(grid, dim, phase_unwrap_nd)
             array = grid.field[0]
         else:
             s = io.Series(path + "/" + prefix + "_%T.h5", io.Access.read_only)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -2,8 +2,10 @@ import numpy as np
 from scipy.constants import c, epsilon_0, e, m_e
 from scipy.interpolate import interp1d
 from scipy.signal import hilbert
+
 try:
     from skimage.restoration import unwrap_phase
+
     skimage_installed = True
 except ImportError:
     skimage_installed = False

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -434,8 +434,7 @@ def get_frequency(
                 skimage_installed = True
             except ImportError:
                 skimage_installed = False
-            assert (
-                skimage_installed,
+            assert skimage_installed, (
                 "scikit-image must be install for nd phase unwrapping.",
                 "Please install scikit-image or use phase_unwrap_nd=False.",
             )

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -430,13 +430,15 @@ def get_frequency(
         if phase_unwrap_nd:
             try:
                 from skimage.restoration import unwrap_phase
+
                 skimage_installed = True
             except ImportError:
                 skimage_installed = False
-            assert(skimage_installed,
-                   "scikit-image must be install for nd phase unwrapping.",
-                   "Please install scikit-image or use phase_unwrap_nd=False.",
-                   )
+            assert (
+                skimage_installed,
+                "scikit-image must be install for nd phase unwrapping.",
+                "Please install scikit-image or use phase_unwrap_nd=False.",
+            )
             phase = unwrap_phase(np.angle(h))
         else:
             phase = np.unwrap(np.angle(h))

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -430,10 +430,13 @@ def get_frequency(
         if phase_unwrap_nd:
             try:
                 from skimage.restoration import unwrap_phase
+
                 phase = unwrap_phase(np.angle(h))
             except ImportError:
-                print("scikit-image must be install for nd phase unwrapping.",
-                      "Please install scikit-image or use phase_unwrap_nd=False.")
+                print(
+                    "scikit-image must be install for nd phase unwrapping.",
+                    "Please install scikit-image or use phase_unwrap_nd=False.",
+                )
         else:
             phase = np.unwrap(np.angle(h))
         omega = np.gradient(-phase, grid.axes[-1], axis=-1, edge_order=2)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -2,13 +2,6 @@ import numpy as np
 from scipy.constants import c, epsilon_0, e, m_e
 from scipy.interpolate import interp1d
 from scipy.signal import hilbert
-
-try:
-    from skimage.restoration import unwrap_phase
-
-    skimage_installed = True
-except ImportError:
-    skimage_installed = False
 from axiprop.lib import PropagatorFFT2, PropagatorResampling
 from axiprop.containers import ScalarFieldEnvelope
 from .grid import Grid
@@ -435,7 +428,12 @@ def get_frequency(
         h = grid.field if is_hilbert else hilbert_transform(grid)
         h = np.squeeze(grid.field)
         if phase_unwrap_nd:
-            phase = unwrap_phase(np.angle(h))
+            try:
+                from skimage.restoration import unwrap_phase
+                phase = unwrap_phase(np.angle(h))
+            except ImportError:
+                print("scikit-image must be install for nd phase unwrapping.",
+                      "Please install scikit-image or use phase_unwrap_nd=False.")
         else:
             phase = np.unwrap(np.angle(h))
         omega = np.gradient(-phase, grid.axes[-1], axis=-1, edge_order=2)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -430,13 +430,14 @@ def get_frequency(
         if phase_unwrap_nd:
             try:
                 from skimage.restoration import unwrap_phase
-
-                phase = unwrap_phase(np.angle(h))
+                skimage_installed = True
             except ImportError:
-                print(
-                    "scikit-image must be install for nd phase unwrapping.",
-                    "Please install scikit-image or use phase_unwrap_nd=False.",
-                )
+                skimage_installed = False
+            assert(skimage_installed,
+                   "scikit-image must be install for nd phase unwrapping.",
+                   "Please install scikit-image or use phase_unwrap_nd=False.",
+                   )
+            phase = unwrap_phase(np.angle(h))
         else:
             phase = np.unwrap(np.angle(h))
         omega = np.gradient(-phase, grid.axes[-1], axis=-1, edge_order=2)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -398,7 +398,7 @@ def get_frequency(
 
     phase_unwrap_nd : boolean (optional)
         If True, the phase unwrapping is n-dimensional (2- or 3-D depending on dim).
-        If False, the phase unwrapping is done in z, treating each transverse cell
+        If False, the phase unwrapping is done in t, treating each transverse cell
         separately. This should be less accurate but faster.
         If set to True, scikit-image must be installed.
 
@@ -552,7 +552,7 @@ def field_to_envelope(grid, dim, phase_unwrap_nd=False):
 
     phase_unwrap_nd : boolean (optional)
         If True, the phase unwrapping is n-dimensional (2- or 3-D depending on dim).
-        If False, the phase unwrapping is done in z, treating each transverse cell
+        If False, the phase unwrapping is done in t, treating each transverse cell
         separately. This should be less accurate but faster.
         If set to True, scikit-image must be installed.
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -2,14 +2,13 @@ import numpy as np
 from scipy.constants import c, epsilon_0, e, m_e
 from scipy.interpolate import interp1d
 from scipy.signal import hilbert
-
 try:
     from skimage.restoration import unwrap_phase
-
     skimage_installed = True
 except ImportError:
     skimage_installed = False
-
+from axiprop.lib import PropagatorFFT2, PropagatorResampling
+from axiprop.containers import ScalarFieldEnvelope
 from .grid import Grid
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ axiprop
 numpy
 openpmd-api
 openpmd-viewer
-scikit-image
 scipy


### PR DESCRIPTION
Quick tests by @AngelFP show that 1D phase unwrapping can be sufficient. This PR proposes to keep the option of ND phase unwrapping, but turn it off by default and hence make scikit-image an optional dependency.