### PR TITLE
Fix cross-references to classes in Sphinx doc

### DIFF
--- a/lasy/profiles/combined_profile.py
+++ b/lasy/profiles/combined_profile.py
@@ -37,11 +37,11 @@ class CombinedLongitudinalTransverseProfile(Profile):
         field (:math:`E_0` in the above formula) is automatically
         calculated so that the pulse has the prescribed energy.
 
-    long_profile : an instance of `lasy`'s :class:`.LongitudinalProfile`
+    long_profile : :class:`.LongitudinalProfile`
         Defines the longitudinal envelope of the laser, i.e. the
         function :math:`\mathcal{L}(t)` in the above formula.
 
-    transverse_profile : an instance of `lasy`'s :class:`.TransverseProfile`
+    transverse_profile : :class:`.TransverseProfile`
         Defines the transverse envelope of the laser, i.e. the
         function :math:`\mathcal{T}(x, y)` in the above formula.
     """

--- a/lasy/profiles/combined_profile.py
+++ b/lasy/profiles/combined_profile.py
@@ -37,11 +37,11 @@ class CombinedLongitudinalTransverseProfile(Profile):
         field (:math:`E_0` in the above formula) is automatically
         calculated so that the pulse has the prescribed energy.
 
-    long_profile : an instance of `lasy`'s :class:LongitudinalProfile
+    long_profile : an instance of `lasy`'s :class:`.LongitudinalProfile`
         Defines the longitudinal envelope of the laser, i.e. the
         function :math:`\mathcal{L}(t)` in the above formula.
 
-    transverse_profile : an instance of `lasy`'s :class:TransverseProfile
+    transverse_profile : an instance of `lasy`'s :class:`.TransverseProfile`
         Defines the transverse envelope of the laser, i.e. the
         function :math:`\mathcal{T}(x, y)` in the above formula.
     """

--- a/lasy/profiles/longitudinal/gaussian_profile.py
+++ b/lasy/profiles/longitudinal/gaussian_profile.py
@@ -8,7 +8,7 @@ class GaussianLongitudinalProfile(LongitudinalProfile):
     Derived class for the analytic profile of a longitudinally-Gaussian laser pulse.
 
     More precisely, the longitudinal envelope
-    (to be used in the :class:CombinedLongitudinalTransverseProfile class)
+    (to be used in the :class:`.CombinedLongitudinalTransverseProfile` class)
     corresponds to:
 
     .. math::

--- a/lasy/profiles/transverse/gaussian_profile.py
+++ b/lasy/profiles/transverse/gaussian_profile.py
@@ -8,7 +8,7 @@ class GaussianTransverseProfile(TransverseProfile):
     Derived class for the analytic profile of a Gaussian laser pulse.
 
     More precisely, at focus (``z_foc=0``), the transverse envelope
-    (to be used in the :class:CombinedLongitudinalTransverseLaser class)
+    (to be used in the :class:`.CombinedLongitudinalTransverseLaser` class)
     corresponds to:
 
     .. math::

--- a/lasy/profiles/transverse/hermite_gaussian_profile.py
+++ b/lasy/profiles/transverse/hermite_gaussian_profile.py
@@ -11,7 +11,7 @@ class HermiteGaussianTransverseProfile(TransverseProfile):
 
     Derived class for an analytic profile.
     More precisely, the transverse envelope (to be used in the
-    :class:CombinedLongitudinalTransverseLaser class) corresponds to:
+    :class:`.CombinedLongitudinalTransverseLaser` class) corresponds to:
 
     .. math::
 

--- a/lasy/profiles/transverse/laguerre_gaussian_profile.py
+++ b/lasy/profiles/transverse/laguerre_gaussian_profile.py
@@ -10,7 +10,7 @@ class LaguerreGaussianTransverseProfile(TransverseProfile):
 
     Derived class for an analytic profile.
     More precisely, at focus (`z_foc=0`), the transverse envelope (to be used in the
-    :class:CombinedLongitudinalTransverseLaser class) corresponds to:
+    :class:`.CombinedLongitudinalTransverseLaser` class) corresponds to:
 
     .. math::
 


### PR DESCRIPTION
The cross-references to classes used an incorrect syntax.

Documentation from the `development` branch:
<img width="705" alt="Screenshot 2023-10-18 at 4 18 58 PM" src="https://github.com/LASY-org/lasy/assets/6685781/8fafd4f6-30bc-4ccc-bd0d-31ff61195a09">

Documentation with this PR:
<img width="666" alt="Screenshot 2023-10-18 at 4 17 48 PM" src="https://github.com/LASY-org/lasy/assets/6685781/c141ec50-fe11-4d27-a8fb-88c614ff8433">
