### PR TITLE
Doc: Button to Copy Code Blocks

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,6 @@ matplotlib
 nbsphinx
 numpydoc
 pydata-sphinx-theme
+sphinx-copybutton
 sphinx-design
 sphinx-gallery

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.autosummary",
     "sphinx.ext.viewcode",
+    "sphinx_copybutton",
     "sphinx_design",
     "numpydoc",
     "matplotlib.sphinxext.plot_directive",


### PR DESCRIPTION
Add a copy button to every code block in the docs.

X-ref: https://github.com/ECP-WarpX/WarpX/pull/4004