### PR TITLE
Correction in documentation of hermit_gaussian_profile.py

### DIFF
--- a/lasy/profiles/transverse/hermite_gaussian_profile.py
+++ b/lasy/profiles/transverse/hermite_gaussian_profile.py
@@ -60,7 +60,7 @@ class HermiteGaussianTransverseProfile(TransverseProfile):
         The order of hermite polynomial in the x direction
     n : int (dimensionless)
         The order of hermite polynomial in the y direction
-    wavelength : float (in meter), optional
+    wavelength : float (in meter)
         The main laser wavelength :math:`\lambda_0` of the laser.
     z_foc : float (in meter), optional
         Position of the focal plane. (The laser pulse is initialized at


### PR DESCRIPTION
With this pull request we aim to rectify a small error in documentation of hermit_gaussian_profile.py
In the documentation it mentions that input of wavelength parameter is optional, which is not the case. 