### PR TITLE
Have multiple calls to `write_to_file` dump to different files

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -109,7 +109,7 @@ class Laser:
         self.grid = Grid(dim, lo, hi, npoints, n_azimuthal_modes)
         self.dim = dim
         self.profile = profile
-        self.output_iteration = 0 # Incremented each time write_to_file is called
+        self.output_iteration = 0  # Incremented each time write_to_file is called
 
         # Create the grid on which to evaluate the laser, evaluate it
         if self.dim == "xyt":

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -109,6 +109,7 @@ class Laser:
         self.grid = Grid(dim, lo, hi, npoints, n_azimuthal_modes)
         self.dim = dim
         self.profile = profile
+        self.output_iteration = 0 # Incremented each time write_to_file is called
 
         # Create the grid on which to evaluate the laser, evaluate it
         if self.dim == "xyt":
@@ -301,11 +302,13 @@ class Laser:
             self.dim,
             file_prefix,
             file_format,
+            self.output_iteration,
             self.grid,
             self.profile.lambda0,
             self.profile.pol,
             save_as_vector_potential,
         )
+        self.output_iteration += 1
 
     def show(self, **kw):
         """

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -6,8 +6,14 @@ from lasy import __version__ as lasy_version
 
 
 def write_to_openpmd_file(
-    dim, file_prefix, file_format, iteration, grid, wavelength,
-    pol, save_as_vector_potential=False
+    dim,
+    file_prefix,
+    file_format,
+    iteration,
+    grid,
+    wavelength,
+    pol,
+    save_as_vector_potential=False,
 ):
     """
     Write the laser field into an openPMD file.

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -6,7 +6,8 @@ from lasy import __version__ as lasy_version
 
 
 def write_to_openpmd_file(
-    dim, file_prefix, file_format, grid, wavelength, pol, save_as_vector_potential=False
+    dim, file_prefix, file_format, iteration, grid, wavelength,
+    pol, save_as_vector_potential=False
 ):
     """
     Write the laser field into an openPMD file.
@@ -26,6 +27,9 @@ def write_to_openpmd_file(
 
     file_format : string
         Format to be used for the output file. Options are "h5" and "bp".
+
+    iteration : int
+        The iteration number for the file to be written.
 
     grid : Grid
         A grid object containing the 3-dimensional array
@@ -47,7 +51,7 @@ def write_to_openpmd_file(
     series = io.Series("{}_%05T.{}".format(file_prefix, file_format), io.Access.create)
     series.set_software("lasy", lasy_version)
 
-    i = series.iterations[0]
+    i = series.iterations[iteration]
 
     # Define the mesh
     m = i.meshes["laserEnvelope"]


### PR DESCRIPTION
As pointed out by @soerenjalas, when calling `write_to_file` multiple times, the output was always written to the same file (the one corresponding to iteration `0`, in the openPMD convention.)

This PR fixes this by keeping track of the iteration number, and writing to separate iterations every time `write_to_file` is called.

**To be discussed:** Should we group all output files into a common folder? (like we do with PIC codes: typically this folder is called `diags` in that case.)