### PR TITLE
Do not mention "Derived class" in the documentation

### DIFF
--- a/lasy/profiles/gaussian_profile.py
+++ b/lasy/profiles/gaussian_profile.py
@@ -5,7 +5,7 @@ from .transverse import GaussianTransverseProfile
 
 class GaussianProfile(CombinedLongitudinalTransverseProfile):
     r"""
-    Derived class for the analytic profile of a Gaussian laser pulse.
+    Class for the analytic profile of a Gaussian laser pulse.
 
     More precisely, the electric field corresponds to:
 

--- a/lasy/profiles/longitudinal/cosine_profile.py
+++ b/lasy/profiles/longitudinal/cosine_profile.py
@@ -5,7 +5,7 @@ from .longitudinal_profile import LongitudinalProfile
 
 class CosineLongitudinalProfile(LongitudinalProfile):
     r"""
-    Derived class for the analytic longitudinal truncated cosine profile of a laser pulse.
+    Class for the analytic longitudinal truncated cosine profile of a laser pulse.
 
     More precisely, the longitudinal envelope
     (to be used in the :class:CombinedLongitudinalTransverseProfile class)

--- a/lasy/profiles/longitudinal/gaussian_profile.py
+++ b/lasy/profiles/longitudinal/gaussian_profile.py
@@ -5,7 +5,7 @@ from .longitudinal_profile import LongitudinalProfile
 
 class GaussianLongitudinalProfile(LongitudinalProfile):
     r"""
-    Derived class for the analytic profile of a longitudinally-Gaussian laser pulse.
+    Class for the analytic profile of a longitudinally-Gaussian laser pulse.
 
     More precisely, the longitudinal envelope
     (to be used in the :class:`.CombinedLongitudinalTransverseProfile` class)

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -6,7 +6,7 @@ from .longitudinal_profile import LongitudinalProfile
 
 class LongitudinalProfileFromData(LongitudinalProfile):
     """
-    Derived class for longitudinal laser profile created using data.
+    Class for longitudinal laser profile created using data.
 
     The data used can either come from an experimental measurement
     or from the output of another code. This data is then used to

--- a/lasy/profiles/longitudinal/super_gaussian_profile.py
+++ b/lasy/profiles/longitudinal/super_gaussian_profile.py
@@ -5,7 +5,7 @@ from .longitudinal_profile import LongitudinalProfile
 
 class SuperGaussianLongitudinalProfile(LongitudinalProfile):
     r"""
-    Derived class for the analytic profile of a longitudinally-super-Gaussian laser pulse.
+    Class for the analytic profile of a longitudinally-super-Gaussian laser pulse.
 
     More precisely, the longitudinal envelope
     (to be used in the :class:`.CombinedLongitudinalTransverseProfile` class)

--- a/lasy/profiles/speckle_profile.py
+++ b/lasy/profiles/speckle_profile.py
@@ -36,7 +36,7 @@ def gen_gaussian_time_series(t_num, dt, fwhm, rms_mean):
 
 class SpeckleProfile(Profile):
     r"""
-    Derived class for the profile of a speckled laser pulse.
+    Class for the profile of a speckled laser pulse.
 
     Speckled lasers are used to mitigate laser-plasma interactions in fusion and ion acceleration contexts.
     More on the subject can be found in chapter 9 of `P. Michel, Introduction to Laser-Plasma Interactions <https://link.springer.com/book/10.1007/978-3-031-23424-8>`__.

--- a/lasy/profiles/transverse/gaussian_profile.py
+++ b/lasy/profiles/transverse/gaussian_profile.py
@@ -5,7 +5,7 @@ from .transverse_profile import TransverseProfile
 
 class GaussianTransverseProfile(TransverseProfile):
     r"""
-    Derived class for the analytic profile of a Gaussian laser pulse.
+    Class for the analytic profile of a Gaussian laser pulse.
 
     More precisely, at focus (``z_foc=0``), the transverse envelope
     (to be used in the :class:`.CombinedLongitudinalTransverseLaser` class)

--- a/lasy/profiles/transverse/hermite_gaussian_profile.py
+++ b/lasy/profiles/transverse/hermite_gaussian_profile.py
@@ -9,7 +9,6 @@ class HermiteGaussianTransverseProfile(TransverseProfile):
     r"""
     A high-order Gaussian laser pulse expressed in the Hermite-Gaussian formalism.
 
-    Derived class for an analytic profile.
     More precisely, the transverse envelope (to be used in the
     :class:`.CombinedLongitudinalTransverseLaser` class) corresponds to:
 

--- a/lasy/profiles/transverse/jinc_profile.py
+++ b/lasy/profiles/transverse/jinc_profile.py
@@ -5,7 +5,7 @@ from .transverse_profile import TransverseProfile
 
 class JincTransverseProfile(TransverseProfile):
     r"""
-    Derived class for the analytic profile of a Jinc laser pulse.
+    Class for the analytic profile of a Jinc laser pulse.
 
     The transverse envelope corresponds to:
 

--- a/lasy/profiles/transverse/laguerre_gaussian_profile.py
+++ b/lasy/profiles/transverse/laguerre_gaussian_profile.py
@@ -8,7 +8,7 @@ class LaguerreGaussianTransverseProfile(TransverseProfile):
     r"""
     High-order Gaussian laser pulse expressed in the Laguerre-Gaussian formalism.
 
-    Derived class for an analytic profile.
+    Class for an analytic profile.
     More precisely, at focus (`z_foc=0`), the transverse envelope (to be used in the
     :class:`.CombinedLongitudinalTransverseLaser` class) corresponds to:
 

--- a/lasy/profiles/transverse/super_gaussian_profile.py
+++ b/lasy/profiles/transverse/super_gaussian_profile.py
@@ -5,7 +5,7 @@ from .transverse_profile import TransverseProfile
 
 class SuperGaussianTransverseProfile(TransverseProfile):
     r"""
-    Derived class for the analytic profile of a super-Gaussian laser pulse.
+    Class for the analytic profile of a super-Gaussian laser pulse.
 
     More precisely, the transverse envelope corresponds to:
 

--- a/lasy/profiles/transverse/transverse_profile.py
+++ b/lasy/profiles/transverse/transverse_profile.py
@@ -50,8 +50,6 @@ class TransverseProfile(object):
         """
         Return the transverse envelope modified by any spatial offsets.
 
-        This is the public facing evaluate method, it calls the _evaluate function of the derived class.
-
         Parameters
         ----------
         x, y: ndarrays of floats

--- a/lasy/profiles/transverse/transverse_profile_from_data.py
+++ b/lasy/profiles/transverse/transverse_profile_from_data.py
@@ -6,7 +6,7 @@ from .transverse_profile import TransverseProfile
 
 class TransverseProfileFromData(TransverseProfile):
     """
-    Derived class for transverse laser profile.
+    Class for transverse laser profile.
 
     Created using data from an experimental measurement or from
     the output of another code.


### PR DESCRIPTION
As mentioned in #228, mentioning derived classes in the documentation is not particularly useful to a user (and may actually be confusing). This PR removes the "Derived class" from the user-facing documentation.