### PR TITLE
Fix complex interpolation in FromArrayProfile method

### DIFF
--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -96,12 +96,10 @@ class FromArrayProfile(Profile):
         """Return the envelope field of the scaled profile."""
         if self.dim == "xyt":
             phase = np.exp( 1.0j * self.field_angl_interp((x, y, t)))
-            envelope = self.field_abs_interp((x, y, t))
+            envelope = phase * self.field_abs_interp((x, y, t))
         else:
             r = np.sqrt(x**2 + y**2)
             phase = np.exp( 1.0j * self.field_angl_interp((r, t)))
-            envelope = self.field_abs_interp((r, t))
-
-        envelope *= phase
+            envelope = phase * self.field_abs_interp((r, t))
 
         return envelope

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -76,8 +76,6 @@ class FromArrayProfile(Profile):
             r = np.concatenate((-axes["r"][::-1], axes["r"]))
             array = np.concatenate((array[::-1], array))
 
-
-
             self.field_abs_interp = RegularGridInterpolator(
                 (r, axes["t"]),
                 np.abs(array),
@@ -95,11 +93,11 @@ class FromArrayProfile(Profile):
     def evaluate(self, x, y, t):
         """Return the envelope field of the scaled profile."""
         if self.dim == "xyt":
-            phase = np.exp( 1.0j * self.field_angl_interp((x, y, t)))
+            phase = np.exp(1.0j * self.field_angl_interp((x, y, t)))
             envelope = phase * self.field_abs_interp((x, y, t))
         else:
             r = np.sqrt(x**2 + y**2)
-            phase = np.exp( 1.0j * self.field_angl_interp((r, t)))
+            phase = np.exp(1.0j * self.field_angl_interp((r, t)))
             envelope = phase * self.field_abs_interp((r, t))
 
         return envelope

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -82,7 +82,8 @@ class FromArrayProfile(Profile):
         else:
             combined_field = self.combined_field_interp((np.sqrt(x**2 + y**2), t))
 
-        envelope = np.abs(np.real(combined_field)) \
-            * np.exp( 1.0j * np.imag(combined_field) )
+        envelope = np.abs(np.real(combined_field)) * np.exp(
+            1.0j * np.imag(combined_field)
+        )
 
         return envelope


### PR DESCRIPTION
This PR fixes the issue with using scipy's `RegularGridInterpolator` with complex numbers used in `FromArrayProfile`. While the amplitude and phase of the complex field normally vary smoothly in space and time, the real and imaginary parts typically strongly oscillate, which results in erroneous results. 

See here an example of the field read from measurement file: on the original grid (left) and with time axis refined by 4
![image](https://github.com/LASY-org/lasy/assets/22051570/b16f1e1f-c997-4009-91c9-e438a3beb6ac)

This PR replaces the single interpolation operation with real-valued amplitude and phase (unwrapped along `t`) interpolations. This fixes the issue with refined grid:
![image](https://github.com/LASY-org/lasy/assets/22051570/69484544-1d1b-4f22-a810-f0901ff5d7dc)