### PR TITLE
Update writing of `position`

### DIFF
--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -103,7 +103,7 @@ def write_to_openpmd_file(
     # Define the dataset
     dataset = io.Dataset(data.dtype, data.shape)
     env = m[io.Mesh_Record_Component.SCALAR]
-    env.position = np.zeros(len(dim))
+    env.position = np.zeros(len(dim), dtype=np.float64)
     env.reset_dataset(dataset)
     env.store_chunk(data)
 

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -103,7 +103,7 @@ def write_to_openpmd_file(
     # Define the dataset
     dataset = io.Dataset(data.dtype, data.shape)
     env = m[io.Mesh_Record_Component.SCALAR]
-    env.position = [0] * len(dim)
+    env.position = np.zeros(len(dim))
     env.reset_dataset(dataset)
     env.store_chunk(data)
 


### PR DESCRIPTION
The previous syntax for writing `position` was ambiguous about the type of `position` and could result in unreadable types when the `lasy` file is produced on certain architectures.

The new syntax now uses the default numpy type (`float64`).