### PR TITLE
Tutorial: Laser From Long&Trans Profile

### DIFF
--- a/docs/source/tutorials/data_laser.ipynb
+++ b/docs/source/tutorials/data_laser.ipynb
@@ -1,0 +1,600 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e401ede1-0719-49e4-b84d-5bd0f0813c80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib ipympl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcf32943-cf31-42c3-995c-2ed75c9761d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasy.profiles.gaussian_profile import GaussianProfile\n",
+    "from lasy.profiles.longitudinal import LongitudinalProfileFromData\n",
+    "from lasy.profiles.transverse import TransverseProfileFromData\n",
+    "from lasy.profiles.combined_profile import CombinedLongitudinalTransverseProfile\n",
+    "from lasy.laser import Laser\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LogNorm\n",
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4a2fd86-a83f-490e-9e10-21d0e3ca7c4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wavelength     = 815e-9  # Laser wavelength in meters\n",
+    "polarization   = (1, 0)  # Linearly polarized in the x direction\n",
+    "energy_J       = 24      # Pulse energy in Joules"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34780a19-9071-4fea-b55e-fc3cc63e4003",
+   "metadata": {},
+   "source": [
+    "# Measured Profile (20-24J)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f88ab1e4-1f5a-4f07-8b7c-4c105b4aa9eb",
+   "metadata": {},
+   "source": [
+    "## Longitudinal (Time)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c16f8e68-b1b1-479a-81cd-0786626d5058",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_intensity = pd.read_csv(\"FROG_analysis_2023-06-15/23_0615Scan007Frog-HPD-1Et.txt\", delimiter=\"\\t\")\n",
+    "#display(df_intensity)\n",
+    "\n",
+    "compressor_setting_mm = 10.8\n",
+    "column_Re = f\"Re({compressor_setting_mm}mm)\"\n",
+    "column_Im = f\"Im({compressor_setting_mm}mm)\"\n",
+    "\n",
+    "# time\n",
+    "fs = 1e-15\n",
+    "time_s = df_intensity[\"[fs]\"].values * fs\n",
+    "\n",
+    "# E_complex(t)\n",
+    "Et_Re = df_intensity[column_Re].values\n",
+    "Et_Im = df_intensity[column_Im].values\n",
+    "Et_complex = Et_Re + 1j * Et_Im\n",
+    "\n",
+    "# retrieve Intensity and Phase\n",
+    "Et_intensity = np.abs(Et_complex)**2\n",
+    "Et_phase = np.arctan(Et_Im, Et_Re)\n",
+    "\n",
+    "# shift to peak intensity at t=0\n",
+    "peak_index = np.argmax(Et_intensity)\n",
+    "time_s -= time_s[peak_index]\n",
+    "\n",
+    "print(time_s, Et_phase.shape, Et_phase.dtype)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e70f703e-15a3-4751-a857-71b17651671a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = 1e-15\n",
+    "longitudinal_data = {\n",
+    "    \"datatype\": \"temporal\",\n",
+    "    \"axis\": time_s,\n",
+    "    \"intensity\": Et_intensity,\n",
+    "    \"phase\": Et_phase,\n",
+    "    \"wavelength\": wavelength\n",
+    "}\n",
+    "\n",
+    "longitudinal_profile = LongitudinalProfileFromData(\n",
+    "    longitudinal_data,\n",
+    "    lo=-200 * fs,\n",
+    "    hi=200 * fs\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c26192e9-7a33-4a31-b291-32e422f0d66e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "longitudinal_profile.evaluate(time_s)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ba9ced4-cc19-48ba-9fec-ddcb6e77128b",
+   "metadata": {},
+   "source": [
+    "## Transverse Mode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4706a1c-1a01-4706-9938-022bde1a816f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!conda install -c conda-forge -y scikit-image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcfff530-c04b-4d28-977c-8143ffe87c62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import skimage\n",
+    "\n",
+    "# Define the transverse profile of the laser pulse\n",
+    "img_url = \"https://user-images.githubusercontent.com/27694869/228038930-d6ab03b1-a726-4b41-a378-5f4a83dc3778.png\"\n",
+    "intensityData = skimage.io.imread(img_url)\n",
+    "\n",
+    "# data cleaning: remove negative values\n",
+    "intensityData[intensityData < 2.1] = 0\n",
+    "# data cleaning: normalize values\n",
+    "pixel_calib = 0.186e-6\n",
+    "lo = (\n",
+    "    -intensityData.shape[0] / 2 * pixel_calib,\n",
+    "    -intensityData.shape[1] / 2 * pixel_calib,\n",
+    ")\n",
+    "hi = (\n",
+    "    intensityData.shape[0] / 2 * pixel_calib,\n",
+    "    intensityData.shape[1] / 2 * pixel_calib,\n",
+    ")\n",
+    "# data cleaning: zoom/clip (if needed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba20f561-54e6-4488-ad9b-d5e916793c4f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cal = 0.143 # spatial calibration mode imager\n",
+    "# zoom/clip\n",
+    "x_i_clip = [100, -100]\n",
+    "y_i_clip = [100, -100]\n",
+    "\n",
+    "transverse_data = np.loadtxt(\"Mode-im/mode-im_scan10_shot25_fluencemap.csv\", delimiter=\",\")\n",
+    "print(transverse_data.shape)\n",
+    "\n",
+    "# data cleaning: remove negative values\n",
+    "transverse_data[transverse_data<1e4] = 0\n",
+    "# data cleaning: normalize\n",
+    "#transverse_scale = np.max(transverse_data)\n",
+    "#transverse_data /= transverse_scale\n",
+    "# data cleaning: zoom/clip\n",
+    "x_i_clip = [150, -150]\n",
+    "y_i_clip = [150, -150]\n",
+    "transverse_data = transverse_data[\n",
+    "    x_i_clip[0]:x_i_clip[1],\n",
+    "    y_i_clip[0]:y_i_clip[1]\n",
+    "]\n",
+    "\n",
+    "# axes\n",
+    "transverse_x_mu = cal * np.arange(0, transverse_data.shape[1], 70)\n",
+    "transverse_y_mu = cal * np.arange(0, transverse_data.shape[0], 70)\n",
+    "transverse_y_mu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12b0d5eb-ad0a-4777-ae82-d612eba69fb0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig,ax = plt.subplots()\n",
+    "cax = ax.imshow(\n",
+    "    transverse_data,\n",
+    "    aspect=\"auto\",\n",
+    "    extent=[\n",
+    "        transverse_x_mu[0], transverse_x_mu[-1],\n",
+    "        transverse_y_mu[0], transverse_y_mu[-1]\n",
+    "    ],\n",
+    "    #norm=LogNorm(),\n",
+    ")\n",
+    "# Add a colorbar\n",
+    "color_bar = fig.colorbar(cax)\n",
+    "# Add a label to the colorbar\n",
+    "color_bar.set_label(r\"Fluence / J/cm$^2$\")\n",
+    "ax.set_xlabel(r\"x / $\\mu$m\")\n",
+    "ax.set_ylabel(\"y / um\")\n",
+    "\n",
+    "# Set the tick positions\n",
+    "#ax.set_xticks(transverse_x_mu)\n",
+    "#ax.set_yticks(transverse_y_mu)\n",
+    "\n",
+    "# Set the tick labels\n",
+    "#ax.set_xticklabels([f\"{i:.{0}f}\" for i in transverse_x_mu])\n",
+    "#ax.set_yticklabels([f\"{j:.{0}f}\" for j in transverse_y_mu])\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea8b598c-1341-4669-ad5d-543d7842a910",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mu = 1e-6\n",
+    "transverse_profile = TransverseProfileFromData(\n",
+    "    transverse_data,\n",
+    "    [transverse_x_mu[0]  * mu, transverse_y_mu[0]  * mu],\n",
+    "    [transverse_x_mu[-1] * mu, transverse_y_mu[-1] * mu]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d55f0ea-a2ea-4157-895f-5d5681403851",
+   "metadata": {},
+   "source": [
+    "# Transversal Profile Denoising\n",
+    "See https://github.com/LASY-org/lasy/blob/13f0e4515493deca36c1375be1d9e83c7e379d42/examples/example_modal_decomposition_data.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82a8a391-c4f1-473f-928e-cc18524e1cec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasy.utils.mode_decomposition import hermite_gauss_decomposition\n",
+    "from lasy.profiles.transverse.hermite_gaussian_profile import (\n",
+    "    HermiteGaussianTransverseProfile,\n",
+    ")\n",
+    "\n",
+    "# Calculate the decomposition into hermite-gauss modes\n",
+    "n_x_max = 20\n",
+    "n_y_max = 20\n",
+    "modeCoeffs, waist = hermite_gauss_decomposition(\n",
+    "    transverse_profile, n_x_max=n_x_max, n_y_max=n_y_max, res=0.5e-6\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd87054b-ab2c-4591-be03-c6bfeae859a1",
+   "metadata": {},
+   "source": [
+    "## Combine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab6ecbd2-0b4e-4251-8709-ce741dc4174e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# original transverse data\n",
+    "org_laser_profile = CombinedLongitudinalTransverseProfile(\n",
+    "    wavelength=wavelength,\n",
+    "    pol=polarization,\n",
+    "    laser_energy=energy_J,\n",
+    "    long_profile=longitudinal_profile,\n",
+    "    trans_profile=transverse_profile\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdb681f0-0974-4316-964a-a80db2e757cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "org_laser_profile.laser_energy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57c41677-70de-4163-a951-389353236b25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# denoised transverse data\n",
+    "\n",
+    "# Reconstruct the pulse using a series of hermite-gauss modes\n",
+    "for i, mode_key in enumerate(list(modeCoeffs)):\n",
+    "    tmp_transverse_profile = HermiteGaussianTransverseProfile(\n",
+    "        waist, mode_key[0], mode_key[1]\n",
+    "    )\n",
+    "    if i == 0:\n",
+    "        laser_profile = modeCoeffs[\n",
+    "            mode_key\n",
+    "        ] * CombinedLongitudinalTransverseProfile(\n",
+    "            wavelength, polarization, energy_J, longitudinal_profile, tmp_transverse_profile\n",
+    "        )\n",
+    "    else:\n",
+    "        laser_profile += modeCoeffs[\n",
+    "            mode_key\n",
+    "        ] * CombinedLongitudinalTransverseProfile(\n",
+    "            wavelength, polarization, energy_J, longitudinal_profile, tmp_transverse_profile\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00be90cf-6bdf-4274-89c2-18475c235263",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "laser_profile.laser_energy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ea4a49a-a526-44bc-9f34-d308b261ef69",
+   "metadata": {},
+   "source": [
+    "## Plot Denoised Profile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcb44ccf-ad2b-4a9b-bc19-9f615d057335",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mpl_toolkits.axes_grid1 import make_axes_locatable\n",
+    "\n",
+    "# Plotting the results\n",
+    "x = np.linspace(-5 * waist, 5 * waist, 500)\n",
+    "X, Y = np.meshgrid(x, x)\n",
+    "\n",
+    "fig, ax = plt.subplots(1, 3, figsize=(12, 4), tight_layout=True)\n",
+    "\n",
+    "pltextent = (np.min(x) * 1e6, np.max(x) * 1e6, np.min(x) * 1e6, np.max(x) * 1e6)\n",
+    "prof1 = np.abs(org_laser_profile.evaluate(X, Y, 0)) ** 2\n",
+    "divider0 = make_axes_locatable(ax[0])\n",
+    "ax0_cb = divider0.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
+    "pl0 = ax[0].imshow(prof1, cmap=\"magma\", extent=pltextent, vmin=0, vmax=np.max(prof1))\n",
+    "cbar0 = fig.colorbar(pl0, cax=ax0_cb)\n",
+    "cbar0.set_label(\"Intensity (norm.)\")\n",
+    "ax[0].set_xlabel(\"x (micron)\")\n",
+    "ax[0].set_ylabel(\"y (micron)\")\n",
+    "ax[0].set_title(\"Original Profile\")\n",
+    "\n",
+    "prof2 = np.abs(laser_profile.evaluate(X, Y, 0)) ** 2\n",
+    "divider1 = make_axes_locatable(ax[1])\n",
+    "ax1_cb = divider1.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
+    "pl1 = ax[1].imshow(prof2, cmap=\"magma\", extent=pltextent, vmin=0, vmax=np.max(prof1))\n",
+    "cbar1 = fig.colorbar(pl1, cax=ax1_cb)\n",
+    "cbar1.set_label(\"Intensity (norm.)\")\n",
+    "ax[1].set_xlabel(\"x (micron)\")\n",
+    "ax[1].set_ylabel(\"y (micron)\")\n",
+    "ax[1].set_title(\"Reconstructed Profile\")\n",
+    "\n",
+    "\n",
+    "prof3 = (prof1 - prof2) / np.max(prof1)\n",
+    "divider2 = make_axes_locatable(ax[2])\n",
+    "ax2_cb = divider2.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
+    "pl2 = ax[2].imshow(100 * np.abs(prof3), cmap=\"magma\", extent=pltextent, vmin=0, vmax=5)\n",
+    "cbar2 = fig.colorbar(pl2, cax=ax2_cb)\n",
+    "cbar2.set_label(\"|Intensity Error| (%)\")\n",
+    "ax[2].set_xlabel(\"x (micron)\")\n",
+    "ax[2].set_ylabel(\"y (micron)\")\n",
+    "ax[2].set_title(\"Error\")\n",
+    "\n",
+    "fig.suptitle(\n",
+    "    \"Hermite-Gauss Reconstruction using n_x_max = %i, n_y_max = %i\" % (n_x_max, n_y_max)\n",
+    ")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "103c9501-3e91-4f9b-a0bb-d3a5e2320d0c",
+   "metadata": {},
+   "source": [
+    "### RT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc1a94ed-e16f-472e-b4f4-b1bdc6efd0af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dimensions     = \"rt\"                               # Use 3D geometry\n",
+    "lo             = (0, -7*pulse_duration)           # Lower bounds of the simulation box\n",
+    "hi             = (5*spot_size, 10*pulse_duration)  # Upper bounds of the simulation box\n",
+    "num_points     = (300, 500)                     # Number of points in each dimension\n",
+    "\n",
+    "laser_rt_org = Laser(dimensions, lo, hi, num_points, org_laser_profile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27498c38-124c-4f64-b77a-daa5c9ac93ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "laser_rt_org.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcce1b21-2f6a-459a-832f-c984b54e8fa4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dimensions     = \"rt\"                               # Use 3D geometry\n",
+    "lo             = (0, -7*pulse_duration)           # Lower bounds of the simulation box\n",
+    "hi             = (5*spot_size, 10*pulse_duration)  # Upper bounds of the simulation box\n",
+    "num_points     = (300, 500)                     # Number of points in each dimension\n",
+    "\n",
+    "# hack: add laser_energy attribute\n",
+    "laser_profile.laser_energy = energy_J\n",
+    "\n",
+    "laser_rt = Laser(dimensions, lo, hi, num_points, laser_profile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa5a0d23-f4f2-4a28-9b7c-726ef7c0179e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "laser_rt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8316887d-5a31-4071-b33a-a48803cb8f39",
+   "metadata": {},
+   "source": [
+    "### XYT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eeaeeae5-d375-4074-8c0c-56fc94bf2c34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dimensions     = \"xyt\"                               # Use 3D geometry\n",
+    "lo             = (-12.0e-6, -12.0e-6, -7*pulse_duration)           # Lower bounds of the simulation box\n",
+    "hi             = ( 12.0e-6,  12.0e-6, 10*pulse_duration)  # Upper bounds of the simulation box\n",
+    "#lo             = (transverse_x_mu[0] *mu, transverse_y_mu[0] *mu, -7*pulse_duration)           # Lower bounds of the simulation box\n",
+    "#hi             = (transverse_x_mu[-1]*mu, transverse_y_mu[-1]*mu, 10*pulse_duration)  # Upper bounds of the simulation box\n",
+    "num_points     = (300, 300, 500)                     # Number of points in each dimension\n",
+    "#num_points     = (50, 50, 200)                     # low res for quick tests\n",
+    "\n",
+    "laser_xyt = Laser(dimensions, lo, hi, num_points, laser_profile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afc25278-b767-498d-a98e-cae1622ac963",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "laser_xyt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7efe8b3-4756-46ac-9608-4cd5c8a9b76a",
+   "metadata": {},
+   "source": [
+    "# Propagate Backwards from Focus for Initialization in Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f43f4bb-db9a-40da-985a-979a87f8e3dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "profile_focal_distance = 24.0e-6\n",
+    "laser_xyt.propagate(-profile_focal_distance)  # Propagate the pulse upstream of the focal plane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "350d331d-7a7a-4f21-a09b-e91e3d689fbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "laser_xyt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7362b02-5d9a-40fc-89ee-ef180c020ab6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_prefix    = \"BELLAiP2_24J_24um_to_focus\"\n",
+    "\n",
+    "laser_xyt.write_to_file(file_prefix, file_format=\"h5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c51984d-37a3-475e-bcbf-f26bbd84e655",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "906831f7-a520-4a13-8c79-73a90428280c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add a tutorial notebook to load a PW-class laser pulse from measured FROG data + measured transverse intensity profile. Includes denoising and backwards propagation to initialization plane and rescaling to specific laser energy after denoising (hack).

- [ ] specific data sources need to be replaced with ones we already have in other tests