### PR TITLE
Reorder profiles in documentation

### DIFF
--- a/docs/source/api/profiles/index.rst
+++ b/docs/source/api/profiles/index.rst
@@ -11,8 +11,8 @@ Typically a laser will be constructed through a combination of two classes ``Lon
    :hidden:
 
    gaussian
-   combined_profile
    from_array_profile
    from_openpmd_profile
+   combined_profile
    longitudinal/index
    transverse/index


### PR DESCRIPTION
This reorders the profiles, so that the combined laser profile appears immediately above the list of longitudinal and transverse profiles.

<img width="363" alt="Screenshot 2023-10-26 at 2 04 04 PM" src="https://github.com/LASY-org/lasy/assets/6685781/e5fcfc87-65d4-45d1-912a-4bfaae9ad425">
