### PR TITLE
Modify mode decomposition to gain independent value of waist in x and y dimension

### DIFF
--- a/docs/source/tutorials/denoised_laser.ipynb
+++ b/docs/source/tutorials/denoised_laser.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "dcf32943-cf31-42c3-995c-2ed75c9761d2",
    "metadata": {},
    "outputs": [],
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "e4a2fd86-a83f-490e-9e10-21d0e3ca7c4d",
    "metadata": {},
    "outputs": [],
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "7ee0575d",
    "metadata": {},
    "outputs": [],
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "e70f703e-15a3-4751-a857-71b17651671a",
    "metadata": {},
    "outputs": [],
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "ac17f984",
    "metadata": {},
    "outputs": [],
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "ab6ecbd2-0b4e-4251-8709-ce741dc4174e",
    "metadata": {},
    "outputs": [],
@@ -315,7 +315,7 @@
     "n_max = 10\n",
     "\n",
     "# Calculate the decomposition and waist of the laser pulse\n",
-    "modeCoeffs, waist = hermite_gauss_decomposition(\n",
+    "modeCoeffs, waistX, waistY = hermite_gauss_decomposition(\n",
     "    transverse_profile,\n",
     "    longitudinal_profile.lambda0,\n",
     "    m_max=m_max,\n",
@@ -329,7 +329,7 @@
     "energy_frac = 0\n",
     "for i, mode_key in enumerate(list(modeCoeffs)):\n",
     "    tmp_transverse_profile = HermiteGaussianTransverseProfile(\n",
-    "        waist[0], waist[1], mode_key[0], mode_key[1], longitudinal_profile.lambda0\n",
+    "        waistX, waistY, mode_key[0], mode_key[1], longitudinal_profile.lambda0\n",
     "    )\n",
     "    energy_frac += modeCoeffs[mode_key] ** 2  # Energy fraction of the mode\n",
     "    if i == 0:  # First mode (0,0)\n",
@@ -367,7 +367,7 @@
    "source": [
     "# Plot the original and denoised profiles\n",
     "# Create a grid for plotting\n",
-    "x = np.linspace(-5 * waist[0], 5 * waist[0], 500)\n",
+    "x = np.linspace(-5 * waistX, 5 * waistX, 500)\n",
     "X, Y = np.meshgrid(x, x)\n",
     "\n",
     "# Determine the figure parameters\n",
@@ -502,7 +502,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },

--- a/docs/source/tutorials/denoised_laser.ipynb
+++ b/docs/source/tutorials/denoised_laser.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "dcf32943-cf31-42c3-995c-2ed75c9761d2",
    "metadata": {},
    "outputs": [],
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "e4a2fd86-a83f-490e-9e10-21d0e3ca7c4d",
    "metadata": {},
    "outputs": [],
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "7ee0575d",
    "metadata": {},
    "outputs": [],
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "e70f703e-15a3-4751-a857-71b17651671a",
    "metadata": {},
    "outputs": [],
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "ac17f984",
    "metadata": {},
    "outputs": [],
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "ab6ecbd2-0b4e-4251-8709-ce741dc4174e",
    "metadata": {},
    "outputs": [],

--- a/docs/source/tutorials/denoised_laser.ipynb
+++ b/docs/source/tutorials/denoised_laser.ipynb
@@ -329,7 +329,7 @@
     "energy_frac = 0\n",
     "for i, mode_key in enumerate(list(modeCoeffs)):\n",
     "    tmp_transverse_profile = HermiteGaussianTransverseProfile(\n",
-    "        waist, waist, mode_key[0], mode_key[1], longitudinal_profile.lambda0\n",
+    "        waist[0], waist[1], mode_key[0], mode_key[1], longitudinal_profile.lambda0\n",
     "    )\n",
     "    energy_frac += modeCoeffs[mode_key] ** 2  # Energy fraction of the mode\n",
     "    if i == 0:  # First mode (0,0)\n",
@@ -367,7 +367,7 @@
    "source": [
     "# Plot the original and denoised profiles\n",
     "# Create a grid for plotting\n",
-    "x = np.linspace(-5 * waist, 5 * waist, 500)\n",
+    "x = np.linspace(-5 * waist[0], 5 * waist[0], 500)\n",
     "X, Y = np.meshgrid(x, x)\n",
     "\n",
     "# Determine the figure parameters\n",
@@ -502,7 +502,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -516,7 +516,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/denoised_laser.ipynb
+++ b/docs/source/tutorials/denoised_laser.ipynb
@@ -516,7 +516,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/lasy/utils/mode_decomposition.py
+++ b/lasy/utils/mode_decomposition.py
@@ -148,7 +148,7 @@ def estimate_best_HG_waist(x, y, field, wavelength):
     waistTestY = np.linspace(w0EstY / 2, w0EstY * 1.5, 30)
     coeffTest = np.zeros_like(waistTestX)
 
-    for i in range(0, 30):
+    for i in range(30):
         # create a gaussian
         HGMode = HermiteGaussianTransverseProfile(
             waistTestX[i], waistTestY[i], 0, 0, wavelength

--- a/lasy/utils/mode_decomposition.py
+++ b/lasy/utils/mode_decomposition.py
@@ -50,7 +50,8 @@ def hermite_gauss_decomposition(
         in the decomposition. The keys of the dictionary are tuples
         corresponding to (`m`,`n`)
 
-    waist : Beam waist for which the decomposition is calculated.
+    waist : array of floats 
+        Beam waist for which the decomposition is calculated.
         It is computed as the waist for which the weight of order 0 is maximum.
     """
     # Check if the provided laserProfile is a transverse profile.
@@ -92,7 +93,7 @@ def hermite_gauss_decomposition(
     weights = {}
     for m in range(m_max):
         for n in range(n_max):
-            HGMode = HermiteGaussianTransverseProfile(w0, w0, m, n, wavelength)
+            HGMode = HermiteGaussianTransverseProfile(w0[0], w0[1], m, n, wavelength)
             coef = np.real(
                 np.sum(field * HGMode.evaluate(X, Y)) * dx * dy
             )  # modalDecomposition
@@ -126,8 +127,8 @@ def estimate_best_HG_waist(x, y, field, wavelength):
 
     Returns
     -------
-    w0 : scalar
-        The calculated waist.
+    w0 : array of floats
+        The calculated waist in x and y axis.
     """
     dx = x[1] - x[0]
     dy = y[1] - y[0]
@@ -136,20 +137,26 @@ def estimate_best_HG_waist(x, y, field, wavelength):
     X, Y = np.meshgrid(x, y)
 
     D4SigX, D4SigY = find_d4sigma(np.abs(field) ** 2)
-    w0Est = np.mean((D4SigX, D4SigY)) / 2 * dx  # convert this to a 1/e^2 width
+    # convert this to a 1/e^2 width
+    w0EstX = np.mean(D4SigX) / 2 * dx  
+    w0EstY = np.mean(D4SigY) / 2 * dy  
 
     # Scan around the waist obtained from the D4sigma calculation,
     # and keep the waist for which this HG mode has the highest scalar
     # product with the input profile.
-    waistTest = np.linspace(w0Est / 2, w0Est * 1.5, 30)
-    coeffTest = np.zeros_like(waistTest)
+    waistTestX = np.linspace(w0EstX / 2, w0EstX * 1.5, 30)
+    waistTestY = np.linspace(w0EstY / 2, w0EstY * 1.5, 30)
+    coeffTest  = np.zeros_like(waistTestX)
 
-    for i, wTest in enumerate(waistTest):
+    for i, wTest in enumerate(waistTestX):
         # create a gaussian
-        HGMode = HermiteGaussianTransverseProfile(wTest, wTest, 0, 0, wavelength)
+        HGMode = HermiteGaussianTransverseProfile(wTest, waistTestY[i], 0, 0, wavelength)
         profile = HGMode.evaluate(X, Y)
         coeffTest[i] = np.real(np.sum(profile * field))
-    w0 = waistTest[np.argmax(coeffTest)]
+    waistX = waistTestX[np.argmax(coeffTest)]
+    waistY = waistTestY[np.argmax(coeffTest)]
+    w0 = [waistX, waistY]
 
-    print("Estimated w0 = %.2f microns (1/e^2 width)" % (w0Est * 1e6))
+    print("Estimated w0(x-axis) = %.2f microns (1/e^2 width)" % (w0[0] * 1e6))
+    print("Estimated w0(y-axis) = %.2f microns (1/e^2 width)" % (w0[1] * 1e6))
     return w0

--- a/lasy/utils/mode_decomposition.py
+++ b/lasy/utils/mode_decomposition.py
@@ -50,7 +50,7 @@ def hermite_gauss_decomposition(
         in the decomposition. The keys of the dictionary are tuples
         corresponding to (`m`,`n`)
 
-    waist : array of floats 
+    waist : array of floats
         Beam waist for which the decomposition is calculated.
         It is computed as the waist for which the weight of order 0 is maximum.
     """
@@ -138,19 +138,21 @@ def estimate_best_HG_waist(x, y, field, wavelength):
 
     D4SigX, D4SigY = find_d4sigma(np.abs(field) ** 2)
     # convert this to a 1/e^2 width
-    w0EstX = np.mean(D4SigX) / 2 * dx  
-    w0EstY = np.mean(D4SigY) / 2 * dy  
+    w0EstX = np.mean(D4SigX) / 2 * dx
+    w0EstY = np.mean(D4SigY) / 2 * dy
 
     # Scan around the waist obtained from the D4sigma calculation,
     # and keep the waist for which this HG mode has the highest scalar
     # product with the input profile.
     waistTestX = np.linspace(w0EstX / 2, w0EstX * 1.5, 30)
     waistTestY = np.linspace(w0EstY / 2, w0EstY * 1.5, 30)
-    coeffTest  = np.zeros_like(waistTestX)
+    coeffTest = np.zeros_like(waistTestX)
 
     for i, wTest in enumerate(waistTestX):
         # create a gaussian
-        HGMode = HermiteGaussianTransverseProfile(wTest, waistTestY[i], 0, 0, wavelength)
+        HGMode = HermiteGaussianTransverseProfile(
+            wTest, waistTestY[i], 0, 0, wavelength
+        )
         profile = HGMode.evaluate(X, Y)
         coeffTest[i] = np.real(np.sum(profile * field))
     waistX = waistTestX[np.argmax(coeffTest)]

--- a/lasy/utils/mode_decomposition.py
+++ b/lasy/utils/mode_decomposition.py
@@ -148,7 +148,7 @@ def estimate_best_HG_waist(x, y, field, wavelength):
     waistTestY = np.linspace(w0EstY / 2, w0EstY * 1.5, 30)
     coeffTest = np.zeros_like(waistTestX)
 
-    for i in range(0,30):
+    for i in range(0, 30):
         # create a gaussian
         HGMode = HermiteGaussianTransverseProfile(
             waistTestX[i], waistTestY[i], 0, 0, wavelength

--- a/lasy/utils/mode_decomposition.py
+++ b/lasy/utils/mode_decomposition.py
@@ -50,7 +50,7 @@ def hermite_gauss_decomposition(
         in the decomposition. The keys of the dictionary are tuples
         corresponding to (`m`,`n`)
 
-    waist : array of floats
+    w0x, w0y : floats
         Beam waist for which the decomposition is calculated.
         It is computed as the waist for which the weight of order 0 is maximum.
     """
@@ -87,13 +87,13 @@ def hermite_gauss_decomposition(
     field = laserProfile.evaluate(X, Y)
 
     # Get estimate of w0
-    w0 = estimate_best_HG_waist(x, y, field, wavelength)
+    w0x, w0y = estimate_best_HG_waist(x, y, field, wavelength)
 
     # Next we loop over the modes and calculate the relevant weights
     weights = {}
     for m in range(m_max):
         for n in range(n_max):
-            HGMode = HermiteGaussianTransverseProfile(w0[0], w0[1], m, n, wavelength)
+            HGMode = HermiteGaussianTransverseProfile(w0x, w0y, m, n, wavelength)
             coef = np.real(
                 np.sum(field * HGMode.evaluate(X, Y)) * dx * dy
             )  # modalDecomposition
@@ -101,7 +101,7 @@ def hermite_gauss_decomposition(
                 coef = 0
             weights[(m, n)] = coef
 
-    return weights, w0
+    return weights, w0x, w0y
 
 
 def estimate_best_HG_waist(x, y, field, wavelength):
@@ -127,7 +127,7 @@ def estimate_best_HG_waist(x, y, field, wavelength):
 
     Returns
     -------
-    w0 : array of floats
+    w0x, w0y : floats
         The calculated waist in x and y axis.
     """
     dx = x[1] - x[0]
@@ -148,17 +148,16 @@ def estimate_best_HG_waist(x, y, field, wavelength):
     waistTestY = np.linspace(w0EstY / 2, w0EstY * 1.5, 30)
     coeffTest = np.zeros_like(waistTestX)
 
-    for i, wTest in enumerate(waistTestX):
+    for i in range(0,30):
         # create a gaussian
         HGMode = HermiteGaussianTransverseProfile(
-            wTest, waistTestY[i], 0, 0, wavelength
+            waistTestX[i], waistTestY[i], 0, 0, wavelength
         )
         profile = HGMode.evaluate(X, Y)
         coeffTest[i] = np.real(np.sum(profile * field))
-    waistX = waistTestX[np.argmax(coeffTest)]
-    waistY = waistTestY[np.argmax(coeffTest)]
-    w0 = [waistX, waistY]
+    w0x = waistTestX[np.argmax(coeffTest)]
+    w0y = waistTestY[np.argmax(coeffTest)]
 
-    print("Estimated w0(x-axis) = %.2f microns (1/e^2 width)" % (w0[0] * 1e6))
-    print("Estimated w0(y-axis) = %.2f microns (1/e^2 width)" % (w0[1] * 1e6))
-    return w0
+    print("Estimated w0(x-axis) = %.2f microns (1/e^2 width)" % (w0x * 1e6))
+    print("Estimated w0(y-axis) = %.2f microns (1/e^2 width)" % (w0y * 1e6))
+    return w0x, w0y


### PR DESCRIPTION
Merge before #315

The following pull request aims to modify mode decomposition in a way that the waist is no longer a simple circle, but has independent values in x and y direction. The task is performed in to make utility consistent with the rest of the code, in light of recent changes to HermiteGaussianTransverseProfile.