### PR TITLE
Show import path in the documentation

### DIFF
--- a/docs/source/api/profiles/combined_profile.rst
+++ b/docs/source/api/profiles/combined_profile.rst
@@ -1,5 +1,5 @@
 Combined Longitudinal and Transverse Profile
 ============================================
 
-.. autoclass:: lasy.profiles.gaussian_profile.CombinedLongitudinalTransverseProfile
+.. autoclass:: lasy.profiles.CombinedLongitudinalTransverseProfile
     :members:

--- a/docs/source/api/profiles/from_array_profile.rst
+++ b/docs/source/api/profiles/from_array_profile.rst
@@ -1,5 +1,5 @@
 Profile defined from external Numpy array
 =========================================
 
-.. autoclass:: lasy.profiles.from_array_profile.FromArrayProfile
+.. autoclass:: lasy.profiles.FromArrayProfile
     :members:

--- a/docs/source/api/profiles/from_openpmd_profile.rst
+++ b/docs/source/api/profiles/from_openpmd_profile.rst
@@ -1,5 +1,5 @@
 Profile read from an openPMD file
 =================================
 
-.. autoclass:: lasy.profiles.from_openpmd_profile.FromOpenPMDProfile
+.. autoclass:: lasy.profiles.FromOpenPMDProfile
     :members:

--- a/docs/source/api/profiles/gaussian.rst
+++ b/docs/source/api/profiles/gaussian.rst
@@ -1,5 +1,5 @@
 Gaussian Laser Profile
 ======================
 
-.. autoclass:: lasy.profiles.gaussian_profile.GaussianProfile
+.. autoclass:: lasy.profiles.GaussianProfile
     :members:

--- a/docs/source/api/profiles/longitudinal/gaussian.rst
+++ b/docs/source/api/profiles/longitudinal/gaussian.rst
@@ -1,5 +1,5 @@
 Gaussian Longitudinal Profile
 =============================
 
-.. autoclass:: lasy.profiles.longitudinal.gaussian_profile.GaussianLongitudinalProfile
+.. autoclass:: lasy.profiles.longitudinal.GaussianLongitudinalProfile
     :members:

--- a/docs/source/api/profiles/longitudinal/longitudinal_profile_from_data.rst
+++ b/docs/source/api/profiles/longitudinal/longitudinal_profile_from_data.rst
@@ -1,5 +1,5 @@
 Longitudinal Profile From Data
 ==============================
 
-.. autoclass:: lasy.profiles.longitudinal.longitudinal_profile_from_data.LongitudinalProfileFromData
+.. autoclass:: lasy.profiles.longitudinal.LongitudinalProfileFromData
     :members:

--- a/docs/source/api/profiles/transverse/gaussian.rst
+++ b/docs/source/api/profiles/transverse/gaussian.rst
@@ -6,5 +6,5 @@ This transverse profile can also be implemented via the lowest order mode of eit
 
 ------------
 
-.. autoclass:: lasy.profiles.transverse.gaussian_profile.GaussianTransverseProfile
+.. autoclass:: lasy.profiles.transverse.GaussianTransverseProfile
     :members:

--- a/docs/source/api/profiles/transverse/hermite_gaussian_profile.rst
+++ b/docs/source/api/profiles/transverse/hermite_gaussian_profile.rst
@@ -9,5 +9,5 @@ Hermite-Gaussian modes are a family of solutions to the paraxial wave equation w
 
 ------------
 
-.. autoclass:: lasy.profiles.transverse.hermite_gaussian_profile.HermiteGaussianTransverseProfile
+.. autoclass:: lasy.profiles.transverse.HermiteGaussianTransverseProfile
     :members:

--- a/docs/source/api/profiles/transverse/jinc_profile.rst
+++ b/docs/source/api/profiles/transverse/jinc_profile.rst
@@ -11,5 +11,5 @@ The shape of the profile is characterised by the waist :math:`w_0`.
 
 ------------
 
-.. autoclass:: lasy.profiles.transverse.jinc_profile.JincTransverseProfile
+.. autoclass:: lasy.profiles.transverse.JincTransverseProfile
     :members:

--- a/docs/source/api/profiles/transverse/laguerre_gaussian_profile.rst
+++ b/docs/source/api/profiles/transverse/laguerre_gaussian_profile.rst
@@ -11,5 +11,5 @@ The modes can have azimuthally varying fields (for :math:`m > 0`) but any single
 
 ------------
 
-.. autoclass:: lasy.profiles.transverse.laguerre_gaussian_profile.LaguerreGaussianTransverseProfile
+.. autoclass:: lasy.profiles.transverse.LaguerreGaussianTransverseProfile
     :members:

--- a/docs/source/api/profiles/transverse/super_gaussian_profile.rst
+++ b/docs/source/api/profiles/transverse/super_gaussian_profile.rst
@@ -10,5 +10,5 @@ The shape of the profile is characterised by the waist :math:`w_0` and by one "o
 
 ------------
 
-.. autoclass:: lasy.profiles.transverse.super_gaussian_profile.SuperGaussianTransverseProfile
+.. autoclass:: lasy.profiles.transverse.SuperGaussianTransverseProfile
     :members:

--- a/docs/source/api/profiles/transverse/transverse_profile_from_data.rst
+++ b/docs/source/api/profiles/transverse/transverse_profile_from_data.rst
@@ -5,5 +5,5 @@ This class allows the user to import an experimentally measured transverse profi
 
 ------------
 
-.. autoclass:: lasy.profiles.transverse.transverse_profile_from_data.TransverseProfileFromData
+.. autoclass:: lasy.profiles.transverse.TransverseProfileFromData
     :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,9 +47,6 @@ extensions = [
 numpydoc_show_class_members = False
 numpydoc_use_plots = True
 
-# Autodoc Settings
-add_module_names = False
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
When reading the documentation for various profiles (e.g. `SuperGaussianTransverseProfile`), the users will also need to know how to import these profiles in their `lasy` script.

This PR makes sure that the Sphinx documentation does show the import path. I also used the shorter path that is available for a number of classes (e.g. `lasy.profiles.transverse.SuperGaussianTransverseProfile` instead of `lasy.profiles.transverse.super_gaussian_profile.SuperGaussianTransverseProfile`

This is how the documentation looks in the **development** branch:

<img width="753" alt="Screenshot 2023-10-18 at 4 00 09 PM" src="https://github.com/LASY-org/lasy/assets/6685781/eb25d4ed-722a-45ee-a941-f55f69a316d8">

This is how it looks **in this PR**:

<img width="762" alt="Screenshot 2023-10-18 at 4 00 33 PM" src="https://github.com/LASY-org/lasy/assets/6685781/e92498d3-429b-4edd-9317-0df2d8abe71e">

