### PR TITLE
allow `r=0` in FromArrayProfile (and derived) method

### DIFF
--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -62,11 +62,13 @@ class FromArrayProfile(Profile):
             else:
                 self.array = array
 
-            # The first point is at dr/2.
-            # To make correct interpolation within the first cell, mirror
-            # field and axes along r.
-            r = np.concatenate((-axes["r"][::-1], axes["r"]))
-            array = np.concatenate((array[::-1], array))
+            # If the first point of radial axis is not 0, we "mirror" it,
+            # to make correct interpolation within the first cell
+            if axes["r"][0] != 0.0:
+                r = np.concatenate(([-axes["r"][0]], axes["r"]))
+                array = np.concatenate(([array[0]], array))
+            else:
+                r = axes["r"]
 
             self.combined_field_interp = RegularGridInterpolator(
                 (r, axes["t"]),


### PR DESCRIPTION
In FromArrayProfile we imposed that radial grid starts at `r>0` as we always mirror the axis and data, and this way inclusion of `r=0`  breaks the interpolation with the non-ascending `[..., -0, 0, ...]` pair. However, we never assert that `r_0!=0` (e.g. in the example we suggest `lo = (0,-2.5*pulse_duration)`).

This PR adds treatment of this case. Also I find mirroring of the hole data to be an overkill since mirroring the single point `r_0(>0)` is enough.
