### PR TITLE
CI: `isort` + `black` compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,7 @@ repos:
 #  hooks:
 #  - id: isort
 #    name: isort (python)
+#    args: ['--profile black']
 
 # Python: Flake8 (checks only, does this support auto-fixes?)
 #- repo: https://github.com/PyCQA/flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,5 @@ add-ignore = ["D100", "D104"]
 
 
 [tool.isort]
+known_first_party = ["lasy"]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,7 @@ convention = "numpy"
 add-ignore = ["D100", "D104"]
 #inherit = false
 #match = .*\.py
+
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
Avoid that these tools follow slightly different rules.