### PR TITLE
Remove `omega0` from explicit inclusion in `optical_element`

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -183,9 +183,7 @@ class Laser:
             # The line below assumes that amplitude_multiplier
             # is cylindrically symmetric, hence we pass
             # `r` as `x` and 0 as `y`
-            multiplier = optical_element.amplitude_multiplier(
-                r, 0, omega
-            )
+            multiplier = optical_element.amplitude_multiplier(r, 0, omega)
             # The azimuthal modes are the components of the Fourier transform
             # along theta (FT_theta). Because the multiplier is assumed to be
             # cylindrically symmetric (i.e. theta-independent):
@@ -197,9 +195,7 @@ class Laser:
             x, y, omega = np.meshgrid(
                 self.grid.axes[0], self.grid.axes[1], self.omega_1d, indexing="ij"
             )
-            spectral_field *= optical_element.amplitude_multiplier(
-                x, y, omega
-            )
+            spectral_field *= optical_element.amplitude_multiplier(x, y, omega)
         self.grid.set_spectral_field(spectral_field)
 
     def propagate(

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -184,7 +184,7 @@ class Laser:
             # is cylindrically symmetric, hence we pass
             # `r` as `x` and 0 as `y`
             multiplier = optical_element.amplitude_multiplier(
-                r, 0, omega, self.profile.omega0
+                r, 0, omega
             )
             # The azimuthal modes are the components of the Fourier transform
             # along theta (FT_theta). Because the multiplier is assumed to be
@@ -198,7 +198,7 @@ class Laser:
                 self.grid.axes[0], self.grid.axes[1], self.omega_1d, indexing="ij"
             )
             spectral_field *= optical_element.amplitude_multiplier(
-                x, y, omega, self.profile.omega0
+                x, y, omega
             )
         self.grid.set_spectral_field(spectral_field)
 

--- a/lasy/optical_elements/axicon.py
+++ b/lasy/optical_elements/axicon.py
@@ -32,7 +32,7 @@ class Axicon(OpticalElement):
     def __init__(self, gamma):
         self.gamma = gamma
 
-    def amplitude_multiplier(self, x, y, omega, omega0):
+    def amplitude_multiplier(self, x, y, omega):
         """
         Return the amplitude multiplier.
 
@@ -41,9 +41,6 @@ class Axicon(OpticalElement):
         x, y, omega : ndarrays of floats
             Define points on which to evaluate the multiplier.
             These arrays need to all have the same shape.
-        omega0 : float (in rad/s)
-            Central angular frequency, as used for the definition
-            of the laser envelope.
 
         Returns
         -------

--- a/lasy/optical_elements/axiparabola.py
+++ b/lasy/optical_elements/axiparabola.py
@@ -33,7 +33,7 @@ class Axiparabola(OpticalElement):
         self.delta = delta
         self.R = R
 
-    def amplitude_multiplier(self, x, y, omega, omega0):
+    def amplitude_multiplier(self, x, y, omega):
         """
         Return the amplitude multiplier.
 
@@ -42,9 +42,6 @@ class Axiparabola(OpticalElement):
         x, y, omega : ndarrays of floats
             Define points on which to evaluate the multiplier.
             These arrays need to all have the same shape.
-        omega0 : float (in rad/s)
-            Central angular frequency, as used for the definition
-            of the laser envelope.
 
         Returns
         -------

--- a/lasy/optical_elements/optical_element.py
+++ b/lasy/optical_elements/optical_element.py
@@ -15,7 +15,7 @@ class OpticalElement(ABC):
         pass
 
     @abstractmethod
-    def amplitude_multiplier(self, x, y, omega, omega0):
+    def amplitude_multiplier(self, x, y, omega):
         r"""
         Return the amplitude multiplier :math:`T`.
 
@@ -36,9 +36,6 @@ class OpticalElement(ABC):
         x, y, omega : ndarrays of floats
             Define points on which to evaluate the multiplier.
             These arrays need to all have the same shape.
-        omega0 : float (in rad/s)
-            Central angular frequency, as used for the definition
-            of the laser envelope.
 
         Returns
         -------

--- a/lasy/optical_elements/parabolic_mirror.py
+++ b/lasy/optical_elements/parabolic_mirror.py
@@ -28,7 +28,7 @@ class ParabolicMirror(OpticalElement):
     def __init__(self, f):
         self.f = f
 
-    def amplitude_multiplier(self, x, y, omega, omega0):
+    def amplitude_multiplier(self, x, y, omega):
         """
         Return the amplitude multiplier.
 
@@ -37,9 +37,6 @@ class ParabolicMirror(OpticalElement):
         x, y, omega : ndarrays of floats
             Define points on which to evaluate the multiplier.
             These arrays need to all have the same shape.
-        omega0 : float (in rad/s)
-            Central angular frequency, as used for the definition
-            of the laser envelope.
 
         Returns
         -------

--- a/lasy/optical_elements/polynomial_spectral_phase.py
+++ b/lasy/optical_elements/polynomial_spectral_phase.py
@@ -42,7 +42,6 @@ class PolynomialSpectralPhase(OpticalElement):
         self.gdd = gdd
         self.tod = tod
         self.fod = fod
-        
 
     def amplitude_multiplier(self, x, y, omega):
         """
@@ -53,7 +52,7 @@ class PolynomialSpectralPhase(OpticalElement):
         x, y, omega : ndarrays of floats
             Define points on which to evaluate the multiplier.
             These arrays need to all have the same shape.
-        
+
 
         Returns
         -------

--- a/lasy/optical_elements/polynomial_spectral_phase.py
+++ b/lasy/optical_elements/polynomial_spectral_phase.py
@@ -33,14 +33,18 @@ class PolynomialSpectralPhase(OpticalElement):
         arriving after the main pulse.
     fod : float (in s^4), optional
         Fourth-order Dispersion (by default: ``fod=0``).
+    omega0 : float (in rad/s)
+        Central angular frequency about which the polynomial is expanded
     """
 
-    def __init__(self, gdd=0, tod=0, fod=0):
+    def __init__(self, omega0, gdd=0, tod=0, fod=0):
+        self.omega0 = omega0
         self.gdd = gdd
         self.tod = tod
         self.fod = fod
+        
 
-    def amplitude_multiplier(self, x, y, omega, omega0):
+    def amplitude_multiplier(self, x, y, omega):
         """
         Return the amplitude multiplier.
 
@@ -49,9 +53,7 @@ class PolynomialSpectralPhase(OpticalElement):
         x, y, omega : ndarrays of floats
             Define points on which to evaluate the multiplier.
             These arrays need to all have the same shape.
-        omega0 : float (in rad/s)
-            Central angular frequency, as used for the definition
-            of the laser envelope.
+        
 
         Returns
         -------
@@ -60,9 +62,9 @@ class PolynomialSpectralPhase(OpticalElement):
             This array has the same shape as the array omega.
         """
         spectral_phase = (
-            self.gdd / 2 * (omega - omega0) ** 2
-            + self.tod / 6 * (omega - omega0) ** 3
-            + self.fod / 24 * (omega - omega0) ** 4
+            self.gdd / 2 * (omega - self.omega0) ** 2
+            + self.tod / 6 * (omega - self.omega0) ** 3
+            + self.fod / 24 * (omega - self.omega0) ** 4
         )
 
         return np.exp(1j * spectral_phase)

--- a/tests/test_polynomial_spectral_phase.py
+++ b/tests/test_polynomial_spectral_phase.py
@@ -8,15 +8,15 @@ temporal shape of the laser pulse again analytical formulas.
 """
 
 import numpy as np
+from scipy.constants import c
 
 from lasy.laser import Laser
 from lasy.optical_elements import PolynomialSpectralPhase
 from lasy.profiles.gaussian_profile import GaussianProfile
-from scipy.constants import c
 
 # Laser parameters
 wavelength = 0.8e-6
-omega0 = 2*np.pi*c/wavelength
+omega0 = 2 * np.pi * c / wavelength
 w0 = 5.0e-6  # m
 pol = (1, 0)
 laser_energy = 1.0  # J
@@ -38,7 +38,7 @@ def test_gdd():
     analytical formula for a Gaussian pulse with GDD.
     """
     gdd = 200e-30
-    dazzler = PolynomialSpectralPhase(omega0,gdd=gdd)
+    dazzler = PolynomialSpectralPhase(omega0, gdd=gdd)
 
     # Initialize the laser
     dim = "xyt"
@@ -75,7 +75,7 @@ def test_tod():
     analytical formula from the stationary phase approximation.
     """
     tod = 5e-42
-    dazzler = PolynomialSpectralPhase(omega0,tod=tod)
+    dazzler = PolynomialSpectralPhase(omega0, tod=tod)
 
     # Initialize the laser
     dim = "xyt"

--- a/tests/test_polynomial_spectral_phase.py
+++ b/tests/test_polynomial_spectral_phase.py
@@ -12,9 +12,11 @@ import numpy as np
 from lasy.laser import Laser
 from lasy.optical_elements import PolynomialSpectralPhase
 from lasy.profiles.gaussian_profile import GaussianProfile
+from scipy.constants import c
 
 # Laser parameters
 wavelength = 0.8e-6
+omega0 = 2*np.pi*c/wavelength
 w0 = 5.0e-6  # m
 pol = (1, 0)
 laser_energy = 1.0  # J
@@ -36,7 +38,7 @@ def test_gdd():
     analytical formula for a Gaussian pulse with GDD.
     """
     gdd = 200e-30
-    dazzler = PolynomialSpectralPhase(gdd=gdd)
+    dazzler = PolynomialSpectralPhase(omega0,gdd=gdd)
 
     # Initialize the laser
     dim = "xyt"
@@ -73,7 +75,7 @@ def test_tod():
     analytical formula from the stationary phase approximation.
     """
     tod = 5e-42
-    dazzler = PolynomialSpectralPhase(tod=tod)
+    dazzler = PolynomialSpectralPhase(omega0,tod=tod)
 
     # Initialize the laser
     dim = "xyt"


### PR DESCRIPTION
I've made a **suggested** modification to the `optical_element` class to remove `omega0` from explicit inclusion in the method `amplitude_multiplier`. 

I find it somewhat confusing that we have both `omega` and `omega0` as input arguments. Seeing them both, I would automatically assume that the frequency axis `omega` is then actually centered around 0, and that `omega` is rather $\Delta \omega$ such that for each optical element we would need to use `omega + omega0` but this is not the case. Instead all but one of our optical elements do not use `omega0` at all.

I understand that this was specifically introduced in #261 for the case of polynomial spectral phase #263 . Here I believe we should instead add `omega0` as an argument required for initialisation of this optic. This optic adds spectral phase as a polynomial expansion of frequency and so defining the central frequency explicitly is, I think, a good idea.

In any case, as mentioned this is just a suggestion so totally fine to not make the change if people prefer it the way it is. Everything mechanically works great as is

@soerenjalas , could you take a look and see what you think, given you created the two PRs above