### PR TITLE
A fix to prevent division by zero during normalization

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -8,6 +8,7 @@ from lasy.utils.laser_utils import (
     normalize_energy,
     normalize_peak_field_amplitude,
     normalize_peak_intensity,
+    compute_laser_energy,
 )
 from lasy.utils.openpmd_output import write_to_openpmd_file
 
@@ -116,7 +117,10 @@ class Laser:
 
         # For profiles that define the energy, normalize the amplitude
         if hasattr(profile, "laser_energy"):
-            self.normalize(profile.laser_energy, kind="energy")
+            if compute_laser_energy(self.dim, self.grid)==0.0:
+                print ("Field is zero everywhere, normalization will be skipped")
+            else:
+                self.normalize(profile.laser_energy, kind="energy")
 
     def normalize(self, value, kind="energy"):
         """

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -8,7 +8,6 @@ from lasy.utils.laser_utils import (
     normalize_energy,
     normalize_peak_field_amplitude,
     normalize_peak_intensity,
-    compute_laser_energy,
 )
 from lasy.utils.openpmd_output import write_to_openpmd_file
 
@@ -117,10 +116,7 @@ class Laser:
 
         # For profiles that define the energy, normalize the amplitude
         if hasattr(profile, "laser_energy"):
-            if compute_laser_energy(self.dim, self.grid) == 0.0:
-                print("Field is zero everywhere, normalization will be skipped")
-            else:
-                self.normalize(profile.laser_energy, kind="energy")
+            self.normalize(profile.laser_energy, kind="energy")
 
     def normalize(self, value, kind="energy"):
         """

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -117,8 +117,8 @@ class Laser:
 
         # For profiles that define the energy, normalize the amplitude
         if hasattr(profile, "laser_energy"):
-            if compute_laser_energy(self.dim, self.grid)==0.0:
-                print ("Field is zero everywhere, normalization will be skipped")
+            if compute_laser_energy(self.dim, self.grid) == 0.0:
+                print("Field is zero everywhere, normalization will be skipped")
             else:
                 self.normalize(profile.laser_energy, kind="energy")
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -79,8 +79,11 @@ def normalize_energy(dim, energy, grid):
         return
 
     current_energy = compute_laser_energy(dim, grid)
-    norm_factor = (energy / current_energy) ** 0.5
-    grid.field *= norm_factor
+    if current_energy == 0.0:
+        print("Field is zero everywhere, normalization will be skipped")
+    else:
+        norm_factor = (energy / current_energy) ** 0.5
+        grid.field *= norm_factor
 
 
 def normalize_peak_field_amplitude(amplitude, grid):
@@ -95,9 +98,11 @@ def normalize_peak_field_amplitude(amplitude, grid):
     grid : a Grid object
         Contains value of the laser envelope and metadata.
     """
-    if amplitude is None:
-        return
-    grid.field *= amplitude / np.abs(grid.field).max()
+    if amplitude is not None:
+        if np.abs(grid.field).max() == 0.0:
+            print("Field is zero everywhere, normalization will be skipped")
+        else:
+            grid.field *= amplitude / np.abs(grid.field).max()
 
 
 def normalize_peak_intensity(peak_intensity, grid):
@@ -112,12 +117,13 @@ def normalize_peak_intensity(peak_intensity, grid):
     grid : a Grid object
         Contains value of the laser envelope and metadata.
     """
-    if peak_intensity is None:
-        return
-    intensity = np.abs(epsilon_0 * grid.field**2 / 2 * c)
-    input_peak_intensity = intensity.max()
-
-    grid.field *= np.sqrt(peak_intensity / input_peak_intensity)
+    if peak_intensity is not None:
+        intensity = np.abs(epsilon_0 * grid.field**2 / 2 * c)
+        input_peak_intensity = intensity.max()
+        if input_peak_intensity == 0.0:
+            print("Field is zero everywhere, normalization will be skipped")
+        else:
+            grid.field *= np.sqrt(peak_intensity / input_peak_intensity)
 
 
 def get_full_field(laser, theta=0, slice=0, slice_axis="x", Nt=None):


### PR DESCRIPTION
I have recently added `import_from_lasy` and `export_to_lasy` methods in axiprop and for the latter one I have used an empty profile to get it's field rewritten, i.e.:
```python
wavelength = 2 * np.pi * c / Container.omega0
empty_longitudinal_profile = LongitudinalProfile(wavelength=wavelength)
empty_transverse_profile = TransverseProfile()
empty_profile = CombinedLongitudinalTransverseProfile(
    wavelength=wavelength,
    pol=polarization,
    laser_energy=0.0,
    long_profile=empty_longitudinal_profile,
    trans_profile=empty_transverse_profile,
)
```

With this I've noticed that the normalization forced at initialization of `CombinedLongitudinalTransverseProfile` divides field by `0.0`,  and generates the corresponding warning. Although my methods work fine with this (`None` field values are overwritten anyway), I don't like this warning. 

So this PR checks the energy before normalization and skips it if field is zero.