### PR TITLE
openPMD write: close file

### DIFF
--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -111,3 +111,4 @@ def write_to_openpmd_file(
     env.store_chunk(data)
 
     series.flush()
+    series.close()


### PR DESCRIPTION
Gives up the file handle and close the file after write.

Fix #187

Thank you for the report, @SchroederSa ! :+1: 