### PR TITLE
Do not extrapolate field in `FromArrayProfile` when using `rz` geometry

### DIFF
--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -64,14 +64,15 @@ class FromArrayProfile(Profile):
                 self.array = array
 
             # The first point is at dr/2.
-            # To avoid problems within the first cell, fill_value in None,
-            # so the value is interpolated. This might cause issues at the upper
-            # boundary.
+            # To make correct interpolation within the first cell, mirror
+            # field and axes along r.
+            r = np.concatenate((-axes["r"][::-1], axes["r"]))
+            array = np.concatenate((array[::-1], array))
             self.field_interp = RegularGridInterpolator(
-                (axes["r"], axes["t"]),
+                (r, axes["t"]),
                 array,
                 bounds_error=False,
-                fill_value=0.,
+                fill_value=0.0,
             )
 
     def evaluate(self, x, y, t):

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -71,7 +71,7 @@ class FromArrayProfile(Profile):
                 (axes["r"], axes["t"]),
                 array,
                 bounds_error=False,
-                fill_value=None,
+                fill_value=0.,
             )
 
     def evaluate(self, x, y, t):


### PR DESCRIPTION
Currently, in order to avoid issues in the first cell when using `rz` geometry, the array is extrapolated when a point outside of the
original domain is requested. However, this leads to artifacts at the upper boundary (and potentially also in the time boundaries).

This PR fixes this issue by creating an interpolation array that is mirrored along the axis. This allows the interpolation within the first cell to be correct and let's us use a fill value of 0 outside of the other boundaries.