### PR TITLE
Fix assert error when creating a grid from a field from file.

### DIFF
--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -691,7 +691,7 @@ def create_grid(array, axes, dim, is_envelope=True):
         grid = Grid(dim, lo, hi, npoints, n_azimuthal_modes=1, is_envelope=is_envelope)
         assert np.all(grid.axes[0] == axes["r"])
         assert np.allclose(grid.axes[1], axes["t"], rtol=1.0e-14)
-        grid.set_temporal_field(array)
+        grid.set_temporal_field(array[np.newaxis])
     return grid
 
 


### PR DESCRIPTION
This addresses a problem when creating a lasy profile from a FBPIC output (OpenPMD) file.
It can be reproduced with the following piece of code:


```py
from lasy.profiles.from_openpmd_profile import FromOpenPMDProfile

lasy_profile = FromOpenPMDProfile(
            path="lab_diags/hdf5",
            iteration=10,
            pol=(1, 0),  # dummy value, currently not needed
            field='E',
            coord='x',
            prefix=None,
            theta=0.0,
        )
```

The error comes when setting the complex, 3D array `grid.temporal_field` object in `grid.set_temporal_field` from the real, 2D array `field` read from file.
A solution to appropriately handling the array data type has been taken care of through #302.

This PR now simply fixes the dimensionality issue by adding an extra (azimuthal) dimension to the field array when passing it to `grid.set_temporal_field`.
