### PR TITLE
CI: Pre-Commit `isort`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,7 +110,7 @@ repos:
   hooks:
   - id: blacken-docs
     additional_dependencies:
-    - black==24.4.0  # keep in sync with black hook
+    - black==23.9.1 # keep in sync with black hook
   # TODO: black-jupyter
 
 # Jupyter Notebooks: clean up all cell outputs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,7 +110,7 @@ repos:
   hooks:
   - id: blacken-docs
     additional_dependencies:
-    - black==23.9.1 # keep in sync with black hook
+    - black==23.9.1  # keep in sync with black hook
   # TODO: black-jupyter
 
 # Jupyter Notebooks: clean up all cell outputs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,12 +71,12 @@ repos:
 
 # Sorts Python imports according to PEP8
 # https://www.python.org/dev/peps/pep-0008/#imports
-#- repo: https://github.com/pycqa/isort
-#  rev: 5.12.0
-#  hooks:
-#  - id: isort
-#    name: isort (python)
-#    args: ['--profile black']
+- repo: https://github.com/pycqa/isort
+  rev: 5.13.2
+  hooks:
+  - id: isort
+    name: isort (python)
+    args: ["--profile", "black", "--filter-files"]
 
 # Python: Flake8 (checks only, does this support auto-fixes?)
 #- repo: https://github.com/PyCQA/flake8
@@ -110,7 +110,7 @@ repos:
   hooks:
   - id: blacken-docs
     additional_dependencies:
-    - black==23.9.1  # keep in sync with black hook
+    - black==24.4.0  # keep in sync with black hook
   # TODO: black-jupyter
 
 # Jupyter Notebooks: clean up all cell outputs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,7 @@
 import os
 import sys
 from datetime import date
+
 from lasy import __version__
 
 sys.path.insert(0, os.path.abspath("../.."))

--- a/examples/example_gerchberg_saxton_algo.py
+++ b/examples/example_gerchberg_saxton_algo.py
@@ -1,12 +1,13 @@
-from lasy.profiles.gaussian_profile import GaussianProfile
-from lasy.laser import Laser
-from lasy.utils.phase_retrieval import gerchberg_saxton_algo
+import copy
+
 import matplotlib.pyplot as plt
 import numpy as np
-from lasy.utils.zernike import zernike
-import copy
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
+from lasy.laser import Laser
+from lasy.profiles.gaussian_profile import GaussianProfile
+from lasy.utils.phase_retrieval import gerchberg_saxton_algo
+from lasy.utils.zernike import zernike
 
 # DEFINE PHYSICAL PARAMETERS & CREATE LASER PROFILE
 wavelength = 800e-9

--- a/examples/example_modal_decomposition_data.py
+++ b/examples/example_modal_decomposition_data.py
@@ -1,19 +1,17 @@
+import matplotlib.pyplot as plt
 import numpy as np
+import skimage
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from lasy.profiles.transverse.transverse_profile_from_data import (
-    TransverseProfileFromData,
-)
+from lasy.profiles.combined_profile import CombinedLongitudinalTransverseProfile
+from lasy.profiles.longitudinal.gaussian_profile import GaussianLongitudinalProfile
 from lasy.profiles.transverse.hermite_gaussian_profile import (
     HermiteGaussianTransverseProfile,
 )
-from lasy.profiles.longitudinal.gaussian_profile import GaussianLongitudinalProfile
-from lasy.profiles.combined_profile import CombinedLongitudinalTransverseProfile
+from lasy.profiles.transverse.transverse_profile_from_data import (
+    TransverseProfileFromData,
+)
 from lasy.utils.mode_decomposition import hermite_gauss_decomposition
-
-import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1 import make_axes_locatable
-import skimage
-
 
 # Define the transverse profile of the laser pulse
 img_url = "https://user-images.githubusercontent.com/27694869/228038930-d6ab03b1-a726-4b41-a378-5f4a83dc3778.png"

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -1,7 +1,6 @@
 import numpy as np
-from scipy.constants import c
-
 from axiprop.lib import PropagatorFFT2, PropagatorResampling
+from scipy.constants import c
 
 from lasy.utils.grid import Grid
 from lasy.utils.laser_utils import (

--- a/lasy/optical_elements/parabolic_mirror.py
+++ b/lasy/optical_elements/parabolic_mirror.py
@@ -1,6 +1,7 @@
-from .optical_element import OpticalElement
 import numpy as np
 from scipy.constants import c
+
+from .optical_element import OpticalElement
 
 
 class ParabolicMirror(OpticalElement):

--- a/lasy/profiles/__init__.py
+++ b/lasy/profiles/__init__.py
@@ -1,7 +1,7 @@
 from .combined_profile import CombinedLongitudinalTransverseProfile
-from .gaussian_profile import GaussianProfile
 from .from_array_profile import FromArrayProfile
 from .from_openpmd_profile import FromOpenPMDProfile
+from .gaussian_profile import GaussianProfile
 from .speckle_profile import SpeckleProfile
 
 __all__ = [

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -1,5 +1,6 @@
-from scipy.interpolate import RegularGridInterpolator
 import numpy as np
+from scipy.interpolate import RegularGridInterpolator
+
 from .profile import Profile
 
 

--- a/lasy/profiles/from_insight_file.py
+++ b/lasy/profiles/from_insight_file.py
@@ -1,6 +1,7 @@
-import numpy as np
 import h5py
+import numpy as np
 from scipy.constants import c
+
 from .from_array_profile import FromArrayProfile
 
 

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -1,10 +1,12 @@
 import numpy as np
-from scipy.constants import c
 import openpmd_api as io
 from openpmd_viewer import OpenPMDTimeSeries
-from .from_array_profile import FromArrayProfile
-from lasy.utils.laser_utils import field_to_envelope, create_grid
+from scipy.constants import c
+
+from lasy.utils.laser_utils import create_grid, field_to_envelope
 from lasy.utils.openpmd_input import reorder_array
+
+from .from_array_profile import FromArrayProfile
 
 
 class FromOpenPMDProfile(FromArrayProfile):

--- a/lasy/profiles/longitudinal/__init__.py
+++ b/lasy/profiles/longitudinal/__init__.py
@@ -1,8 +1,8 @@
 from .cosine_profile import CosineLongitudinalProfile
 from .gaussian_profile import GaussianLongitudinalProfile
-from .super_gaussian_profile import SuperGaussianLongitudinalProfile
-from .longitudinal_profile_from_data import LongitudinalProfileFromData
 from .longitudinal_profile import LongitudinalProfile
+from .longitudinal_profile_from_data import LongitudinalProfileFromData
+from .super_gaussian_profile import SuperGaussianLongitudinalProfile
 
 __all__ = [
     "CosineLongitudinalProfile",

--- a/lasy/profiles/transverse/__init__.py
+++ b/lasy/profiles/transverse/__init__.py
@@ -1,14 +1,14 @@
 from .gaussian_profile import GaussianTransverseProfile
 from .hermite_gaussian_profile import HermiteGaussianTransverseProfile
+from .jinc_profile import JincTransverseProfile
 from .laguerre_gaussian_profile import LaguerreGaussianTransverseProfile
 from .super_gaussian_profile import SuperGaussianTransverseProfile
-from .jinc_profile import JincTransverseProfile
-from .transverse_profile_from_data import TransverseProfileFromData
 from .transverse_profile import (
-    TransverseProfile,
-    SummedTransverseProfile,
     ScaledTransverseProfile,
+    SummedTransverseProfile,
+    TransverseProfile,
 )
+from .transverse_profile_from_data import TransverseProfileFromData
 
 __all__ = [
     "GaussianTransverseProfile",

--- a/lasy/profiles/transverse/hermite_gaussian_profile.py
+++ b/lasy/profiles/transverse/hermite_gaussian_profile.py
@@ -1,6 +1,7 @@
+from math import factorial
+
 import numpy as np
 from scipy.special import hermite
-from math import factorial
 
 from .transverse_profile import TransverseProfile
 

--- a/lasy/profiles/transverse/jinc_profile.py
+++ b/lasy/profiles/transverse/jinc_profile.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.special as scispe
+
 from .transverse_profile import TransverseProfile
 
 

--- a/lasy/profiles/transverse/transverse_profile_from_data.py
+++ b/lasy/profiles/transverse/transverse_profile_from_data.py
@@ -1,6 +1,8 @@
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator
+
 from lasy.utils.exp_data_utils import find_center_of_mass
+
 from .transverse_profile import TransverseProfile
 
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1,9 +1,10 @@
 import numpy as np
-from scipy.constants import c, epsilon_0, e, m_e
+from axiprop.containers import ScalarFieldEnvelope
+from axiprop.lib import PropagatorFFT2, PropagatorResampling
+from scipy.constants import c, e, epsilon_0, m_e
 from scipy.interpolate import interp1d
 from scipy.signal import hilbert
-from axiprop.lib import PropagatorFFT2, PropagatorResampling
-from axiprop.containers import ScalarFieldEnvelope
+
 from .grid import Grid
 
 

--- a/lasy/utils/mode_decomposition.py
+++ b/lasy/utils/mode_decomposition.py
@@ -1,14 +1,15 @@
+import math
+
+import numpy as np
+
+from lasy.profiles.transverse.hermite_gaussian_profile import (
+    HermiteGaussianTransverseProfile,
+)
 from lasy.profiles.transverse.transverse_profile import TransverseProfile
 from lasy.profiles.transverse.transverse_profile_from_data import (
     TransverseProfileFromData,
 )
-from lasy.profiles.transverse.hermite_gaussian_profile import (
-    HermiteGaussianTransverseProfile,
-)
 from lasy.utils.exp_data_utils import find_d4sigma
-
-import numpy as np
-import math
 
 
 def hermite_gauss_decomposition(laserProfile, n_x_max=12, n_y_max=12, res=1e-6):

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -1,8 +1,10 @@
 import numpy as np
 import openpmd_api as io
 from scipy.constants import c
-from .laser_utils import field_to_vector_potential
+
 from lasy import __version__ as lasy_version
+
+from .laser_utils import field_to_vector_potential
 
 
 def write_to_openpmd_file(

--- a/lasy/utils/phase_retrieval.py
+++ b/lasy/utils/phase_retrieval.py
@@ -1,4 +1,5 @@
 import copy
+
 import numpy as np
 
 

--- a/lasy/utils/zernike.py
+++ b/lasy/utils/zernike.py
@@ -1,5 +1,6 @@
-import numpy as np
 import math
+
+import numpy as np
 
 
 def get_zernike_nm(j):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import find_packages, setup
+
 import lasy  # In order to extract the version number
 
 # README file is long description

--- a/tests/test_gaussian_propagator.py
+++ b/tests/test_gaussian_propagator.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import numpy as np
 import pytest
 
-import numpy as np
 from lasy.laser import Laser
 from lasy.profiles.gaussian_profile import GaussianProfile
 

--- a/tests/test_gsalgo.py
+++ b/tests/test_gsalgo.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import pytest
+import copy
 
 import numpy as np
+import pytest
+
 from lasy.laser import Laser
 from lasy.profiles.gaussian_profile import GaussianProfile
-from lasy.utils.zernike import zernike
 from lasy.utils.phase_retrieval import gerchberg_saxton_algo
-import copy
+from lasy.utils.zernike import zernike
 
 w0 = 25.0e-6  # m
 

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -1,28 +1,28 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 import numpy as np
-from scipy.special import gamma as gamma
+import pytest
 from scipy.constants import c
+from scipy.special import gamma as gamma
 
 from lasy.laser import Laser
-from lasy.profiles.profile import Profile, SummedProfile, ScaledProfile
-from lasy.profiles import GaussianProfile, FromArrayProfile, SpeckleProfile
+from lasy.profiles import FromArrayProfile, GaussianProfile, SpeckleProfile
 from lasy.profiles.longitudinal import (
+    CosineLongitudinalProfile,
     GaussianLongitudinalProfile,
     SuperGaussianLongitudinalProfile,
-    CosineLongitudinalProfile,
 )
+from lasy.profiles.profile import Profile, ScaledProfile, SummedProfile
 from lasy.profiles.transverse import (
     GaussianTransverseProfile,
-    LaguerreGaussianTransverseProfile,
-    SuperGaussianTransverseProfile,
     HermiteGaussianTransverseProfile,
     JincTransverseProfile,
-    TransverseProfileFromData,
-    TransverseProfile,
-    SummedTransverseProfile,
+    LaguerreGaussianTransverseProfile,
     ScaledTransverseProfile,
+    SummedTransverseProfile,
+    SuperGaussianTransverseProfile,
+    TransverseProfile,
+    TransverseProfileFromData,
 )
 from lasy.utils.exp_data_utils import find_center_of_mass
 

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pytest
 from scipy.constants import c
-from scipy.special import gamma as gamma
 
 from lasy.laser import Laser
 from lasy.profiles import FromArrayProfile, GaussianProfile, SpeckleProfile

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from lasy.laser import Laser
 from lasy.profiles.gaussian_profile import GaussianProfile
-from lasy.utils.laser_utils import get_spectrum, compute_laser_energy, get_duration
+from lasy.utils.laser_utils import compute_laser_energy, get_duration, get_spectrum
 
 
 def get_gaussian_profile():

--- a/tests/test_parabolic_mirror.py
+++ b/tests/test_parabolic_mirror.py
@@ -8,9 +8,10 @@ expected value in the far field (i.e. in the focal plane)
 """
 
 import numpy as np
+
 from lasy.laser import Laser
-from lasy.profiles.gaussian_profile import GaussianProfile
 from lasy.optical_elements import ParabolicMirror
+from lasy.profiles.gaussian_profile import GaussianProfile
 
 wavelength = 0.8e-6
 w0 = 5.0e-3  # m, initialized in near field

--- a/tests/test_speckles.py
+++ b/tests/test_speckles.py
@@ -1,9 +1,9 @@
 import numpy as np
+import pytest
+from scipy.constants import c
 
 from lasy.laser import Laser
 from lasy.profiles.speckle_profile import SpeckleProfile
-import pytest
-from scipy.constants import c
 
 
 @pytest.mark.parametrize(

--- a/tests/test_t2z2t.py
+++ b/tests/test_t2z2t.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-
 import numpy as np
+import pytest
+from scipy.constants import c
+
 from lasy.laser import Laser
 from lasy.profiles.gaussian_profile import GaussianProfile
-from lasy.utils.laser_utils import import_from_z, export_to_z
-from scipy.constants import c
+from lasy.utils.laser_utils import export_to_z, import_from_z
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Sorts Python imports according to PEP8:
https://www.python.org/dev/peps/pep-0008/#imports

Pythonic import order is:
- core/std modules
- external modules
- own modules

with each of them being alphabetical in their sub-group.

Set to be compatible with our `black` code formatter. Follow-up to #235.