### PR TITLE
Added tests for LongitudinalProfileFromData and fix for issue #185

### DIFF
--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -63,14 +63,16 @@ class LongitudinalProfileFromData(LongitudinalProfile):
 
     def __init__(self, data, lo, hi):
         if data["datatype"] == "spectral":
-            if not "axis_is_wavelength" in data: # Set to wavelength data by default
+            if "axis_is_wavelength" not in data:  # Set to wavelength data by default
                 data["axis_is_wavelength"] = True
             if data["axis_is_wavelength"]:
                 wavelength = data["axis"]  # Accept as wavelength
                 spectral_intensity = data["intensity"]
             else:
                 wavelength = 2.0 * np.pi * c / data["axis"]  # Convert to wavelength
-                spectral_intensity = data["intensity"] * 2.0 * np.pi * c / wavelength ** 2 # Convert spectral data
+                spectral_intensity = (
+                    data["intensity"] * 2.0 * np.pi * c / wavelength**2
+                )  # Convert spectral data
             assert np.all(np.diff(wavelength) > 0) or np.all(
                 np.diff(wavelength) < 0
             ), 'data["axis"] must be in monotonically increasing or decreasing order.'

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -65,18 +65,15 @@ class LongitudinalProfileFromData(LongitudinalProfile):
             assert np.all(np.diff(wavelength) > 0) or np.all(
                 np.diff(wavelength) < 0
             ), 'data["axis"] must be in monotonically increasing or decreasing order.'
-            if np.all(np.diff(wavelength) < 0):
-                wavelength = wavelength[::-1]
-                spectral_intensity = data["intensity"][::-1]
-            else:
-                spectral_intensity = data["intensity"]
+            spectral_intensity = data["intensity"]
             if data.get("phase") is None:
                 spectral_phase = np.zeros_like(wavelength)
             else:
-                if np.all(np.diff(wavelength) < 0):
-                    spectral_phase = data["phase"][::-1]
-                else:
-                    spectral_phase = data["phase"]
+                spectral_phase = data["phase"]
+            if np.all(np.diff(wavelength) < 0: # Flip arrays
+                wavelength = wavelength[::-1]
+                spectral_intensity = spectral_intensity[::-1]
+                spectral_phase = spectral_phase[::-1]
             dt = data["dt"]
             cwl = np.sum(spectral_intensity * wavelength) / np.sum(spectral_intensity)
             cfreq = c / cwl

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -35,7 +35,7 @@ class LongitudinalProfileFromData(LongitudinalProfile):
             The horizontal axis of the pulse duration measurement.
             The array must be monotonically increasing or decreasing.
             When datatype is 'spectral' axis is wavelength in meters OR
-            angular frequency in 1/seconds.
+           frequency in 1/seconds.
             When datatype is 'temporal' axis is time in seconds.
 
         intensity : ndarrays of floats

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -62,14 +62,10 @@ class LongitudinalProfileFromData(LongitudinalProfile):
         if data["datatype"] == "spectral":
             # First find central frequency
             wavelength = data["axis"]
-            assert np.all(
-                np.diff(wavelength) > 0
-            ) or np.all(
+            assert np.all(np.diff(wavelength) > 0) or np.all(
                 np.diff(wavelength) < 0
             ), 'data["axis"] must be in monotonically increasing or decreasing order.'
-            if np.all(
-                np.diff(wavelength) < 0
-            ):
+            if np.all(np.diff(wavelength) < 0):
                 wavelength = wavelength[::-1]
                 spectral_intensity = data["intensity"][::-1]
             else:
@@ -77,9 +73,7 @@ class LongitudinalProfileFromData(LongitudinalProfile):
             if data.get("phase") is None:
                 spectral_phase = np.zeros_like(wavelength)
             else:
-                if np.all(
-                    np.diff(wavelength) < 0
-                ):
+                if np.all(np.diff(wavelength) < 0):
                     spectral_phase = data["phase"][::-1]
                 else:
                     spectral_phase = data["phase"]

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -29,7 +29,7 @@ class LongitudinalProfileFromData(LongitudinalProfile):
 
         axis : ndarrays of floats
             The horizontal axis of the pulse duration measurement.
-            The array must be monotonously increasing.
+            The array must be monotonically increasing or decreasing.
             When datatype is 'spectral' axis is wavelength in meters.
             When datatype is 'temporal' axis is time in seconds.
 
@@ -64,12 +64,25 @@ class LongitudinalProfileFromData(LongitudinalProfile):
             wavelength = data["axis"]
             assert np.all(
                 np.diff(wavelength) > 0
-            ), 'data["axis"] must be in monotonously increasing order.'
-            spectral_intensity = data["intensity"]
+            ) or np.all(
+                np.diff(wavelength) < 0
+            ), 'data["axis"] must be in monotonically increasing or decreasing order.'
+            if np.all(
+                np.diff(wavelength) < 0
+            ):
+                wavelength = wavelength[::-1]
+                spectral_intensity = data["intensity"][::-1]
+            else:
+                spectral_intensity = data["intensity"]
             if data.get("phase") is None:
                 spectral_phase = np.zeros_like(wavelength)
             else:
-                spectral_phase = data["phase"]
+                if np.all(
+                    np.diff(wavelength) < 0
+                ):
+                    spectral_phase = data["phase"][::-1]
+                else:
+                    spectral_phase = data["phase"]
             dt = data["dt"]
             cwl = np.sum(spectral_intensity * wavelength) / np.sum(spectral_intensity)
             cfreq = c / cwl

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -62,18 +62,26 @@ class LongitudinalProfileFromData(LongitudinalProfile):
         if data["datatype"] == "spectral":
             # First find central frequency
             wavelength = data["axis"]
-            assert np.all(np.diff(wavelength) > 0) or np.all(
-                np.diff(wavelength) < 0
-            ), 'data["axis"] must be in monotonically increasing or decreasing order.'
+            assert np.all(
+                np.diff(wavelength) > 0
+            ), 'data["axis"] must be in monotonously increasing order.'
             spectral_intensity = data["intensity"]
             if data.get("phase") is None:
                 spectral_phase = np.zeros_like(wavelength)
             else:
                 spectral_phase = data["phase"]
-            if np.all(np.diff(wavelength) < 0: # Flip arrays
-                wavelength = wavelength[::-1]
-                spectral_intensity = spectral_intensity[::-1]
-                spectral_phase = spectral_phase[::-1]
+            # assert np.all(np.diff(wavelength) > 0) or np.all(
+            #     np.diff(wavelength) < 0
+            # ), 'data["axis"] must be in monotonically increasing or decreasing order.'
+            # spectral_intensity = data["intensity"]
+            # if data.get("phase") is None:
+            #     spectral_phase = np.zeros_like(wavelength)
+            # else:
+            #     spectral_phase = data["phase"]
+            # if np.all(np.diff(wavelength) < 0: # Flip arrays
+            #     wavelength = wavelength[::-1]
+            #     spectral_intensity = spectral_intensity[::-1]
+            #     spectral_phase = spectral_phase[::-1]
             dt = data["dt"]
             cwl = np.sum(spectral_intensity * wavelength) / np.sum(spectral_intensity)
             cfreq = c / cwl

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -67,9 +67,9 @@ class LongitudinalProfileFromData(LongitudinalProfile):
                 np.round(np.log10(data["axis"])) - 15.0 < 1.0
             ), 'data["axis"] must be wavelength [m] or angular frequency [s^-1].'
             if np.all(np.round(np.log10(data["axis"])) + 6.0 < 1.0):
-                wavelength = data["axis"] # Accept as wavelength
+                wavelength = data["axis"]  # Accept as wavelength
             else:
-                wavelength = 2.0 * np.pi * c / data["axis"] # Convert to wavelength
+                wavelength = 2.0 * np.pi * c / data["axis"]  # Convert to wavelength
             assert np.all(np.diff(wavelength) > 0) or np.all(
                 np.diff(wavelength) < 0
             ), 'data["axis"] must be in monotonically increasing or decreasing order.'

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -25,9 +25,7 @@ class LongitudinalProfileFromData(LongitudinalProfile):
 
         datatype : string
             The domain in which the data has been passed. Options
-            are 'spectral' and 'temporal'. Spectral data may either be,
-            a) Wavelength dependent (lambda): data["axis_is_wavelength"] = True or
-            b) Angular freuqency dependent (omega): data["axis_is_wavelength"] = False
+            are 'spectral' and 'temporal'.
 
         axis : ndarrays of floats
             The horizontal axis of the pulse duration measurement.

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -26,8 +26,8 @@ class LongitudinalProfileFromData(LongitudinalProfile):
         datatype : string
             The domain in which the data has been passed. Options
             are 'spectral' and 'temporal'. Spectral data may either be,
-            a) Wavelength dependent (lambda) or
-            b) Angular freuqency dependent (omega)
+            a) Wavelength dependent (lambda): data["axis_is_wavelength"] = True or
+            b) Angular freuqency dependent (omega): data["axis_is_wavelength"] = False
 
         axis : ndarrays of floats
             The horizontal axis of the pulse duration measurement.
@@ -63,17 +63,17 @@ class LongitudinalProfileFromData(LongitudinalProfile):
 
     def __init__(self, data, lo, hi):
         if data["datatype"] == "spectral":
-            assert np.all(np.round(np.log10(data["axis"])) + 6.0 < 1.0) or np.all(
-                np.round(np.log10(data["axis"])) - 15.0 < 1.0
-            ), 'data["axis"] must be wavelength [m] or angular frequency [s^-1].'
-            if np.all(np.round(np.log10(data["axis"])) + 6.0 < 1.0):
+            if not "axis_is_wavelength" in data: # Set to wavelength data by default
+                data["axis_is_wavelength"] = True
+            if data["axis_is_wavelength"]:
                 wavelength = data["axis"]  # Accept as wavelength
+                spectral_intensity = data["intensity"]
             else:
                 wavelength = 2.0 * np.pi * c / data["axis"]  # Convert to wavelength
+                spectral_intensity = data["intensity"] * 2.0 * np.pi * c / wavelength ** 2 # Convert spectral data
             assert np.all(np.diff(wavelength) > 0) or np.all(
                 np.diff(wavelength) < 0
             ), 'data["axis"] must be in monotonically increasing or decreasing order.'
-            spectral_intensity = data["intensity"]
             if data.get("phase") is None:
                 spectral_phase = np.zeros_like(wavelength)
             else:

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -35,7 +35,7 @@ class LongitudinalProfileFromData(LongitudinalProfile):
             The horizontal axis of the pulse duration measurement.
             The array must be monotonically increasing or decreasing.
             When datatype is 'spectral' axis is wavelength in meters OR
-           frequency in 1/seconds.
+            frequency in 1/seconds.
             When datatype is 'temporal' axis is time in seconds.
 
         intensity : ndarrays of floats

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -27,6 +27,10 @@ class LongitudinalProfileFromData(LongitudinalProfile):
             The domain in which the data has been passed. Options
             are 'spectral' and 'temporal'.
 
+        axis_is_wavelength : boolean (optional, default True)
+            If True, the axis represents wavelength in [m] (SI).
+            If False, it represents frequency in [1/s] (SI).
+
         axis : ndarrays of floats
             The horizontal axis of the pulse duration measurement.
             The array must be monotonically increasing or decreasing.

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -62,26 +62,18 @@ class LongitudinalProfileFromData(LongitudinalProfile):
         if data["datatype"] == "spectral":
             # First find central frequency
             wavelength = data["axis"]
-            assert np.all(
-                np.diff(wavelength) > 0
-            ), 'data["axis"] must be in monotonously increasing order.'
+            assert np.all(np.diff(wavelength) > 0) or np.all(
+                np.diff(wavelength) < 0
+            ), 'data["axis"] must be in monotonically increasing or decreasing order.'
             spectral_intensity = data["intensity"]
             if data.get("phase") is None:
                 spectral_phase = np.zeros_like(wavelength)
             else:
                 spectral_phase = data["phase"]
-            # assert np.all(np.diff(wavelength) > 0) or np.all(
-            #     np.diff(wavelength) < 0
-            # ), 'data["axis"] must be in monotonically increasing or decreasing order.'
-            # spectral_intensity = data["intensity"]
-            # if data.get("phase") is None:
-            #     spectral_phase = np.zeros_like(wavelength)
-            # else:
-            #     spectral_phase = data["phase"]
-            # if np.all(np.diff(wavelength) < 0: # Flip arrays
-            #     wavelength = wavelength[::-1]
-            #     spectral_intensity = spectral_intensity[::-1]
-            #     spectral_phase = spectral_phase[::-1]
+            if np.all(np.diff(wavelength) < 0): # Flip arrays
+                wavelength = wavelength[::-1]
+                spectral_intensity = spectral_intensity[::-1]
+                spectral_phase = spectral_phase[::-1]
             dt = data["dt"]
             cwl = np.sum(spectral_intensity * wavelength) / np.sum(spectral_intensity)
             cfreq = c / cwl

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -65,9 +65,10 @@ class LongitudinalProfileFromData(LongitudinalProfile):
 
     def __init__(self, data, lo, hi):
         if data["datatype"] == "spectral":
-            if "axis_is_wavelength" not in data:  # Set to wavelength data by default
-                data["axis_is_wavelength"] = True
-            if data["axis_is_wavelength"]:
+            axis_is_wavelength = True  # Set to wavelength data by default
+            if "axis_is_wavelength" in data:
+                axis_is_wavelength = data["axis_is_wavelength"]
+            if axis_is_wavelength:
                 wavelength = data["axis"]  # Accept as wavelength
                 spectral_intensity = data["intensity"]
             else:

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -25,12 +25,15 @@ class LongitudinalProfileFromData(LongitudinalProfile):
 
         datatype : string
             The domain in which the data has been passed. Options
-            are 'spectral' and 'temporal'
+            are 'spectral' and 'temporal'. Spectral data may either be,
+            a) Wavelength dependent (lambda) or
+            b) Angular freuqency dependent (omega)
 
         axis : ndarrays of floats
             The horizontal axis of the pulse duration measurement.
             The array must be monotonically increasing or decreasing.
-            When datatype is 'spectral' axis is wavelength in meters.
+            When datatype is 'spectral' axis is wavelength in meters OR
+            angular frequency in 1/seconds.
             When datatype is 'temporal' axis is time in seconds.
 
         intensity : ndarrays of floats
@@ -60,8 +63,13 @@ class LongitudinalProfileFromData(LongitudinalProfile):
 
     def __init__(self, data, lo, hi):
         if data["datatype"] == "spectral":
-            # First find central frequency
-            wavelength = data["axis"]
+            assert np.all(np.round(np.log10(data["axis"])) + 6.0 < 1.0) or np.all(
+                np.round(np.log10(data["axis"])) - 15.0 < 1.0
+            ), 'data["axis"] must be wavelength [m] or angular frequency [s^-1].'
+            if np.all(np.round(np.log10(data["axis"])) + 6.0 < 1.0):
+                wavelength = data["axis"] # Accept as wavelength
+            else:
+                wavelength = 2.0 * np.pi * c / data["axis"] # Convert to wavelength
             assert np.all(np.diff(wavelength) > 0) or np.all(
                 np.diff(wavelength) < 0
             ), 'data["axis"] must be in monotonically increasing or decreasing order.'

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -70,7 +70,7 @@ class LongitudinalProfileFromData(LongitudinalProfile):
                 spectral_phase = np.zeros_like(wavelength)
             else:
                 spectral_phase = data["phase"]
-            if np.all(np.diff(wavelength) < 0): # Flip arrays
+            if np.all(np.diff(wavelength) < 0):  # Flip arrays
                 wavelength = wavelength[::-1]
                 spectral_intensity = spectral_intensity[::-1]
                 spectral_phase = spectral_phase[::-1]

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -246,7 +246,7 @@ def test_longitudinal_profiles():
         t[1] - t[0]
     )  # Generate spectral data assuming analytic ft of GaussianLongitudinalProfile
     profile = np.exp(
-        tau**2 * ((omega - omega_0) ** 2) / 4.0 + 1.0j * (cep_phase + omega * t_peak)
+        - tau**2 * ((omega - omega_0) ** 2) / 4.0 + 1.0j * (cep_phase + omega * t_peak)
     )
     spectral_intensity = np.abs(profile) ** 2 / np.max(np.abs(profile) ** 2)
     spectral_phase = np.unwrap(np.angle(profile))

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -238,15 +238,15 @@ def test_longitudinal_profiles():
     print("cep_phase = ", cep_phase_cos)
     assert np.abs(cep_phase_cos - cep_phase) / cep_phase < 0.02
 
-    # LongitudinalProfileFromData - initially assuming zero phase
+    # LongitudinalProfileFromData
     print("LongitudinalProfileFromData")
     data = {}
     data["datatype"] = "spectral"
     data["dt"] = np.abs(
         t[1] - t[0]
-    )  # Generate spectral data assuming sunchirped Gaussian
+    )  # Generate spectral data assuming analytic ft of GaussianLongitudinalProfile
     profile = np.exp(
-        tau**2 * ((omega - omega_0) ** 2) / 4.0 + +1.0j * (cep_phase + omega * t_peak)
+        tau**2 * ((omega - omega_0) ** 2) / 4.0 + 1.0j * (cep_phase + omega * t_peak)
     )
     spectral_intensity = np.abs(profile) ** 2 / np.max(np.abs(profile) ** 2)
     spectral_phase = np.unwrap(np.angle(profile))
@@ -254,7 +254,7 @@ def test_longitudinal_profiles():
     print("Case 1: monotonically increasing spectral data")
     data["axis"] = wavelength_axis
     data["intensity"] = spectral_intensity
-    # data["phase"] = spectral_phase
+    data["phase"] = spectral_phase
     profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
     field_data = profile_data.evaluate(t)
 
@@ -272,7 +272,7 @@ def test_longitudinal_profiles():
     print("Case 2: monotonically decreasing spectral data")
     data["axis"] = wavelength_axis[::-1]
     data["intensity"] = spectral_intensity[::-1]
-    # data["phase"] = spectral_phase[::-1]
+    data["phase"] = spectral_phase[::-1]
     profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
     field_data = profile_data.evaluate(t)
 

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -157,10 +157,10 @@ def test_longitudinal_profiles():
     omega_fwhm = 4 * np.log(2) / tau_fwhm  # Assumes fully-compressed
     t_peak = 1.0 * tau_fwhm
     cep_phase = 0.5 * np.pi
-    omega0 = 2.0 * np.pi * c / wavelength
+    omega_0 = 2.0 * np.pi * c / wavelength
 
     t = np.linspace(t_peak - 4 * tau_fwhm, t_peak + 4 * tau_fwhm, npoints)
-    omega = np.linspace(omega0 - 4 * omega_fwhm, omega0 + 4 * omega_fwhm, npoints)
+    omega = np.linspace(omega_0 - 4 * omega_fwhm, omega_0 + 4 * omega_fwhm, npoints)
     wavelength_axis = 2.0 * np.pi * c / omega
 
     # GaussianLongitudinalProfile
@@ -244,9 +244,9 @@ def test_longitudinal_profiles():
     data["datatype"] = "spectral"
     data["dt"] = np.abs(
         t[1] - t[0]
-    )  # Generate spectral data assuming unchirped Gaussian
+    )  # Generate spectral data assuming sunchirped Gaussian
     profile = np.exp(
-        tau**2 * ((omega - omega0) ** 2) / 4.0 + +1.0j * (cep_phase + omega * t_peak)
+        tau**2 * ((omega - omega_0) ** 2) / 4.0 + +1.0j * (cep_phase + omega * t_peak)
     )
 
     print("Case 1: monotonically increasing spectral data")

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -242,9 +242,12 @@ def test_longitudinal_profiles():
     print("LongitudinalProfileFromData")
     data = {}
     data["datatype"] = "spectral"
-    data["dt"] = np.abs(t[1] - t[0]) # Generate spectral data assuming unchirped Gaussian
-    profile = np.exp(tau**2 * ((omega - omega0) ** 2) / 4.0 + 
-                    + 1.0j * (cep_phase + omega * t_peak))
+    data["dt"] = np.abs(
+        t[1] - t[0]
+    )  # Generate spectral data assuming unchirped Gaussian
+    profile = np.exp(
+        tau**2 * ((omega - omega0) ** 2) / 4.0 + +1.0j * (cep_phase + omega * t_peak)
+    )
 
     print("Case 1: monotonically increasing spectral data")
     data["axis"] = wavelength_axis

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -9,8 +9,8 @@ from lasy.profiles import FromArrayProfile, GaussianProfile, SpeckleProfile
 from lasy.profiles.longitudinal import (
     CosineLongitudinalProfile,
     GaussianLongitudinalProfile,
-    SuperGaussianLongitudinalProfile,
     LongitudinalProfileFromData,
+    SuperGaussianLongitudinalProfile,
 )
 from lasy.profiles.profile import Profile, ScaledProfile, SummedProfile
 from lasy.profiles.transverse import (
@@ -234,15 +234,14 @@ def test_longitudinal_profiles():
     print("cep_phase_th = ", cep_phase)
     print("cep_phase = ", cep_phase_cos)
     assert np.abs(cep_phase_cos - cep_phase) / cep_phase < 0.02
-    
+
     # LongitudinalProfileFromData
     print("LongitudinalProfileFromData (monotonically increasing)")
     tau = tau_fwhm / np.sqrt(2 * np.log(2))
     # Generate spectral data
     profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
     field = profile_data.evaluate(t)
-    
-    
+
     # The following are the actual tests
     std_gauss = np.sqrt(np.average((t - t_peak) ** 2, weights=np.abs(field_gaussian)))
     std_gauss_th = tau / np.sqrt(2.0)

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -243,6 +243,7 @@ def test_longitudinal_profiles():
     print("LongitudinalProfileFromData")
     data = {}
     data["datatype"] = "spectral"
+    data["dt"] = np.abs(t[1]-t[0])
     Gamma = 2 * np.log(2) / tau_fwhm**2 # Generate spectral data assuming unchirped Gaussian
     spectral_intensity = np.exp(-((omega - omega_0) ** 2) / (4.0 * Gamma))
     

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -240,7 +240,7 @@ def test_longitudinal_profiles():
 
     # LongitudinalProfileFromData
     print("LongitudinalProfileFromData")
-    data = {}  # Generate spectral data assuming analytic ft of GaussianLongitudinalProfile
+    data = {}  # Generate spectral data assuming analytic Fourier transform of GaussianLongitudinalProfile
     data["datatype"] = "spectral"
     data["dt"] = 1e-16
     profile = np.exp(
@@ -289,6 +289,7 @@ def test_longitudinal_profiles():
     data["axis"] = omega
     data["intensity"] = spectral_intensity
     data["phase"] = spectral_phase
+    data["axis_is_wavelength"] = False
     profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
     field_data = profile_data.evaluate(t)
 
@@ -307,6 +308,7 @@ def test_longitudinal_profiles():
     data["axis"] = omega[::-1]
     data["intensity"] = spectral_intensity[::-1]
     data["phase"] = spectral_phase[::-1]
+    data["axis_is_wavelength"] = False
     profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
     field_data = profile_data.evaluate(t)
 

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -11,7 +11,6 @@ from lasy.profiles.longitudinal import (
     GaussianLongitudinalProfile,
     LongitudinalProfileFromData,
     SuperGaussianLongitudinalProfile,
-    LongitudinalProfileFromData,
 )
 from lasy.profiles.profile import Profile, ScaledProfile, SummedProfile
 from lasy.profiles.transverse import (
@@ -155,14 +154,14 @@ def test_longitudinal_profiles():
 
     wavelength = 800e-9
     tau_fwhm = 30.0e-15
-    omega_fwhm = 4 * np.log(2) / tau_fwhm # Assumes fully-compressed
+    omega_fwhm = 4 * np.log(2) / tau_fwhm  # Assumes fully-compressed
     t_peak = 1.0 * tau_fwhm
     cep_phase = 0.5 * np.pi
     omega_0 = 2.0 * np.pi * c / wavelength
 
     t = np.linspace(t_peak - 4 * tau_fwhm, t_peak + 4 * tau_fwhm, npoints)
     omega = np.linspace(omega_0 - 4 * omega_fwhm, omega_0 + 4 * omega_fwhm, npoints)
-    wavelength = 2. * np.pi * c / omega
+    wavelength = 2.0 * np.pi * c / omega
 
     # GaussianLongitudinalProfile
     print("GaussianLongitudinalProfile")
@@ -243,9 +242,11 @@ def test_longitudinal_profiles():
     print("LongitudinalProfileFromData")
     data = {}
     data["datatype"] = "spectral"
-    Gamma = 2 * np.log(2) / tau_fwhm**2 # Generate spectral data assuming unchirped Gaussian
+    Gamma = (
+        2 * np.log(2) / tau_fwhm**2
+    )  # Generate spectral data assuming unchirped Gaussian
     spectral_intensity = np.exp(-((omega - omega_0) ** 2) / (4.0 * Gamma))
-    
+
     print("Case 1: monotonically increasing spectral data")
     data["axis"] = wavelength
     data["intensity"] = spectral_intensity
@@ -262,7 +263,7 @@ def test_longitudinal_profiles():
     print("t_peak_th = ", t_peak)
     print("t_peak = ", t_peak_gaussian_data)
     assert np.abs(t_peak_gaussian_data - t_peak) / t_peak < 0.01
-    
+
     print("Case 2: monotonically decreasing spectral data")
     data["axis"] = wavelength[::-1]
     data["intensity"] = spectral_intensity[::-1]
@@ -279,7 +280,7 @@ def test_longitudinal_profiles():
     print("t_peak_th = ", t_peak)
     print("t_peak = ", t_peak_gaussian_data)
     assert np.abs(t_peak_gaussian_data - t_peak) / t_peak < 0.01
-    
+
 
 def test_profile_gaussian_3d_cartesian(gaussian):
     # - 3D Cartesian case

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -161,7 +161,7 @@ def test_longitudinal_profiles():
 
     t = np.linspace(t_peak - 4 * tau_fwhm, t_peak + 4 * tau_fwhm, npoints)
     omega = np.linspace(omega_0 - 4 * omega_fwhm, omega_0 + 4 * omega_fwhm, npoints)
-    wavelength_axis = 2.0 * np.pi * c / omega # Note: monotonically decreasing
+    wavelength_axis = 2.0 * np.pi * c / omega  # Note: monotonically decreasing
 
     # GaussianLongitudinalProfile
     print("GaussianLongitudinalProfile")
@@ -302,7 +302,7 @@ def test_longitudinal_profiles():
     print("t_peak_th = ", t_peak)
     print("t_peak = ", t_peak_gaussian_data)
     assert np.abs(t_peak_gaussian_data - t_peak) / t_peak < 0.01
-    
+
     print("Case 4: monotonically decreasing data on angular frequency axis")
     data["axis"] = omega[::-1]
     data["intensity"] = spectral_intensity[::-1]

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -240,7 +240,7 @@ def test_longitudinal_profiles():
 
     # LongitudinalProfileFromData
     print("LongitudinalProfileFromData")
-    data = {} # Generate spectral data assuming analytic ft of GaussianLongitudinalProfile
+    data = {}  # Generate spectral data assuming analytic ft of GaussianLongitudinalProfile
     data["datatype"] = "spectral"
     data["dt"] = 1e-15
     profile = np.exp(

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -242,7 +242,7 @@ def test_longitudinal_profiles():
     print("LongitudinalProfileFromData")
     data = {}  # Generate spectral data assuming analytic ft of GaussianLongitudinalProfile
     data["datatype"] = "spectral"
-    data["dt"] = 1e-15
+    data["dt"] = 1e-16
     profile = np.exp(
         -(tau**2) * ((omega - omega_0) ** 2) / 4.0 + 1.0j * (cep_phase + omega * t_peak)
     )

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -240,11 +240,9 @@ def test_longitudinal_profiles():
 
     # LongitudinalProfileFromData
     print("LongitudinalProfileFromData")
-    data = {}
+    data = {} # Generate spectral data assuming analytic ft of GaussianLongitudinalProfile
     data["datatype"] = "spectral"
-    data["dt"] = np.abs(
-        t[1] - t[0]
-    )  # Generate spectral data assuming analytic ft of GaussianLongitudinalProfile
+    data["dt"] = 1e-15
     profile = np.exp(
         -(tau**2) * ((omega - omega_0) ** 2) / 4.0 + 1.0j * (cep_phase + omega * t_peak)
     )

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -242,7 +242,7 @@ def test_longitudinal_profiles():
     print("LongitudinalProfileFromData")
     data = {}
     data["datatype"] = "spectral"
-    data["dt"] = np.abs(t[1]-t[0])
+    data["dt"] = np.abs(t[1] - t[0])
     Gamma = (
         2 * np.log(2) / tau_fwhm**2
     )  # Generate spectral data assuming unchirped Gaussian

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -157,7 +157,7 @@ def test_longitudinal_profiles():
     omega_fwhm = 4 * np.log(2) / tau_fwhm  # Assumes fully-compressed
     t_peak = 1.0 * tau_fwhm
     cep_phase = 0.5 * np.pi
-    omega_0 = 2.0 * np.pi * c / wavelength
+    omega0 = 2.0 * np.pi * c / wavelength
 
     t = np.linspace(t_peak - 4 * tau_fwhm, t_peak + 4 * tau_fwhm, npoints)
     omega = np.linspace(omega_0 - 4 * omega_fwhm, omega_0 + 4 * omega_fwhm, npoints)
@@ -246,7 +246,7 @@ def test_longitudinal_profiles():
     Gamma = (
         2 * np.log(2) / tau_fwhm**2
     )  # Generate spectral data assuming unchirped Gaussian
-    spectral_intensity = np.exp(-((omega - omega_0) ** 2) / (4.0 * Gamma))
+    spectral_intensity = np.exp(-((omega - omega0) ** 2) / (4.0 * Gamma))
 
     print("Case 1: monotonically increasing spectral data")
     data["axis"] = wavelength

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -246,7 +246,7 @@ def test_longitudinal_profiles():
         t[1] - t[0]
     )  # Generate spectral data assuming analytic ft of GaussianLongitudinalProfile
     profile = np.exp(
-        - tau**2 * ((omega - omega_0) ** 2) / 4.0 + 1.0j * (cep_phase + omega * t_peak)
+        -(tau**2) * ((omega - omega_0) ** 2) / 4.0 + 1.0j * (cep_phase + omega * t_peak)
     )
     spectral_intensity = np.abs(profile) ** 2 / np.max(np.abs(profile) ** 2)
     spectral_phase = np.unwrap(np.angle(profile))

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -10,6 +10,7 @@ from lasy.profiles.longitudinal import (
     CosineLongitudinalProfile,
     GaussianLongitudinalProfile,
     SuperGaussianLongitudinalProfile,
+    LongitudinalProfileFromData,
 )
 from lasy.profiles.profile import Profile, ScaledProfile, SummedProfile
 from lasy.profiles.transverse import (
@@ -233,6 +234,32 @@ def test_longitudinal_profiles():
     print("cep_phase_th = ", cep_phase)
     print("cep_phase = ", cep_phase_cos)
     assert np.abs(cep_phase_cos - cep_phase) / cep_phase < 0.02
+    
+    # LongitudinalProfileFromData
+    print("LongitudinalProfileFromData (monotonically increasing)")
+    tau = tau_fwhm / np.sqrt(2 * np.log(2))
+    # Generate spectral data
+    profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
+    field = profile_data.evaluate(t)
+    
+    
+    # The following are the actual tests
+    std_gauss = np.sqrt(np.average((t - t_peak) ** 2, weights=np.abs(field_gaussian)))
+    std_gauss_th = tau / np.sqrt(2.0)
+    print("std_th = ", std_gauss_th)
+    print("std = ", std_gauss)
+    assert np.abs(std_gauss - std_gauss_th) / std_gauss_th < 0.01
+
+    t_peak_gaussian = t[np.argmax(np.abs(field_gaussian))]
+    print("t_peak_th = ", t_peak)
+    print("t_peak = ", t_peak_gaussian)
+    assert np.abs(t_peak_gaussian - t_peak) / t_peak < 0.01
+
+    ff_gaussian = field_gaussian * np.exp(-1.0j * omega_0 * t)
+    cep_phase_gaussian = np.angle(ff_gaussian[np.argmax(np.abs(field_gaussian))])
+    print("cep_phase_th = ", cep_phase)
+    print("cep_phase = ", cep_phase_gaussian)
+    assert np.abs(cep_phase_gaussian - cep_phase) / cep_phase < 0.02
 
 
 def test_profile_gaussian_3d_cartesian(gaussian):

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -248,10 +248,13 @@ def test_longitudinal_profiles():
     profile = np.exp(
         tau**2 * ((omega - omega_0) ** 2) / 4.0 + +1.0j * (cep_phase + omega * t_peak)
     )
+    spectral_intensity = np.abs(profile) ** 2 / np.max(np.abs(profile) ** 2)
+    spectral_phase = np.unwrap(np.angle(profile))
 
     print("Case 1: monotonically increasing spectral data")
     data["axis"] = wavelength_axis
     data["intensity"] = spectral_intensity
+    # data["phase"] = spectral_phase
     profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
     field_data = profile_data.evaluate(t)
 
@@ -269,6 +272,7 @@ def test_longitudinal_profiles():
     print("Case 2: monotonically decreasing spectral data")
     data["axis"] = wavelength_axis[::-1]
     data["intensity"] = spectral_intensity[::-1]
+    # data["phase"] = spectral_phase[::-1]
     profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
     field_data = profile_data.evaluate(t)
 

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -242,6 +242,7 @@ def test_longitudinal_profiles():
     print("LongitudinalProfileFromData")
     data = {}
     data["datatype"] = "spectral"
+    data["dt"] = np.abs(t[1]-t[0])
     Gamma = (
         2 * np.log(2) / tau_fwhm**2
     )  # Generate spectral data assuming unchirped Gaussian

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -161,7 +161,7 @@ def test_longitudinal_profiles():
 
     t = np.linspace(t_peak - 4 * tau_fwhm, t_peak + 4 * tau_fwhm, npoints)
     omega = np.linspace(omega_0 - 4 * omega_fwhm, omega_0 + 4 * omega_fwhm, npoints)
-    wavelength_axis = 2.0 * np.pi * c / omega
+    wavelength_axis = 2.0 * np.pi * c / omega # Note: monotonically decreasing
 
     # GaussianLongitudinalProfile
     print("GaussianLongitudinalProfile")
@@ -249,7 +249,7 @@ def test_longitudinal_profiles():
     spectral_intensity = np.abs(profile) ** 2 / np.max(np.abs(profile) ** 2)
     spectral_phase = np.unwrap(np.angle(profile))
 
-    print("Case 1: monotonically increasing spectral data")
+    print("Case 1: monotonically decreasing data on wavelength axis")
     data["axis"] = wavelength_axis
     data["intensity"] = spectral_intensity
     data["phase"] = spectral_phase
@@ -267,8 +267,44 @@ def test_longitudinal_profiles():
     print("t_peak = ", t_peak_gaussian_data)
     assert np.abs(t_peak_gaussian_data - t_peak) / t_peak < 0.01
 
-    print("Case 2: monotonically decreasing spectral data")
+    print("Case 2: monotonically increasing data on wavelength axis")
     data["axis"] = wavelength_axis[::-1]
+    data["intensity"] = spectral_intensity[::-1]
+    data["phase"] = spectral_phase[::-1]
+    profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
+    field_data = profile_data.evaluate(t)
+
+    std_gauss_data = np.sqrt(np.average((t - t_peak) ** 2, weights=np.abs(field_data)))
+    std_gauss_th = tau / np.sqrt(2.0)
+    print("std_th = ", std_gauss_th)
+    print("std = ", std_gauss_data)
+    assert np.abs(std_gauss_data - std_gauss_th) / std_gauss_th < 0.01
+
+    t_peak_gaussian_data = t[np.argmax(np.abs(field_data))]
+    print("t_peak_th = ", t_peak)
+    print("t_peak = ", t_peak_gaussian_data)
+    assert np.abs(t_peak_gaussian_data - t_peak) / t_peak < 0.01
+
+    print("Case 3: monotonically increasing data on angular frequency axis")
+    data["axis"] = omega
+    data["intensity"] = spectral_intensity
+    data["phase"] = spectral_phase
+    profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
+    field_data = profile_data.evaluate(t)
+
+    std_gauss_data = np.sqrt(np.average((t - t_peak) ** 2, weights=np.abs(field_data)))
+    std_gauss_th = tau / np.sqrt(2.0)
+    print("std_th = ", std_gauss_th)
+    print("std = ", std_gauss_data)
+    assert np.abs(std_gauss_data - std_gauss_th) / std_gauss_th < 0.01
+
+    t_peak_gaussian_data = t[np.argmax(np.abs(field_data))]
+    print("t_peak_th = ", t_peak)
+    print("t_peak = ", t_peak_gaussian_data)
+    assert np.abs(t_peak_gaussian_data - t_peak) / t_peak < 0.01
+    
+    print("Case 4: monotonically decreasing data on angular frequency axis")
+    data["axis"] = omega[::-1]
     data["intensity"] = spectral_intensity[::-1]
     data["phase"] = spectral_phase[::-1]
     profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))

--- a/tests/test_laser_profiles.py
+++ b/tests/test_laser_profiles.py
@@ -160,8 +160,8 @@ def test_longitudinal_profiles():
     omega0 = 2.0 * np.pi * c / wavelength
 
     t = np.linspace(t_peak - 4 * tau_fwhm, t_peak + 4 * tau_fwhm, npoints)
-    omega = np.linspace(omega_0 - 4 * omega_fwhm, omega_0 + 4 * omega_fwhm, npoints)
-    wavelength = 2.0 * np.pi * c / omega
+    omega = np.linspace(omega0 - 4 * omega_fwhm, omega0 + 4 * omega_fwhm, npoints)
+    wavelength_axis = 2.0 * np.pi * c / omega
 
     # GaussianLongitudinalProfile
     print("GaussianLongitudinalProfile")
@@ -242,14 +242,12 @@ def test_longitudinal_profiles():
     print("LongitudinalProfileFromData")
     data = {}
     data["datatype"] = "spectral"
-    data["dt"] = np.abs(t[1] - t[0])
-    Gamma = (
-        2 * np.log(2) / tau_fwhm**2
-    )  # Generate spectral data assuming unchirped Gaussian
-    spectral_intensity = np.exp(-((omega - omega0) ** 2) / (4.0 * Gamma))
+    data["dt"] = np.abs(t[1] - t[0]) # Generate spectral data assuming unchirped Gaussian
+    profile = np.exp(tau**2 * ((omega - omega0) ** 2) / 4.0 + 
+                    + 1.0j * (cep_phase + omega * t_peak))
 
     print("Case 1: monotonically increasing spectral data")
-    data["axis"] = wavelength
+    data["axis"] = wavelength_axis
     data["intensity"] = spectral_intensity
     profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
     field_data = profile_data.evaluate(t)
@@ -266,7 +264,7 @@ def test_longitudinal_profiles():
     assert np.abs(t_peak_gaussian_data - t_peak) / t_peak < 0.01
 
     print("Case 2: monotonically decreasing spectral data")
-    data["axis"] = wavelength[::-1]
+    data["axis"] = wavelength_axis[::-1]
     data["intensity"] = spectral_intensity[::-1]
     profile_data = LongitudinalProfileFromData(data, np.min(t), np.max(t))
     field_data = profile_data.evaluate(t)


### PR DESCRIPTION
Editing LongitudinalProfileFromData to allow for monotonically decreasing spectral data (fix for https://github.com/LASY-org/lasy/issues/185) and adding relevant tests to test_laser_profiles. Currently no tests exist for LongitudinalProfileFromData, so adding tests for monotonically increasing/decreasing spectral data. Test for temporal data could be added in future.