### PR TITLE
Closes #215 , add overloading for addition and multiplication operators in TransverseProfile

### DIFF
--- a/lasy/profiles/transverse/__init__.py
+++ b/lasy/profiles/transverse/__init__.py
@@ -4,7 +4,12 @@ from .laguerre_gaussian_profile import LaguerreGaussianTransverseProfile
 from .super_gaussian_profile import SuperGaussianTransverseProfile
 from .jinc_profile import JincTransverseProfile
 from .transverse_profile_from_data import TransverseProfileFromData
-from .transverse_profile import TransverseProfile, SummedTransverseProfile, ScaledTransverseProfile
+from .transverse_profile import (
+    TransverseProfile,
+    SummedTransverseProfile,
+    ScaledTransverseProfile,
+)
+
 __all__ = [
     "GaussianTransverseProfile",
     "HermiteGaussianTransverseProfile",
@@ -14,5 +19,5 @@ __all__ = [
     "TransverseProfileFromData",
     "TransverseProfile",
     "SummedTransverseProfile",
-    "ScaledTransverseProfile"
+    "ScaledTransverseProfile",
 ]

--- a/lasy/profiles/transverse/__init__.py
+++ b/lasy/profiles/transverse/__init__.py
@@ -4,7 +4,7 @@ from .laguerre_gaussian_profile import LaguerreGaussianTransverseProfile
 from .super_gaussian_profile import SuperGaussianTransverseProfile
 from .jinc_profile import JincTransverseProfile
 from .transverse_profile_from_data import TransverseProfileFromData
-
+from .transverse_profile import TransverseProfile, SummedTransverseProfile, ScaledTransverseProfile
 __all__ = [
     "GaussianTransverseProfile",
     "HermiteGaussianTransverseProfile",
@@ -12,4 +12,7 @@ __all__ = [
     "SuperGaussianTransverseProfile",
     "JincTransverseProfile",
     "TransverseProfileFromData",
+    "TransverseProfile",
+    "SummedTransverseProfile",
+    "ScaledTransverseProfile"
 ]

--- a/lasy/profiles/transverse/transverse_profile.py
+++ b/lasy/profiles/transverse/transverse_profile.py
@@ -34,6 +34,18 @@ class TransverseProfile(object):
         # (This should be replaced by any class that inherits from this one.)
         return np.zeros(x.shape, dtype="complex128")
 
+    def __add__(self, other):
+        """Return the sum of two transverse profiles."""
+        return SummedTransverseProfile(self, other)
+
+    def __mul__(self, factor):
+        """Return the scaled transverse profile."""
+        return ScaledTransverseProfile(self, factor)
+
+    def __rmul__(self, factor):
+        """Return the scaled transverse profile."""
+        return ScaledTransverseProfile(self, factor)
+    
     def evaluate(self, x, y):
         """
         Return the transverse envelope modified by any spatial offsets.
@@ -72,3 +84,56 @@ class TransverseProfile(object):
         self.y_offset = y_offset
 
         return self
+
+class SummedTransverseProfile(TransverseProfile):
+    """
+    Base class for transverse profiles that are the sum of several other transverse profiles.
+
+    Transverse Profile class that represents the sum of multiple transverse profiles.
+
+    Parameters
+    ----------
+    transverse_profiles: list of TransverseProfile objects
+        List of transverse profiles to be summed.
+    """
+
+    def __init__(self, *transverse_profiles):
+        """Initialize the summed profile."""
+        # Check that all transverse_profiles are TransverseProfile objects
+        assert all(
+            [isinstance(tp, TransverseProfile) for tp in transverse_profiles]
+        ), "All summands must be Profile objects."
+        self.transverse_profiles = transverse_profiles
+
+    def evaluate(self, x, y):
+        """Return the envelope field of the summed profile."""
+        # Sum the fields of each profile
+        return sum([tp.evaluate(x, y) for tp in self.transverse_profiles])
+
+class ScaledTransverseProfile(TransverseProfile):
+    """
+    Base class for transverse profiles that are scaled by a factor.
+
+    Transverse Profile class that represents scaled transverse profiles.
+
+    Parameters
+    ----------
+    transverse_profile: TrasnverseProfile object
+        Trasnverse profile to be scaled.
+    factor: int or float
+        Factor by which to scale the profile.
+    """
+
+    def __init__(self, transverse_profile, factor):
+        """Initialize the summed profile."""
+        # Check that the factor is a number
+        assert isinstance(factor, (int, float, complex)), "The factor must be a number."
+        # Check that the profile is a Profile object
+        assert isinstance(transverse_profile, TransverseProfile), "The profile must be a TransverseProfile object."
+        self.transverse_profile = transverse_profile
+        self.factor = factor
+
+    def evaluate(self, x, y):
+        """Return the envelope field of the scaled transverse profile."""
+        # Sum the fields of each profile
+        return self.transverse_profile.evaluate(x, y) * self.factor

--- a/lasy/profiles/transverse/transverse_profile.py
+++ b/lasy/profiles/transverse/transverse_profile.py
@@ -45,7 +45,7 @@ class TransverseProfile(object):
     def __rmul__(self, factor):
         """Return the scaled transverse profile."""
         return ScaledTransverseProfile(self, factor)
-    
+
     def evaluate(self, x, y):
         """
         Return the transverse envelope modified by any spatial offsets.
@@ -85,6 +85,7 @@ class TransverseProfile(object):
 
         return self
 
+
 class SummedTransverseProfile(TransverseProfile):
     """
     Base class for transverse profiles that are the sum of several other transverse profiles.
@@ -110,6 +111,7 @@ class SummedTransverseProfile(TransverseProfile):
         # Sum the fields of each profile
         return sum([tp.evaluate(x, y) for tp in self.transverse_profiles])
 
+
 class ScaledTransverseProfile(TransverseProfile):
     """
     Base class for transverse profiles that are scaled by a factor.
@@ -129,7 +131,9 @@ class ScaledTransverseProfile(TransverseProfile):
         # Check that the factor is a number
         assert isinstance(factor, (int, float, complex)), "The factor must be a number."
         # Check that the profile is a Profile object
-        assert isinstance(transverse_profile, TransverseProfile), "The profile must be a TransverseProfile object."
+        assert isinstance(
+            transverse_profile, TransverseProfile
+        ), "The profile must be a TransverseProfile object."
         self.transverse_profile = transverse_profile
         self.factor = factor
 

--- a/lasy/profiles/transverse/transverse_profile.py
+++ b/lasy/profiles/transverse/transverse_profile.py
@@ -99,6 +99,7 @@ class SummedTransverseProfile(TransverseProfile):
 
     def __init__(self, *transverse_profiles):
         """Initialize the summed profile."""
+        TransverseProfile.__init__(self)
         # Check that all transverse_profiles are TransverseProfile objects
         assert all(
             [isinstance(tp, TransverseProfile) for tp in transverse_profiles]
@@ -126,6 +127,7 @@ class ScaledTransverseProfile(TransverseProfile):
 
     def __init__(self, transverse_profile, factor):
         """Initialize the summed profile."""
+        TransverseProfile.__init__(self)
         # Check that the factor is a number
         assert isinstance(factor, (int, float, complex)), "The factor must be a number."
         # Check that the profile is a Profile object

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -299,6 +299,7 @@ def test_scale_transverse_profiles():
     scaled_trans_profile_right = trans_profile_1 * 2.0
     # Check that the result is a ScaledProfile object
     assert isinstance(scaled_trans_profile, ScaledTransverseProfile)
+    assert isinstance(scaled_trans_profile_right, ScaledTransverseProfile)
     # Check that the profiles are stored correctly
     assert scaled_trans_profile.transverse_profile == trans_profile_1
     # Check that the evaluate method works

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -8,7 +8,7 @@ from lasy.laser import Laser
 from lasy.profiles.profile import Profile, SummedProfile, ScaledProfile
 from lasy.profiles import GaussianProfile, FromArrayProfile
 from lasy.profiles.longitudinal import GaussianLongitudinalProfile
-from lasy.profiles.transverse.transverse_profile import (
+from lasy.profiles.transverse import (
     GaussianTransverseProfile,
     LaguerreGaussianTransverseProfile,
     SuperGaussianTransverseProfile,

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -33,13 +33,14 @@ class MockProfile(Profile):
 
     def evaluate(self, x, y, t):
         return np.ones_like(x, dtype="complex128") * self.value
-    
+
+
 class MockTransverseProfile(TransverseProfile):
     """
     A mock TransverseProfile class that always returns a constant value.
     """
 
-    def __init__(self,value):
+    def __init__(self, value):
         self.value = value
 
     def evaluate(self, x, y):
@@ -270,6 +271,7 @@ def test_scale_error_if_not_scalar():
     with pytest.raises(AssertionError):
         profile_1 * [1.0, 2.0]
 
+
 def test_add_transverse_profiles():
     # Add the two profiles together
     trans_profile_1 = MockTransverseProfile(1.0)
@@ -283,10 +285,12 @@ def test_add_transverse_profiles():
     # Check that the evaluate method works
     assert np.allclose(summed_trans_profile.evaluate(0, 0), 3.0)
 
+
 def test_add_transverse_error_if_not_all_transverse_profiles():
     trans_profile_1 = MockTransverseProfile(1.0)
     with pytest.raises(AssertionError):
         trans_profile_1 + 1.0
+
 
 def test_scale_transverse_profiles():
     # Add the two profiles together

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -8,7 +8,7 @@ from lasy.laser import Laser
 from lasy.profiles.profile import Profile, SummedProfile, ScaledProfile
 from lasy.profiles import GaussianProfile, FromArrayProfile
 from lasy.profiles.longitudinal import GaussianLongitudinalProfile
-from lasy.profiles.transverse import (
+from lasy.profiles.transverse.transverse_profile import (
     GaussianTransverseProfile,
     LaguerreGaussianTransverseProfile,
     SuperGaussianTransverseProfile,

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -41,6 +41,7 @@ class MockTransverseProfile(TransverseProfile):
     """
 
     def __init__(self, value):
+        super().__init__()
         self.value = value
 
     def evaluate(self, x, y):


### PR DESCRIPTION
I've followed @soerenjalas implementation of overloading in the Profile class and added it directly in the TransverseProfile class. This allows one to create a laser transverse profile from a sum of hermite gaussians without having to first create the full laser object. This makes things cleaner and should hopefully speed up calculations.

This should close #215 