### PR TITLE
Fixes #178, fixes #153 Modal Decomposition Bug

### DIFF
--- a/lasy/utils/mode_decomposition.py
+++ b/lasy/utils/mode_decomposition.py
@@ -87,7 +87,9 @@ def hermite_gauss_decomposition(laserProfile, n_x_max=12, n_y_max=12, res=1e-6):
     for i in range(n_x_max):
         for j in range(n_y_max):
             HGMode = HermiteGaussianTransverseProfile(w0, i, j)
-            coef = np.real(np.sum(field * HGMode.evaluate(X, Y)) * dx * dy)  # modalDecomposition
+            coef = np.real(
+                np.sum(field * HGMode.evaluate(X, Y)) * dx * dy
+            )  # modalDecomposition
             if math.isnan(coef):
                 coef = 0
             weights[(i, j)] = coef

--- a/lasy/utils/mode_decomposition.py
+++ b/lasy/utils/mode_decomposition.py
@@ -87,7 +87,7 @@ def hermite_gauss_decomposition(laserProfile, n_x_max=12, n_y_max=12, res=1e-6):
     for i in range(n_x_max):
         for j in range(n_y_max):
             HGMode = HermiteGaussianTransverseProfile(w0, i, j)
-            coef = np.sum(field * HGMode.evaluate(X, Y)) * dx * dy  # modalDecomposition
+            coef = np.real(np.sum(field * HGMode.evaluate(X, Y)) * dx * dy)  # modalDecomposition
             if math.isnan(coef):
                 coef = 0
             weights[(i, j)] = coef
@@ -137,7 +137,7 @@ def estimate_best_HG_waist(x, y, field):
         # create a gaussian
         HGMode = HermiteGaussianTransverseProfile(wTest, 0, 0)
         profile = HGMode.evaluate(X, Y)
-        coeffTest[i] = np.sum(profile * field)
+        coeffTest[i] = np.real(np.sum(profile * field))
     w0 = waistTest[np.argmax(coeffTest)]
 
     print("Estimated w0 = %.2f microns" % (w0Est * 1e6))


### PR DESCRIPTION
There is a bug in `modal_decompositon.py` which has been raised in issues #153 and #178 raised by @alexanatoly and @RemiLehe .  I've looked into this and found that where the coefficient for each mode is calculated, it remains complex when it should be cast to real. This previously threw some warnings but let the code run. However, recently it has stopped working altogether. The fix is simple, just cast to real. Have confirmed that the decomposition still functions on the test data.

Until this gets merged with `development`, a workaround would be to cast the modal coefficients to real before using them. For example starting at line 53 in `example_modal_decompositon_data.py`
```
# Reconstruct the pulse using a series of hermite-gauss modes
for i, mode_key in enumerate(list(modeCoeffs)):
    tmp_transverse_profile = HermiteGaussianTransverseProfile(
        waist, mode_key[0], mode_key[1]
    )
    if i == 0:
        reconstructedProfile = modeCoeffs[
            mode_key
        ] * CombinedLongitudinalTransverseProfile(
            wavelength, pol, energy, longitudinal_profile, tmp_transverse_profile
        )
    else:
        reconstructedProfile += modeCoeffs[
            mode_key
        ] * CombinedLongitudinalTransverseProfile(
            wavelength, pol, energy, longitudinal_profile, tmp_transverse_profile
        )
```
would become


<pre><code>
# Reconstruct the pulse using a series of hermite-gauss modes
for i, mode_key in enumerate(list(modeCoeffs)):
    tmp_transverse_profile = HermiteGaussianTransverseProfile(
        waist, mode_key[0], mode_key[1]
    )
    if i == 0:
        reconstructedProfile = <b>np.real(</b>modeCoeffs[
            mode_key
        ] <b>)</b> * CombinedLongitudinalTransverseProfile(
            wavelength, pol, energy, longitudinal_profile, tmp_transverse_profile
        )
    else:
        reconstructedProfile += <b>np.real(</b>modeCoeffs[
            mode_key
        ] <b>)</b> * CombinedLongitudinalTransverseProfile(
            wavelength, pol, energy, longitudinal_profile, tmp_transverse_profile
        )
</code></pre>
