### PR TITLE
Add possibility to choose the number of points in theta

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -44,6 +44,17 @@ class Laser:
         Only used if ``dim`` is ``'rt'``. The number of azimuthal modes
         used in order to represent the laser field.
 
+    n_theta_evals: int (optional)
+        Only used if ``dim`` is ``'rt'``. The number of points in the theta
+        (azimuthal) direction at which to evaluate the laser field, before
+        decomposing it into ``n_azimuthal_modes`` azimuthal modes. By default,
+        this is set to ``2*n_azimuthal_modes - 1``. However, for highly asymmetrical
+        profiles, it may be necessary to increase this number.
+
+        For instance, using ``n_theta_evals=20`` and ``n_azimuthal_modes=1``
+        will evaluate the laser field at 20 points in the azimuthal direction
+        and then average the values to extract the amplitude of the azimuthal mode 0.
+
     Examples
     --------
     >>> import matplotlib.pyplot as plt
@@ -92,7 +103,7 @@ class Laser:
     >>>         axes[step].set(ylabel='r (µm)')
     """
 
-    def __init__(self, dim, lo, hi, npoints, profile, n_azimuthal_modes=1):
+    def __init__(self, dim, lo, hi, npoints, profile, n_azimuthal_modes=1, n_theta_evals=None):
         self.grid = Grid(dim, lo, hi, npoints, n_azimuthal_modes)
         self.dim = dim
         self.profile = profile
@@ -102,17 +113,23 @@ class Laser:
             x, y, t = np.meshgrid(*self.grid.axes, indexing="ij")
             self.grid.field[...] = profile.evaluate(x, y, t)
         elif self.dim == "rt":
-            # Generate 2*n_azimuthal_modes - 1 evenly-spaced values of
-            # theta, to evaluate the laser
-            n_theta = 2 * self.grid.n_azimuthal_modes - 1
-            theta1d = 2 * np.pi / n_theta * np.arange(n_theta)
+            if n_theta_evals is None:
+                # Generate 2*n_azimuthal_modes - 1 evenly-spaced values of
+                # theta, to evaluate the laser
+                n_theta_evals = 2 * self.grid.n_azimuthal_modes - 1
+            # Make sure that there are enough points to resolve the azimuthal modes
+            assert n_theta_evals >= 2 * self.grid.n_azimuthal_modes - 1
+            theta1d = 2 * np.pi / n_theta * np.arange(n_theta_evals)
             theta, r, t = np.meshgrid(theta1d, *self.grid.axes, indexing="ij")
             x = r * np.cos(theta)
             y = r * np.sin(theta)
             # Evaluate the profile on the generated grid
             envelope = profile.evaluate(x, y, t)
             # Perform the azimuthal decomposition
-            self.grid.field[...] = np.fft.ifft(envelope, axis=0)
+            azimuthal_modes = np.fft.ifft(envelope, axis=0)
+            self.grid.field[:n_azimuthal_modes] = azimuthal_modes[:n_azimuthal_modes]
+            if n_azimuthal_modes > 1:
+                self.grid.field[-n_azimuthal_modes+1:] = azimuthal_modes[-n_azimuthal_modes+1:]
 
         # For profiles that define the energy, normalize the amplitude
         if hasattr(profile, "laser_energy"):

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -103,7 +103,9 @@ class Laser:
     >>>         axes[step].set(ylabel='r (µm)')
     """
 
-    def __init__(self, dim, lo, hi, npoints, profile, n_azimuthal_modes=1, n_theta_evals=None):
+    def __init__(
+        self, dim, lo, hi, npoints, profile, n_azimuthal_modes=1, n_theta_evals=None
+    ):
         self.grid = Grid(dim, lo, hi, npoints, n_azimuthal_modes)
         self.dim = dim
         self.profile = profile
@@ -119,7 +121,7 @@ class Laser:
                 n_theta_evals = 2 * self.grid.n_azimuthal_modes - 1
             # Make sure that there are enough points to resolve the azimuthal modes
             assert n_theta_evals >= 2 * self.grid.n_azimuthal_modes - 1
-            theta1d = 2 * np.pi / n_theta * np.arange(n_theta_evals)
+            theta1d = 2 * np.pi / n_theta_evals * np.arange(n_theta_evals)
             theta, r, t = np.meshgrid(theta1d, *self.grid.axes, indexing="ij")
             x = r * np.cos(theta)
             y = r * np.sin(theta)
@@ -129,7 +131,9 @@ class Laser:
             azimuthal_modes = np.fft.ifft(envelope, axis=0)
             self.grid.field[:n_azimuthal_modes] = azimuthal_modes[:n_azimuthal_modes]
             if n_azimuthal_modes > 1:
-                self.grid.field[-n_azimuthal_modes+1:] = azimuthal_modes[-n_azimuthal_modes+1:]
+                self.grid.field[-n_azimuthal_modes + 1 :] = azimuthal_modes[
+                    -n_azimuthal_modes + 1 :
+                ]
 
         # For profiles that define the energy, normalize the amplitude
         if hasattr(profile, "laser_energy"):

--- a/tests/test_gaussian_propagator.py
+++ b/tests/test_gaussian_propagator.py
@@ -81,3 +81,17 @@ def test_RT_case(gaussian):
 
     laser = Laser(dim, lo, hi, npoints, gaussian)
     check_gaussian_propagation(laser)
+
+def test_RT_case_multimode(gaussian):
+    # - Cylindrical case
+    dim = "rt"
+    lo = (0e-6, -60e-15)
+    hi = (25e-6, +60e-15)
+    npoints = (100, 100)
+
+    # Note: using 3 modes and 20 points is unnecessary here,
+    # since the profile is purely cylindrical. This is
+    # done here only to make sure that the code is robust.
+    laser = Laser(dim, lo, hi, npoints, gaussian,
+                  n_azimuthal_modes=3, n_theta_evals=20)
+    check_gaussian_propagation(laser)

--- a/tests/test_gaussian_propagator.py
+++ b/tests/test_gaussian_propagator.py
@@ -82,6 +82,7 @@ def test_RT_case(gaussian):
     laser = Laser(dim, lo, hi, npoints, gaussian)
     check_gaussian_propagation(laser)
 
+
 def test_RT_case_multimode(gaussian):
     # - Cylindrical case
     dim = "rt"
@@ -92,6 +93,5 @@ def test_RT_case_multimode(gaussian):
     # Note: using 3 modes and 20 points is unnecessary here,
     # since the profile is purely cylindrical. This is
     # done here only to make sure that the code is robust.
-    laser = Laser(dim, lo, hi, npoints, gaussian,
-                  n_azimuthal_modes=3, n_theta_evals=20)
+    laser = Laser(dim, lo, hi, npoints, gaussian, n_azimuthal_modes=3, n_theta_evals=20)
     check_gaussian_propagation(laser)


### PR DESCRIPTION
This PR adds a new, optional parameter `n_theta_evals` (see docstring in this PR.)

For highly asymmetrical lasers, setting this to a high number can be important in order to obtain a good approximation of the laser pulse we projecting it onto few azimuthal modes (i.e. symmetrizing it). 