### PR TITLE
Make is_envelope a member of Grid

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -228,6 +228,7 @@ class Laser:
         show_progress : bool (optional)
             Whether to show a progress bar when performing the computation
         """
+        assert self.grid.is_envelope # The propagator assumes envelope
         # apply boundary "absorption" if required
         if nr_boundary is not None:
             assert type(nr_boundary) is int and nr_boundary > 0

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -228,7 +228,7 @@ class Laser:
         show_progress : bool (optional)
             Whether to show a progress bar when performing the computation
         """
-        assert self.grid.is_envelope # The propagator assumes envelope
+        assert self.grid.is_envelope  # The propagator assumes envelope
         # apply boundary "absorption" if required
         if nr_boundary is not None:
             assert type(nr_boundary) is int and nr_boundary > 0

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -100,7 +100,7 @@ class FromOpenPMDProfile(FromArrayProfile):
         # If array does not contain the envelope but the electric field,
         # extract the envelope with a Hilbert transform
         if not is_envelope:
-            grid = create_grid(F, axes, dim)
+            grid = create_grid(F, axes, dim, is_envelope=is_envelope)
             grid, omg0 = field_to_envelope(grid, dim, phase_unwrap_nd)
             array = grid.get_temporal_field()[0]
         else:

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -105,6 +105,7 @@ class Grid:
             The spectral field.
         """
         assert field.shape == self.spectral_field.shape
+        assert field.dtype == "complex128"
         self.spectral_field[:, :, :] = field
         self.spectral_field_valid = True
         self.temporal_field_valid = False  # Invalidates the temporal field

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -67,7 +67,6 @@ class Grid:
             ncomp = 2 * self.n_azimuthal_modes - 1
             self.shape = (ncomp, self.npoints[0], self.npoints[1])
 
-        # This overwrites the dtype of temporal_field above
         self.set_is_envelope(is_envelope)
         self.temporal_field = np.zeros(self.shape, dtype=self.dtype)
         self.temporal_field_valid = False

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -74,9 +74,7 @@ class Grid:
         self.spectral_field_valid = False
 
     def get_dtype(self):
-        """
-        Get the data type of self.temporal_field.
-        """
+        """Get the data type of self.temporal_field."""
         if self.is_envelope:
             return "complex128"
         else:

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -81,6 +81,7 @@ class Grid:
             self.dtype = "complex128"
         else:
             self.dtype = "float64"
+        self.temporal_field = self.temporal_field.astype(dtype=self.dtype)
         self.is_envelope = is_envelope
 
     def set_temporal_field(self, field):

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -69,8 +69,8 @@ class Grid:
             self.shape = (ncomp, self.npoints[0], self.npoints[1])
 
         self.temporal_field = np.zeros(self.shape, dtype=self.get_dtype())
-        self.spectral_field = np.zeros(self.shape, dtype=self.get_dtype())
         self.temporal_field_valid = False
+        self.spectral_field = np.zeros(self.shape, dtype="complex128")
         self.spectral_field_valid = False
 
     def get_dtype(self):
@@ -105,8 +105,6 @@ class Grid:
             The spectral field.
         """
         assert field.shape == self.spectral_field.shape
-        assert field.dtype == self.get_dtype()
-        assert self.is_envelope
         self.spectral_field[:, :, :] = field
         self.spectral_field_valid = True
         self.temporal_field_valid = False  # Invalidates the temporal field
@@ -125,7 +123,6 @@ class Grid:
         """
         # We return a copy, so that the user cannot modify
         # the original field, unless get_temporal_field is called
-        assert self.is_envelope
         if self.temporal_field_valid:
             return self.temporal_field.copy()
         elif self.spectral_field_valid:
@@ -164,7 +161,6 @@ class Grid:
         (Only along the time axis, not along the transverse spatial coordinates.)
         """
         assert self.temporal_field_valid
-        assert self.is_envelope
         self.spectral_field = np.fft.ifft(
             self.temporal_field, axis=time_axis_indx, norm="backward"
         )
@@ -177,7 +173,6 @@ class Grid:
         (Only along the time axis, not along the transverse spatial coordinates.)
         """
         assert self.spectral_field_valid
-        assert self.is_envelope
         self.temporal_field = np.fft.fft(
             self.spectral_field, axis=time_axis_indx, norm="backward"
         )

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -48,7 +48,8 @@ class Grid:
         self.npoints = npoints
         self.axes = []
         self.dx = []
-        self.is_envelope = is_envelope
+        self.dtype = None
+        self.set_is_envelope(is_envelope)
         for i in range(ndims):
             self.axes.append(np.linspace(lo[i], hi[i], npoints[i]))
             self.dx.append(self.axes[i][1] - self.axes[i][0])
@@ -68,17 +69,19 @@ class Grid:
             ncomp = 2 * self.n_azimuthal_modes - 1
             self.shape = (ncomp, self.npoints[0], self.npoints[1])
 
-        self.temporal_field = np.zeros(self.shape, dtype=self.get_dtype())
+        self.temporal_field = np.zeros(self.shape, dtype=self.dtype)
         self.temporal_field_valid = False
         self.spectral_field = np.zeros(self.shape, dtype="complex128")
         self.spectral_field_valid = False
 
-    def get_dtype(self):
-        """Get the data type of self.temporal_field."""
-        if self.is_envelope:
-            return "complex128"
+    def set_is_envelope(is_envelope):
+        """Set is_envelope attribute. Also set dtype accordingly."""
+        assert is_envelope in [True, False]
+        if is_envelope:
+            self.dtype = "complex128"
         else:
-            return "float64"
+            self.dtype = "float64"
+        self.is_envelope = is_envelope
 
     def set_temporal_field(self, field):
         """

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -74,7 +74,7 @@ class Grid:
         self.spectral_field = np.zeros(self.shape, dtype="complex128")
         self.spectral_field_valid = False
 
-    def set_is_envelope(is_envelope):
+    def set_is_envelope(self, is_envelope):
         """Set is_envelope attribute. Also set dtype accordingly."""
         assert is_envelope in [True, False]
         if is_envelope:
@@ -93,7 +93,7 @@ class Grid:
             The temporal field.
         """
         assert field.shape == self.temporal_field.shape
-        assert field.dtype == self.get_dtype()
+        assert field.dtype == self.dtype
         self.temporal_field[:, :, :] = field
         self.temporal_field_valid = True
         self.spectral_field_valid = False  # Invalidates the spectral field

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -67,9 +67,9 @@ class Grid:
             ncomp = 2 * self.n_azimuthal_modes - 1
             self.shape = (ncomp, self.npoints[0], self.npoints[1])
 
-        self.temporal_field = np.zeros(self.shape, dtype="complex128")
         # This overwrites the dtype of temporal_field above
         self.set_is_envelope(is_envelope)
+        self.temporal_field = np.zeros(self.shape, dtype=self.dtype)
         self.temporal_field_valid = False
         self.spectral_field = np.zeros(self.shape, dtype="complex128")
         self.spectral_field_valid = False
@@ -88,7 +88,8 @@ class Grid:
             self.dtype = "complex128"
         else:
             self.dtype = "float64"
-        self.temporal_field = self.temporal_field.astype(dtype=self.dtype)
+        if hasattr(self, "temporal_field"):
+            self.temporal_field = self.temporal_field.astype(dtype=self.dtype)
         self.is_envelope = is_envelope
 
     def set_temporal_field(self, field):

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -48,8 +48,6 @@ class Grid:
         self.npoints = npoints
         self.axes = []
         self.dx = []
-        self.dtype = None
-        self.set_is_envelope(is_envelope)
         for i in range(ndims):
             self.axes.append(np.linspace(lo[i], hi[i], npoints[i]))
             self.dx.append(self.axes[i][1] - self.axes[i][0])
@@ -69,7 +67,9 @@ class Grid:
             ncomp = 2 * self.n_azimuthal_modes - 1
             self.shape = (ncomp, self.npoints[0], self.npoints[1])
 
-        self.temporal_field = np.zeros(self.shape, dtype=self.dtype)
+        self.temporal_field = np.zeros(self.shape, dtype="complex128")
+        # This overwrites the dtype of temporal_field above
+        self.set_is_envelope(is_envelope)
         self.temporal_field_valid = False
         self.spectral_field = np.zeros(self.shape, dtype="complex128")
         self.spectral_field_valid = False

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -75,7 +75,14 @@ class Grid:
         self.spectral_field_valid = False
 
     def set_is_envelope(self, is_envelope):
-        """Set is_envelope attribute. Also set dtype accordingly."""
+        """
+        Set is_envelope attribute. Also set dtype accordingly.
+
+        Parameters
+        ----------
+        is_envelope : boolean
+            Whether the grid should represent an envelope (True) or a full electric field (False)
+        """
         assert is_envelope in [True, False]
         if is_envelope:
             self.dtype = "complex128"

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -74,6 +74,9 @@ class Grid:
         self.spectral_field_valid = False
 
     def get_dtype(self):
+        """
+        Get the data type of self.temporal_field.
+        """
         if self.is_envelope:
             return "complex128"
         else:
@@ -105,7 +108,7 @@ class Grid:
         """
         assert field.shape == self.spectral_field.shape
         assert field.dtype == self.get_dtype()
-        assert self.is_envelope == True
+        assert self.is_envelope
         self.spectral_field[:, :, :] = field
         self.spectral_field_valid = True
         self.temporal_field_valid = False  # Invalidates the temporal field
@@ -124,7 +127,7 @@ class Grid:
         """
         # We return a copy, so that the user cannot modify
         # the original field, unless get_temporal_field is called
-        assert self.is_envelope == True
+        assert self.is_envelope
         if self.temporal_field_valid:
             return self.temporal_field.copy()
         elif self.spectral_field_valid:
@@ -147,7 +150,7 @@ class Grid:
         """
         # We return a copy, so that the user cannot modify
         # the original field, unless set_spectral_field is called
-        assert self.is_envelope == True
+        assert self.is_envelope
         if self.spectral_field_valid:
             return self.spectral_field.copy()
         elif self.temporal_field_valid:
@@ -163,7 +166,7 @@ class Grid:
         (Only along the time axis, not along the transverse spatial coordinates.)
         """
         assert self.temporal_field_valid
-        assert self.is_envelope == True
+        assert self.is_envelope
         self.spectral_field = np.fft.ifft(
             self.temporal_field, axis=time_axis_indx, norm="backward"
         )
@@ -176,7 +179,7 @@ class Grid:
         (Only along the time axis, not along the transverse spatial coordinates.)
         """
         assert self.spectral_field_valid
-        assert self.is_envelope == True
+        assert self.is_envelope
         self.temporal_field = np.fft.fft(
             self.spectral_field, axis=time_axis_indx, norm="backward"
         )

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -283,6 +283,7 @@ def get_spectrum(grid, dim, range=None, bins=20, omega0=None, method="sum"):
 
     omega0 : scalar (optional)
         Angular frequency at which the envelope is defined.
+        Only used if grid.is_envelope is True.
 
     method : {'sum', 'on_axis', 'raw'} (optional)
         Determines the type of spectrum that is returned as described above.
@@ -390,6 +391,7 @@ def get_frequency(
 
     omega0 : scalar
         Angular frequency at which the envelope is defined.
+        Only used if grid.is_envelope is True.
 
     phase_unwrap_nd : boolean (optional)
         If True, the phase unwrapping is n-dimensional (2- or 3-D depending on dim).

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -648,7 +648,7 @@ def weighted_std(values, weights=None):
     return std
 
 
-def create_grid(array, axes, dim):
+def create_grid(array, axes, dim, is_envelope=True):
     """Create a lasy grid from a numpy array.
 
     Parameters

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -587,6 +587,7 @@ def field_to_envelope(grid, dim, phase_unwrap_nd=False):
         phase_unwrap_nd=phase_unwrap_nd,
     )
     field *= np.exp(1j * omg0_h * grid.axes[-1])
+    grid.is_envelope = True
     grid.set_temporal_field(field)
 
     return grid, omg0_h

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -510,7 +510,7 @@ def field_to_vector_potential(grid, omega0):
     # Here, we neglect the time derivative of the envelope of E, the first RHS
     # term in: E = -dA/dt + 1j * omega0 * A where E and A are the field and
     # vector potential envelopes, respectively
-    assert grid.is_envelope is True
+    assert grid.is_envelope
     omega, _ = get_frequency(grid, omega0=omega0)
     return -1j * e * grid.get_temporal_field() / (m_e * omega * c)
 
@@ -537,7 +537,7 @@ def vector_potential_to_field(grid, omega0, direct=True):
     -------
     Envelope of the electric field (V/m).
     """
-    assert grid.is_envelope is True
+    assert grid.is_envelope
     field = grid.get_temporal_field()
     if direct:
         A = (
@@ -587,7 +587,7 @@ def field_to_envelope(grid, dim, phase_unwrap_nd=False):
         phase_unwrap_nd=phase_unwrap_nd,
     )
     field *= np.exp(1j * omg0_h * grid.axes[-1])
-    grid.is_envelope = True
+    grid.set_is_envelope(True)
     grid.set_temporal_field(field)
 
     return grid, omg0_h

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -219,9 +219,7 @@ def get_full_field(laser, theta=0, slice=0, slice_axis="x", Nt=None):
     return env, ext
 
 
-def get_spectrum(
-    grid, dim, range=None, bins=20, omega0=None, method="sum"
-):
+def get_spectrum(grid, dim, range=None, bins=20, omega0=None, method="sum"):
     r"""
     Get the frequency spectrum of an envelope or electric field.
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -47,9 +47,7 @@ def compute_laser_energy(dim, grid):
         energy = ((dV * epsilon_0) * abs(envelope) ** 2).sum()
     else:  # dim == "rt":
         energy = (
-            dV[np.newaxis, :, np.newaxis]
-            * epsilon_0
-            * abs(envelope[:, :, :]) ** 2
+            dV[np.newaxis, :, np.newaxis] * epsilon_0 * abs(envelope[:, :, :]) ** 2
         ).sum()
 
     if grid.is_envelope:

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -38,7 +38,7 @@ def test_laser_analysis_utils():
 
         # Check that energy computed from spectrum agrees with `compute_laser_energy`.
         spectrum, omega = get_spectrum(
-            laser.grid, dim, is_envelope=True, omega0=laser.profile.omega0
+            laser.grid, dim, omega0=laser.profile.omega0
         )
         d_omega = omega[1] - omega[0]
         spectrum_energy = np.sum(spectrum) * d_omega

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -37,9 +37,7 @@ def test_laser_analysis_utils():
         laser = get_gaussian_laser(dim)
 
         # Check that energy computed from spectrum agrees with `compute_laser_energy`.
-        spectrum, omega = get_spectrum(
-            laser.grid, dim, omega0=laser.profile.omega0
-        )
+        spectrum, omega = get_spectrum(laser.grid, dim, omega0=laser.profile.omega0)
         d_omega = omega[1] - omega[0]
         spectrum_energy = np.sum(spectrum) * d_omega
         energy = compute_laser_energy(dim, laser.grid)


### PR DESCRIPTION
Currently, `Grid` can be constructed with an array representing the full electric field (e.g. to use it to convert from field to envelope) or full envelope (as used internally in LASY). This PR proposes to clarify this behavior by making `is_envelope` a member variable of class `Grid`, assuming that the stored array is complex iff `is_envelope is True`. I see two advantages:
 - the use of `utils` like `field_to_envelope` would be safer and cleaner;
 - some other functions (e.g. propagator) could be applied to the full field, which would benefit from this handling.

This addresses issue #301 reported by @delaossa in #300.