### PR TITLE
Resampling

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -292,24 +292,13 @@ class Laser:
         self.grid.field *= np.exp(1j * omega0 * distance / c)
 
     def write_to_file(
-        self,
-        iteration,
-        distance,
-        file_prefix="laser",
-        file_format="h5",
-        save_as_vector_potential=False,
+        self, file_prefix="laser", file_format="h5", save_as_vector_potential=False
     ):
         """
         Write the laser profile + metadata to file.
 
         Parameters
         ----------
-        iteration: integer
-            Current iteration
-
-        distance: scalar
-            Propagation distance(overall position of the laser)
-
         file_prefix : string
             The file name will start with this prefix.
 
@@ -322,8 +311,6 @@ class Laser:
         """
         write_to_openpmd_file(
             self.dim,
-            iteration,
-            step,
             file_prefix,
             file_format,
             self.grid,

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -139,7 +139,9 @@ class Laser:
         else:
             raise ValueError(f'kind "{kind}" not recognized')
 
-    def propagate(self, distance, nr_boundary=None, backend="NP", grid=None, show_progress=True):
+    def propagate(
+        self, distance, nr_boundary=None, backend="NP", grid=None, show_progress=True
+    ):
         """
         Propagate the laser pulse by the distance specified.
 
@@ -154,10 +156,10 @@ class Laser:
             Only used for ``'rt'``.
         backend : string (optional)
             Backend used by axiprop (see axiprop documentation).
-            
+
         grid : Grid object (optional)
             Resample the field onto a new grid. Only works for ``'rt'``.
-            
+
         show_progress : bool (optional)
             Whether to show a progress bar when performing the computation
         """
@@ -210,7 +212,7 @@ class Laser:
                 spatial_axes_n = (grid.axes[0],)
                 # Overwrite grid
                 self.grid = grid
-                self.prop = [] # Delete existing propagator
+                self.prop = []  # Delete existing propagator
                 # Create Propagator and pass resampled axis
                 for m in self.grid.azimuthal_modes:
                     self.prop.append(
@@ -249,7 +251,7 @@ class Laser:
                 field_fft[i_m, :, :] = np.transpose(transform_data).copy()
             # Delete Propagator if resampling was done
             if grid is not None:
-                del self.prop  
+                del self.prop
         else:
             # Construct the propagator for non-rt case (check if exists)
             if not hasattr(self, "prop"):
@@ -290,7 +292,12 @@ class Laser:
         self.grid.field *= np.exp(1j * omega0 * distance / c)
 
     def write_to_file(
-        self, iteration, distance, file_prefix="laser", file_format="h5", save_as_vector_potential=False
+        self,
+        iteration,
+        distance,
+        file_prefix="laser",
+        file_format="h5",
+        save_as_vector_potential=False,
     ):
         """
         Write the laser profile + metadata to file.
@@ -299,10 +306,10 @@ class Laser:
         ----------
         iteration: integer
             Current iteration
-            
+
         distance: scalar
             Propagation distance(overall position of the laser)
-        
+
         file_prefix : string
             The file name will start with this prefix.
 

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -6,7 +6,13 @@ from lasy import __version__ as lasy_version
 
 
 def write_to_openpmd_file(
-    dim, file_prefix, file_format, grid, wavelength, pol, save_as_vector_potential=False,
+    dim,
+    file_prefix,
+    file_format,
+    grid,
+    wavelength,
+    pol,
+    save_as_vector_potential=False,
 ):
     """
     Write the laser field into an openPMD file.

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -6,15 +6,7 @@ from lasy import __version__ as lasy_version
 
 
 def write_to_openpmd_file(
-    dim,
-    iteration,
-    distance,
-    file_prefix,
-    file_format,
-    grid,
-    wavelength,
-    pol,
-    save_as_vector_potential=False,
+    dim, file_prefix, file_format, grid, wavelength, pol, save_as_vector_potential=False,
 ):
     """
     Write the laser field into an openPMD file.
@@ -28,12 +20,6 @@ def write_to_openpmd_file(
                  Cartesian (x,y) transversely, and temporal (t) longitudinally.
         - 'rt' : The laser pulse is represented on a 2D grid:
                  Cylindrical (r) transversely, and temporal (t) longitudinally.
-
-    iteration: integer
-        Current iteration
-
-    distance: scalar
-        Propagation distance (overall)
 
     file_prefix : string
         The file name will start with this prefix.
@@ -61,7 +47,7 @@ def write_to_openpmd_file(
     series = io.Series("{}_%05T.{}".format(file_prefix, file_format), io.Access.create)
     series.set_software("lasy", lasy_version)
 
-    i = series.iterations[iteration]
+    i = series.iterations[0]
 
     # Define the mesh
     m = i.meshes["laserEnvelope"]
@@ -80,8 +66,6 @@ def write_to_openpmd_file(
     # Store metadata needed to reconstruct the field
     m.set_attribute("angularFrequency", 2 * np.pi * c / wavelength)
     m.set_attribute("polarization", pol)
-    m.set_attribute("t", distance / c)
-    m.set_attribute("iteration", iteration)
     if save_as_vector_potential:
         m.set_attribute("envelopeField", "normalized_vector_potential")
         m.unit_dimension = {}

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -6,7 +6,7 @@ from lasy import __version__ as lasy_version
 
 
 def write_to_openpmd_file(
-    dim, file_prefix, file_format, grid, wavelength, pol, save_as_vector_potential=False
+    dim, iteration, distance, file_prefix, file_format, grid, wavelength, pol, save_as_vector_potential=False
 ):
     """
     Write the laser field into an openPMD file.
@@ -20,7 +20,13 @@ def write_to_openpmd_file(
                  Cartesian (x,y) transversely, and temporal (t) longitudinally.
         - 'rt' : The laser pulse is represented on a 2D grid:
                  Cylindrical (r) transversely, and temporal (t) longitudinally.
-
+                 
+    iteration: integer
+        Current iteration
+            
+    distance: scalar
+        Propagation distance (overall)
+ 
     file_prefix : string
         The file name will start with this prefix.
 
@@ -47,7 +53,7 @@ def write_to_openpmd_file(
     series = io.Series("{}_%05T.{}".format(file_prefix, file_format), io.Access.create)
     series.set_software("lasy", lasy_version)
 
-    i = series.iterations[0]
+    i = series.iterations[iteration]
 
     # Define the mesh
     m = i.meshes["laserEnvelope"]
@@ -66,6 +72,8 @@ def write_to_openpmd_file(
     # Store metadata needed to reconstruct the field
     m.set_attribute("angularFrequency", 2 * np.pi * c / wavelength)
     m.set_attribute("polarization", pol)
+    m.set_attribute('t', distance/c)
+    m.set_attribute('iteration', iteration)
     if save_as_vector_potential:
         m.set_attribute("envelopeField", "normalized_vector_potential")
         m.unit_dimension = {}

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -6,7 +6,15 @@ from lasy import __version__ as lasy_version
 
 
 def write_to_openpmd_file(
-    dim, iteration, distance, file_prefix, file_format, grid, wavelength, pol, save_as_vector_potential=False
+    dim,
+    iteration,
+    distance,
+    file_prefix,
+    file_format,
+    grid,
+    wavelength,
+    pol,
+    save_as_vector_potential=False,
 ):
     """
     Write the laser field into an openPMD file.
@@ -20,13 +28,13 @@ def write_to_openpmd_file(
                  Cartesian (x,y) transversely, and temporal (t) longitudinally.
         - 'rt' : The laser pulse is represented on a 2D grid:
                  Cylindrical (r) transversely, and temporal (t) longitudinally.
-                 
+
     iteration: integer
         Current iteration
-            
+
     distance: scalar
         Propagation distance (overall)
- 
+
     file_prefix : string
         The file name will start with this prefix.
 
@@ -72,8 +80,8 @@ def write_to_openpmd_file(
     # Store metadata needed to reconstruct the field
     m.set_attribute("angularFrequency", 2 * np.pi * c / wavelength)
     m.set_attribute("polarization", pol)
-    m.set_attribute('t', distance/c)
-    m.set_attribute('iteration', iteration)
+    m.set_attribute("t", distance / c)
+    m.set_attribute("iteration", iteration)
     if save_as_vector_potential:
         m.set_attribute("envelopeField", "normalized_vector_potential")
         m.unit_dimension = {}


### PR DESCRIPTION
Adds the option to resample the field onto a new grid during the propagation step. This can be useful for example when focusing the laser from a large beam size to a small spot.

The resampling option only works in the `'rt'` geometry. In order to resample the fields, the user can simply pass a new grid object to the `propagate()` function. The new grid replaces the original grid.