### PR TITLE
centralized setup of spectral axis

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -183,7 +183,9 @@ class Laser:
             # The line below assumes that amplitude_multiplier
             # is cylindrically symmetric, hence we pass
             # `r` as `x` and 0 as `y`
-            multiplier = optical_element.amplitude_multiplier(r, 0, omega, self.profile.omega0)
+            multiplier = optical_element.amplitude_multiplier(
+                r, 0, omega, self.profile.omega0
+            )
             # The azimuthal modes are the components of the Fourier transform
             # along theta (FT_theta). Because the multiplier is assumed to be
             # cylindrically symmetric (i.e. theta-independent):

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -192,7 +192,9 @@ class Laser:
             x, y, omega = np.meshgrid(
                 self.grid.axes[0], self.grid.axes[1], self.omega_1d, indexing="ij"
             )
-            spectral_field *= optical_element.amplitude_multiplier(x, y, omega, self.omega0)
+            spectral_field *= optical_element.amplitude_multiplier(
+                x, y, omega, self.omega0
+            )
         self.grid.set_spectral_field(spectral_field)
 
     def propagate(self, distance, nr_boundary=None, backend="NP", show_progress=True):
@@ -286,8 +288,9 @@ class Laser:
         # propagators, so it needs to be added by hand.
         # Note: subtracting by omega0 is only a global phase convention,
         # that derives from the definition of the envelope in lasy.
-        spectral_field *= np.exp(-1j \
-            * (self.omega_1d[None, None, :] - self.omega0) * translate_time)
+        spectral_field *= np.exp(
+            -1j * (self.omega_1d[None, None, :] - self.omega0) * translate_time
+        )
         self.grid.set_spectral_field(spectral_field)
 
         # Translate the domain

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -67,11 +67,6 @@ class Grid:
         self.spectral_field = np.zeros(self.shape, dtype="complex128")
         self.spectral_field_valid = False
 
-        # Envelope frequency axis
-        dt = self.dx[time_axis_indx]
-        Nt = self.shape[time_axis_indx]
-        self.omega_env = 2 * np.pi * np.fft.fftfreq(Nt, dt)
-
     def set_temporal_field(self, field):
         """
         Set the temporal field.

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -61,10 +61,16 @@ class Grid:
             # 0, 1, 2, ..., n_azimuthal_modes-1, -n_azimuthal_modes+1, ..., -1
             ncomp = 2 * self.n_azimuthal_modes - 1
             self.shape = (ncomp, self.npoints[0], self.npoints[1])
+
         self.temporal_field = np.zeros(self.shape, dtype="complex128")
         self.temporal_field_valid = False
         self.spectral_field = np.zeros(self.shape, dtype="complex128")
         self.spectral_field_valid = False
+
+        # Envelope frequency axis
+        dt = self.dx[time_axis_indx]
+        Nt = self.shape[time_axis_indx]
+        self.omega_env = 2 * np.pi * np.fft.fftfreq(Nt, dt)
 
     def set_temporal_field(self, field):
         """


### PR DESCRIPTION
Currently spectral axis `omega` is independently created in the separate `apply_optics` and `propagate` methods, which doubles the code. this PR centralizes this procedure 
 - the envelope spectral axis is created and registered along with the `grid` construction as soon as we have `dt` and `Nt`
 -  the actual spectral axis  is created and registered at the `laser` object