### PR TITLE
Add spatio-temporal diagnostics in laser utilities

### DIFF
--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -874,9 +874,11 @@ def import_from_z(dim, grid, omega0, field_z, z_axis, z0=0.0, t0=0.0, backend="N
         field *= np.exp(1j * (z0 / c + t_axis) * omega0)
         grid.set_temporal_field(field)
 
+
 def get_STC(dim, grid, tau, w0, k0):
     r"""
     Calculate the spatio-temporal coupling factors of the laser.
+
     Parameters
     ----------
     dim : string


### PR DESCRIPTION
### PR Description

In the laser utilities, a new function, ```get_STC```, has been added to evaluate the STC parameters using the following formulas, with the laser envelope expressed as $a = a_0 e^{i\theta}$:
- The temporal chirp is calculated through
  $\\Phi^{(2)} = \\frac{4\\phi^{(2)}}{4(\\phi^{(2)})^2+\\tau^4}$
  Here $\\tau$ is duration in **_s_**, and `phi2` refers to group-delay dispersion $\\phi^{(2)} $, and $\\Phi^{(2)}$ can be calculated by $\\frac{\\partial^2 \\theta }{\\partial t ^2}$.
- Similarly, the spatial chirp is tested through:
  $\\nu = \\frac{4\\zeta }{w_0^2\\tau^2+4\\zeta^2}$
  Here $L_0$ and $w_0$ are the laser duration and laser waist respectively. $\\zeta$ is `zeta`, and $\\nu = \\frac{\\partial^2 \\theta }{\\partial t \\partial r} $, where $r = xcos(\\theta)+ysin(\\theta)$ in 3d ($\\theta$ is the direction angle of r on xoy plane). 
- Finally, the angular chirp term is tested through:
  $\\beta = \\frac{p-\\Phi^{(2)}\\nu}{ k_0}$
  with $p$ refering to the pulse front tilt $p = \\frac{dt}{dr}$

