### PR TITLE
Remove member function of the `Grid` object

### DIFF
--- a/docs/source/api/utils/grid.rst
+++ b/docs/source/api/utils/grid.rst
@@ -2,4 +2,3 @@ Grid
 ====
 
 .. autoclass:: lasy.utils.grid.Grid
-    :members:


### PR DESCRIPTION
The member functions of `Grid` are meant to be used internally in `lasy` and should probably not show up in the user-facing documentation.