### PR TITLE
remove the version specifier for axiprop in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-axiprop==0.5.1
+axiprop
 numpy
 openpmd-api
 openpmd-viewer


### PR DESCRIPTION
This PR removes version specifier for `axiprop` in requirements, since no API breaking developments in there expected, and the releases are checked for compatibility with `lasy` anyway