### PR TITLE
[WIP] openPMD: Group-Based Encoding

### DIFF
--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -45,7 +45,7 @@ class FromOpenPMDProfile(FromArrayProfile):
     prefix : string
         Prefix of the openPMD file from which the envelope is read.
         Only used when envelope=True.
-        The provided iteration is read from <path>/<prefix>_%T.h5.
+        The provided iteration is read from <path>/<prefix>.h5.
 
     theta : float or None, optional
         Only used if the openPMD input is in thetaMode geometry.
@@ -102,7 +102,7 @@ class FromOpenPMDProfile(FromArrayProfile):
             grid, omg0 = field_to_envelope(grid, dim, phase_unwrap_nd)
             array = grid.field[0]
         else:
-            s = io.Series(path + "/" + prefix + "_%T.h5", io.Access.read_only)
+            s = io.Series(path + "/" + prefix + ".h5", io.Access.read_only)
             it = s.iterations[iteration]
             omg0 = it.meshes["laserEnvelope"].get_attribute("angularFrequency")
             array = F

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -44,7 +44,7 @@ def write_to_openpmd_file(
     array = grid.field
 
     # Create file
-    series = io.Series("{}_%05T.{}".format(file_prefix, file_format), io.Access.create)
+    series = io.Series("{}.{}".format(file_prefix, file_format), io.Access.create)
     series.set_software("lasy", lasy_version)
 
     i = series.iterations[0]


### PR DESCRIPTION
Since a LASY file usually describes one data snapshot, the openPMD `groupBased` encoding is more suitable and less confusing in file naming.

https://github.com/openPMD/openPMD-standard/blob/1.1.0/STANDARD.md#iterations-and-time-series

- [ ] default to `groupBased` and add an option to change it if desired to `fileBased` (as in WarpX)
- [ ] update FBPIC
- [ ] update WarpX
- [ ] update HiPACE++
- [ ] update Wake-T
- [ ] double check openPMD-viewer with both backends (openPMD-api and `h5py`)