### PR TITLE
Pass omega0 when applying optical element

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -184,7 +184,7 @@ class Laser:
             # The line below assumes that amplitude_multiplier
             # is cylindrically symmetric, hence we pass
             # `r` as `x` and 0 as `y`
-            multiplier = optical_element.amplitude_multiplier(r, 0, omega)
+            multiplier = optical_element.amplitude_multiplier(r, 0, omega, omega0)
             # The azimuthal modes are the components of the Fourier transform
             # along theta (FT_theta). Because the multiplier is assumed to be
             # cylindrically symmetric (i.e. theta-independent):
@@ -196,7 +196,7 @@ class Laser:
             x, y, omega = np.meshgrid(
                 self.grid.axes[0], self.grid.axes[1], omega_1d, indexing="ij"
             )
-            spectral_field *= optical_element.amplitude_multiplier(x, y, omega)
+            spectral_field *= optical_element.amplitude_multiplier(x, y, omega, omega0)
         self.grid.set_spectral_field(spectral_field)
 
     def propagate(self, distance, nr_boundary=None, backend="NP", show_progress=True):

--- a/lasy/optical_elements/optical_element.py
+++ b/lasy/optical_elements/optical_element.py
@@ -1,7 +1,8 @@
 import numpy as np
+from abc import ABC, abstractmethod
 
 
-class OpticalElement(object):
+class OpticalElement(ABC):
     """
     Base class to model thin optical elements.
 
@@ -12,7 +13,8 @@ class OpticalElement(object):
     def __init__(self):
         pass
 
-    def amplitude_multiplier(self, x, y, omega):
+    @abstractmethod
+    def amplitude_multiplier(self, x, y, omega, omega0):
         r"""
         Return the amplitude multiplier :math:`T`.
 
@@ -29,6 +31,8 @@ class OpticalElement(object):
         x, y, omega: ndarrays of floats
             Define points on which to evaluate the multiplier.
             These arrays need to all have the same shape.
+        omega0: float
+            Central angular frequency of the laser.
 
         Returns
         -------

--- a/lasy/optical_elements/optical_element.py
+++ b/lasy/optical_elements/optical_element.py
@@ -1,5 +1,6 @@
-import numpy as np
 from abc import ABC, abstractmethod
+
+import numpy as np
 
 
 class OpticalElement(ABC):

--- a/lasy/optical_elements/parabolic_mirror.py
+++ b/lasy/optical_elements/parabolic_mirror.py
@@ -28,7 +28,7 @@ class ParabolicMirror(OpticalElement):
     def __init__(self, f):
         self.f = f
 
-    def amplitude_multiplier(self, x, y, omega):
+    def amplitude_multiplier(self, x, y, omega, omega0):
         """
         Return the amplitude multiplier.
 


### PR DESCRIPTION
For many optical elements the central laser frequency needs to be known. With this PR it is passed when calling `apply_optics`

Edit: I turned OpticalElement into an abstract class to ensure that all child implementations of `amplitude_multiplier` use `x,y,omega,omega0` as arguments. I'm also fine with reverting this if you don't like it.