### PR TITLE
Update documentation to discuss sum of profiles

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,4 +9,3 @@ pydata-sphinx-theme
 sphinx-copybutton
 sphinx-design
 sphinx-gallery
-axiprop

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ pydata-sphinx-theme
 sphinx-copybutton
 sphinx-design
 sphinx-gallery
+axiprop

--- a/docs/source/api/profiles/index.rst
+++ b/docs/source/api/profiles/index.rst
@@ -1,6 +1,9 @@
 Laser Profiles
 ==============
 
+.. autoclass:: lasy.profiles.Profile
+    :members:
+
 .. toctree::
    :hidden:
 

--- a/docs/source/api/profiles/transverse/index.rst
+++ b/docs/source/api/profiles/transverse/index.rst
@@ -1,6 +1,9 @@
 Transverse Laser Profiles
 =========================
 
+.. autoclass:: lasy.profiles.transverse.TransverseProfile
+    :members:
+
 .. toctree::
    :maxdepth: 4
    :hidden:

--- a/lasy/profiles/__init__.py
+++ b/lasy/profiles/__init__.py
@@ -1,3 +1,4 @@
+from .profile import Profile
 from .combined_profile import CombinedLongitudinalTransverseProfile
 from .from_array_profile import FromArrayProfile
 from .from_insight_file import FromInsightFile
@@ -6,6 +7,7 @@ from .gaussian_profile import GaussianProfile
 from .speckle_profile import SpeckleProfile
 
 __all__ = [
+    "Profile",
     "CombinedLongitudinalTransverseProfile",
     "GaussianProfile",
     "FromArrayProfile",

--- a/lasy/profiles/__init__.py
+++ b/lasy/profiles/__init__.py
@@ -1,9 +1,9 @@
-from .profile import Profile
 from .combined_profile import CombinedLongitudinalTransverseProfile
 from .from_array_profile import FromArrayProfile
 from .from_insight_file import FromInsightFile
 from .from_openpmd_profile import FromOpenPMDProfile
 from .gaussian_profile import GaussianProfile
+from .profile import Profile
 from .speckle_profile import SpeckleProfile
 
 __all__ = [

--- a/lasy/profiles/profile.py
+++ b/lasy/profiles/profile.py
@@ -8,6 +8,11 @@ class Profile(object):
 
     Any new laser profile should inherit from this class, and define its own
     `evaluate` method, using the same signature as the method below.
+    For most cases, use derived classes instead of this base class.
+
+    Common operators (addition and multiplication by a scalar) are provided as part of this base class.
+    For such operations, the user is responsible for handling the complex phase and weights of summed profiles.
+    In particular, summing between different types of profiles is not recommended.
 
     Parameters
     ----------

--- a/lasy/profiles/transverse/transverse_profile.py
+++ b/lasy/profiles/transverse/transverse_profile.py
@@ -7,6 +7,12 @@ class TransverseProfile(object):
 
     Any new transverse profile should inherit from this class, and define its own
     `evaluate` method, using the same signature as the method below.
+    For most cases, use derived classes instead of this base class.
+
+    Common operators (addition and multiplication by a scalar) are provided as part of this base class.
+    For such operations, the user is responsible for handling the complex phase and weights of summed profiles.
+    In particular, summing between different types of profiles is not recommended.
+    This feature is tailored for linear combination of profiles of the same type, in particular analytical profiles like Laguerre-gauss or Hermite-Gauss.
     """
 
     def __init__(self):


### PR DESCRIPTION
Supersedes #264.

While `Profile` and `TransverseProfile` classes have a `__add__` operator, @RemiLehe in particular noticed that summing different profiles could be risky. This PR proposes to update the documentation to be transparent with the user.