### PR TITLE
Add option to specify save directory for openpmd output

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -327,7 +327,11 @@ class Laser:
         self.grid.field *= np.exp(1j * omega0 * distance / c)
 
     def write_to_file(
-        self, file_prefix="laser", file_format="h5", write_dir="diags", save_as_vector_potential=False
+        self,
+        file_prefix="laser",
+        file_format="h5",
+        write_dir="diags",
+        save_as_vector_potential=False,
     ):
         """
         Write the laser profile + metadata to file.

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -327,13 +327,16 @@ class Laser:
         self.grid.field *= np.exp(1j * omega0 * distance / c)
 
     def write_to_file(
-        self, file_prefix="laser", file_format="h5", save_as_vector_potential=False
+        self, file_prefix="laser", file_format="h5", write_dir="diags", save_as_vector_potential=False
     ):
         """
         Write the laser profile + metadata to file.
 
         Parameters
         ----------
+        write_dir : string
+            The directory where the file will be written.
+
         file_prefix : string
             The file name will start with this prefix.
 
@@ -346,6 +349,7 @@ class Laser:
         """
         write_to_openpmd_file(
             self.dim,
+            write_dir,
             file_prefix,
             file_format,
             self.output_iteration,

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import openpmd_api as io
 from scipy.constants import c
@@ -5,7 +7,6 @@ from scipy.constants import c
 from lasy import __version__ as lasy_version
 
 from .laser_utils import field_to_vector_potential
-import os
 
 
 def write_to_openpmd_file(
@@ -61,7 +62,9 @@ def write_to_openpmd_file(
     array = grid.field
 
     # Create file
-    full_filepath = os.path.join(write_dir, "{}_%05T.{}".format(file_prefix, file_format))
+    full_filepath = os.path.join(
+        write_dir, "{}_%05T.{}".format(file_prefix, file_format)
+    )
     if os.path.exists(full_filepath):
         raise FileExistsError("File already exists: {}".format(full_filepath))
     os.makedirs(write_dir, exist_ok=True)

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -5,10 +5,12 @@ from scipy.constants import c
 from lasy import __version__ as lasy_version
 
 from .laser_utils import field_to_vector_potential
+import os
 
 
 def write_to_openpmd_file(
     dim,
+    write_dir,
     file_prefix,
     file_format,
     iteration,
@@ -33,6 +35,9 @@ def write_to_openpmd_file(
     file_prefix : string
         The file name will start with this prefix.
 
+    write_dir : string
+        The directory where the file will be written.
+
     file_format : string
         Format to be used for the output file. Options are "h5" and "bp".
 
@@ -56,7 +61,11 @@ def write_to_openpmd_file(
     array = grid.field
 
     # Create file
-    series = io.Series("{}_%05T.{}".format(file_prefix, file_format), io.Access.create)
+    full_filepath = os.path.join(write_dir, "{}_%05T.{}".format(file_prefix, file_format))
+    if os.path.exists(full_filepath):
+        raise FileExistsError("File already exists: {}".format(full_filepath))
+    os.makedirs(write_dir, exist_ok=True)
+    series = io.Series(full_filepath, io.Access.create)
     series.set_software("lasy", lasy_version)
 
     i = series.iterations[iteration]

--- a/lasy/utils/openpmd_output.py
+++ b/lasy/utils/openpmd_output.py
@@ -65,8 +65,6 @@ def write_to_openpmd_file(
     full_filepath = os.path.join(
         write_dir, "{}_%05T.{}".format(file_prefix, file_format)
     )
-    if os.path.exists(full_filepath):
-        raise FileExistsError("File already exists: {}".format(full_filepath))
     os.makedirs(write_dir, exist_ok=True)
     series = io.Series(full_filepath, io.Access.create)
     series.set_software("lasy", lasy_version)


### PR DESCRIPTION
Adds a `write_dir` option to `Laser.write_to_file()`. Default directory is `./diags`.