### PR TITLE
Fix warning from pydata theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,6 +76,7 @@ html_theme_options = {
             "icon": "fa-brands fa-github",
         },
     ],
+    "navigation_with_keys": False,
 }
 
 # Prevent panels extension from modifying page style.


### PR DESCRIPTION
The latest version of the theme raises a warning if navigation_with_keys is not explicitly set, which causes readthedocs to report a failed build. This PR simply sets it to the new default.