### PR TITLE
Add `show` method to visualize the laser

### DIFF
--- a/docs/source/tutorials/gaussian_laser.ipynb
+++ b/docs/source/tutorials/gaussian_laser.ipynb
@@ -80,6 +80,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8ac8f985-4a09-4b9a-a9ff-11ce2ef94caa",
+   "metadata": {},
+   "source": [
+    "The laser pulse can be visualized with the `show` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb8dc634-b3c4-4448-834b-fe9acb6c9645",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "laser.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "292c6e63-0480-4fb9-b1ad-6b679a3472d0",
    "metadata": {},
    "source": [
@@ -95,6 +113,16 @@
    "source": [
     "z_R            = 3.14159*spot_size**2/wavelength    # The Rayleigh length\n",
     "laser.propagate(-z_R)                               # Propagate the pulse upstream of the focal plane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3158e51d-e331-438d-90c1-5f8c63bf9841",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "laser.show()"
    ]
   },
   {
@@ -143,7 +171,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -279,9 +279,9 @@ class Laser:
 
     def show(self, **kw):
         """
-        Show a 2D image of the laser amplitude
+        Show a 2D image of the laser amplitude.
 
-        Parameters:
+        Parameters
         ----------
         **kw: additional arguments to be passed to matplotlib's imshow command
         """

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -277,8 +277,7 @@ class Laser:
             save_as_vector_potential,
         )
 
-
-    def show( self, **kw ):
+    def show(self, **kw):
         """
         Show a 2D image of the laser amplitude
 
@@ -289,21 +288,34 @@ class Laser:
         if self.dim == "rt":
             # Show field above and below axis, with proper sign
             E = [
-                np.concatenate( ( (-1)**m * self.grid.field[0,::-1], self.grid.field[0] ) ) \
+                np.concatenate(
+                    ((-1) ** m * self.grid.field[0, ::-1], self.grid.field[0])
+                )
                 for m in self.grid.azimuthal_modes
             ]
             E = sum(E)
-            extent = [self.grid.lo[-1], self.grid.hi[-1], -self.grid.hi[0], self.grid.hi[0]]
+            extent = [
+                self.grid.lo[-1],
+                self.grid.hi[-1],
+                -self.grid.hi[0],
+                self.grid.hi[0],
+            ]
 
         else:
             # In 3D show an image in the xt plane
-            i_slice = int(self.grid.field.shape[1]//2)
-            E = self.grid.field[:,i_slice,:]
-            extent=[self.grid.lo[-1], self.grid.hi[-1], self.grid.lo[0], self.grid.hi[0]]
+            i_slice = int(self.grid.field.shape[1] // 2)
+            E = self.grid.field[:, i_slice, :]
+            extent = [
+                self.grid.lo[-1],
+                self.grid.hi[-1],
+                self.grid.lo[0],
+                self.grid.hi[0],
+            ]
 
         import matplotlib.pyplot as plt
-        plt.imshow( abs(E), extent=extent, aspect='auto', origin='lower', **kw )
+
+        plt.imshow(abs(E), extent=extent, aspect="auto", origin="lower", **kw)
         cb = plt.colorbar()
-        cb.set_label('$|E_{envelope}|$ (V/m)')
-        plt.xlabel('t (s)')
-        plt.ylabel('x (m)')
+        cb.set_label("$|E_{envelope}|$ (V/m)")
+        plt.xlabel("t (s)")
+        plt.ylabel("x (m)")

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -286,7 +286,7 @@ class Laser:
         **kw: additional arguments to be passed to matplotlib's imshow command
         """
         if self.dim == "rt":
-            # Show field above and below axis, with proper sign
+            # Show field in the plane y=0, above and below axis, with proper sign for each mode
             E = [
                 np.concatenate(
                     ((-1) ** m * self.grid.field[0, ::-1], self.grid.field[0])

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -293,7 +293,7 @@ class Laser:
                 )
                 for m in self.grid.azimuthal_modes
             ]
-            E = sum(E) # Sum all the modes
+            E = sum(E)  # Sum all the modes
             extent = [
                 self.grid.lo[-1],
                 self.grid.hi[-1],

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -276,3 +276,34 @@ class Laser:
             self.profile.pol,
             save_as_vector_potential,
         )
+
+
+    def show( self, **kw ):
+        """
+        Show a 2D image of the laser amplitude
+
+        Parameters:
+        ----------
+        **kw: additional arguments to be passed to matplotlib's imshow command
+        """
+        if self.dim == "rt":
+            # Show field above and below axis, with proper sign
+            E = [
+                np.concatenate( ( (-1)**m * self.grid.field[0,::-1], self.grid.field[0] ) ) \
+                for m in self.grid.azimuthal_modes
+            ]
+            E = sum(E)
+            extent = [self.grid.lo[-1], self.grid.hi[-1], -self.grid.hi[0], self.grid.hi[0]]
+
+        else:
+            # In 3D show an image in the xt plane
+            i_slice = int(self.grid.field.shape[1]//2)
+            E = self.grid.field[:,i_slice,:]
+            extent=[self.grid.lo[-1], self.grid.hi[-1], self.grid.lo[0], self.grid.hi[0]]
+
+        import matplotlib.pyplot as plt
+        plt.imshow( abs(E), extent=extent, aspect='auto', origin='lower', **kw )
+        cb = plt.colorbar()
+        cb.set_label('$|E_{envelope}|$ (V/m)')
+        plt.xlabel('t (s)')
+        plt.ylabel('x (m)')

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -293,7 +293,7 @@ class Laser:
                 )
                 for m in self.grid.azimuthal_modes
             ]
-            E = sum(E)
+            E = sum(E) # Sum all the modes
             extent = [
                 self.grid.lo[-1],
                 self.grid.hi[-1],


### PR DESCRIPTION
This addresses #183. This adds a basic plotting capability (useful e.g. to make sure that the laser is fully inside the box, before dumping to disk). 
For more advanced plotting, the user should probably dump the laser to file, and then use openPMD-viewer.

I also made use of this method in the tutorial:
<img width="908" alt="Screenshot 2023-10-26 at 11 10 29 AM" src="https://github.com/LASY-org/lasy/assets/6685781/51be68bc-33cc-4603-82f1-c1f9c36dae30">

