### PR TITLE
Utility to make laser periodic on the grid

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -377,7 +377,7 @@ class Laser:
             if Nvalue == 1:
                 make_periodic_on_grid(self.dim, value, self.grid)
             else:
-                make_periodic_on_grid(self.dim, value[0], self.grid, sg_order=value[1])                
+                make_periodic_on_grid(self.dim, value[0], self.grid, sg=value[1])                
         else:
             raise ValueError(f'kind "{kind}" not recognized')
 

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -7,6 +7,7 @@ from lasy.utils.laser_utils import (
     normalize_energy,
     normalize_peak_field_amplitude,
     normalize_peak_intensity,
+    make_periodic_on_grid,
 )
 from lasy.utils.openpmd_output import write_to_openpmd_file
 
@@ -353,6 +354,28 @@ class Laser:
         self.grid.hi[time_axis_indx] += translate_time
         self.grid.axes[time_axis_indx] += translate_time
 
+    def make_periodic(self, value, kind="grid"):
+        """
+        Make the laser periodic. Currently supported option is "grid"
+
+        Parameters
+        ----------
+        value : array_like
+            Value(s) used for applying periodicity, defined in ``kind``
+
+        kind : string (optional)
+            Options: ``'grid``' (default is ``'grid'``)
+            grid: periodicity is enforced on the grid by Fourier transforming the spatial profile and applying a filter with maximum k given by value[0] (mandatory) and super-Gaussian order given by value[1] (optional, default is 4)
+        """
+        if kind == "grid":
+            if len(value) == 1:
+                make_periodic_on_grid(self.dim, value, self.grid)
+            else:
+                make_periodic_on_grid(self.dim, value[0], self.grid, sg_order=value[1])                
+        else:
+            raise ValueError(f'kind "{kind}" not recognized')
+
+    
     def write_to_file(
         self,
         file_prefix="laser",

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -4,11 +4,11 @@ from scipy.constants import c
 
 from lasy.utils.grid import Grid, time_axis_indx
 from lasy.utils.laser_utils import (
+    make_periodic_on_grid,
     normalize_average_intensity,
     normalize_energy,
     normalize_peak_field_amplitude,
     normalize_peak_intensity,
-    make_periodic_on_grid,
 )
 from lasy.utils.openpmd_output import write_to_openpmd_file
 
@@ -383,7 +383,7 @@ class Laser:
                 make_periodic_on_grid(self.dim, value[0], self.grid, n_order=value[1])
         else:
             raise ValueError(f'kind "{kind}" not recognized')
-    
+
     def write_to_file(
         self,
         file_prefix="laser",

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -360,15 +360,21 @@ class Laser:
 
         Parameters
         ----------
-        value : array_like
+        value : scalar or array_like
             Value(s) used for applying periodicity, defined in ``kind``
 
         kind : string (optional)
             Options: ``'grid``' (default is ``'grid'``)
             grid: periodicity is enforced on the grid by Fourier transforming the spatial profile and applying a filter with maximum k given by value[0] (mandatory) and super-Gaussian order given by value[1] (optional, default is 4)
         """
+        # get length of value
+        try:
+            Nvalue = len(value)
+        except:
+            Nvalue = 1
+            
         if kind == "grid":
-            if len(value) == 1:
+            if Nvalue == 1:
                 make_periodic_on_grid(self.dim, value, self.grid)
             else:
                 make_periodic_on_grid(self.dim, value[0], self.grid, sg_order=value[1])                

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -375,15 +375,14 @@ class Laser:
             Nvalue = len(value)
         except:
             Nvalue = 1
-            
+
         if kind == "grid":
             if Nvalue == 1:
                 make_periodic_on_grid(self.dim, value, self.grid)
             else:
-                make_periodic_on_grid(self.dim, value[0], self.grid, sg=value[1])                
+                make_periodic_on_grid(self.dim, value[0], self.grid, sg=value[1])
         else:
             raise ValueError(f'kind "{kind}" not recognized')
-
     
     def write_to_file(
         self,

--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -368,7 +368,7 @@ class Laser:
 
         kind : string (optional)
             Options: ``'grid``' (default is ``'grid'``)
-            grid: periodicity is enforced on the grid by Fourier transforming the spatial profile and applying a filter with maximum k given by value[0] (mandatory) and super-Gaussian order given by value[1] (optional, default is 4)
+            grid: periodicity is enforced on the grid by Fourier transforming the spatial profile and applying a filter with maximum k given by value[0] (mandatory) and super-Gaussian order given by value[1] (optional, default is 8)
         """
         # get length of value
         try:
@@ -380,7 +380,7 @@ class Laser:
             if Nvalue == 1:
                 make_periodic_on_grid(self.dim, value, self.grid)
             else:
-                make_periodic_on_grid(self.dim, value[0], self.grid, sg=value[1])
+                make_periodic_on_grid(self.dim, value[0], self.grid, n_order=value[1])
         else:
             raise ValueError(f'kind "{kind}" not recognized')
     

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1134,8 +1134,6 @@ def make_periodic_on_grid(dim, kmax, grid, sg_order=4):
 
     # Transform the field from spatial to wavenumber domain
     field_fft = np.fft.fftn(field, axes=(0,1))
-    # center zero frequency to make application of filter easier
-    field_fft = np.fft.fftshift(field_fft, axes=(0,1))
     # Create the axes for wavenumbers
     kx = 2 * np.pi * np.fft.fftfreq(Nx, grid.dx[0])
     ky = 2 * np.pi * np.fft.fftfreq(Ny, grid.dx[1])
@@ -1144,7 +1142,6 @@ def make_periodic_on_grid(dim, kmax, grid, sg_order=4):
     filt = np.exp(-((kx_g**2+ky_g**2)/(kmax**2))**sg_order)
     field_fft *= np.repeat(filt[:,:,np.newaxis],Nt,axis=2)
     # inverse transform
-    field_fft = np.fft.ifftshift(field_fft, axes=(0,1))
     field = np.fft.ifftn(field_fft, axes=(0,1))
     grid.set_temporal_field(field)
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1105,7 +1105,7 @@ def get_propation_angle(dim, grid, k0):
     angle_y = np.average(pphi_py, weights=env_abs2) / k0
     return [angle_x, angle_y]
 
-def make_periodic_on_grid(dim, kmax, grid, sg_order=4):
+def make_periodic_on_grid(dim, kmax, grid, sg=4):
     r"""
     Makes the laser periodic on the grid. This is done by applying a low-pass super-Gaussian filter to the spatially Fouier transformed field. 
 
@@ -1124,8 +1124,8 @@ def make_periodic_on_grid(dim, kmax, grid, sg_order=4):
     grid : a Grid object.
         It contains an ndarray (V/m) with the value of the envelope field and the associated metadata that defines the points at which the laser is defined.
 
-    sg_order : scalar
-        Super-Gaussian order of the filter, exp(-(k**2/kmax**2)**sg_order
+    sg : scalar
+        Super-Gaussian order of the filter, exp(-(k**2/kmax**2)**sg
     """
     assert dim == "xyt", "Only cartesian domains are currently supported."
     
@@ -1139,7 +1139,7 @@ def make_periodic_on_grid(dim, kmax, grid, sg_order=4):
     ky = 2 * np.pi * np.fft.fftfreq(Ny, grid.dx[1])
     [ky_g,kx_g] = np.meshgrid(ky,kx)
     # filter
-    filt = np.exp(-((kx_g**2+ky_g**2)/(kmax**2))**sg_order)
+    filt = np.exp(-((kx_g**2+ky_g**2)/(kmax**2))**sg)
     field_fft *= np.repeat(filt[:,:,np.newaxis],Nt,axis=2)
     # inverse transform
     field = np.fft.ifftn(field_fft, axes=(0,1))

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1139,7 +1139,7 @@ def make_periodic_on_grid(dim, kmax, grid, sg_order=4):
     # Create the axes for wavenumbers
     kx = 2 * np.pi * np.fft.fftfreq(Nx, grid.dx[0])
     ky = 2 * np.pi * np.fft.fftfreq(Ny, grid.dx[1])
-    [ky_g,kx_g] = np.meshgrid[ky,kx]
+    [ky_g,kx_g] = np.meshgrid(ky,kx)
     # filter
     filt = np.exp(-((kx**2+ky**2)/(kmax**2))**sg_order)
     field_fft *= filt

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1163,7 +1163,7 @@ def make_periodic_on_grid(dim, kmax, grid, n_order=8):
     ky = 2 * np.pi * np.fft.fftfreq(Ny, grid.dx[1])
     [ky_g,kx_g] = np.meshgrid(ky,kx)
     # filter
-    filt = np.exp(-(kx_g**2+ky_g**2)/(kmax**2),n_order/2)
+    filt = np.exp(-np.power((kx_g**2+ky_g**2)/(kmax**2),n_order/2))
     field_fft *= np.repeat(filt[:,:,np.newaxis],Nt,axis=2)
     # inverse transform
     field = np.fft.ifftn(field_fft, axes=(0,1))

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1139,7 +1139,7 @@ def make_periodic_on_grid(dim, kmax, grid, sg_order=4):
     # Create the axes for wavenumbers
     kx = 2 * np.pi * np.fft.fftfreq(Nx, grid.dx[0])
     ky = 2 * np.pi * np.fft.fftfreq(Ny, grid.dx[1])
-    [ky_g,kx_g] = np.meshgrid[ky_g,kx_g]
+    [ky_g,kx_g] = np.meshgrid[ky,kx]
     # filter
     filt = np.exp(-((kx**2+ky**2)/(kmax**2))**sg_order)
     field_fft *= filt

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1128,6 +1128,7 @@ def get_propation_angle(dim, grid, k0):
     angle_y = np.average(pphi_py, weights=env_abs2) / k0
     return [angle_x, angle_y]
 
+
 def make_periodic_on_grid(dim, kmax, grid, n_order=8):
     r"""
     Makes the laser periodic on the grid. This is done by applying a low-pass super-Gaussian filter to the spatially Fouier transformed field.
@@ -1157,14 +1158,14 @@ def make_periodic_on_grid(dim, kmax, grid, n_order=8):
     Nx, Ny, Nt = field.shape
 
     # Transform the field from spatial to wavenumber domain
-    field_fft = np.fft.fftn(field, axes=(0,1))
+    field_fft = np.fft.fftn(field, axes=(0, 1))
     # Create the axes for wavenumbers
     kx = 2 * np.pi * np.fft.fftfreq(Nx, grid.dx[0])
     ky = 2 * np.pi * np.fft.fftfreq(Ny, grid.dx[1])
-    [ky_g,kx_g] = np.meshgrid(ky,kx)
+    [ky_g, kx_g] = np.meshgrid(ky, kx)
     # filter
-    filt = np.exp(-np.power((kx_g**2+ky_g**2)/(kmax**2),n_order/2))
-    field_fft *= np.repeat(filt[:,:,np.newaxis],Nt,axis=2)
+    filt = np.exp(-np.power((kx_g**2 + ky_g**2) / (kmax**2), n_order / 2))
+    field_fft *= np.repeat(filt[:, :, np.newaxis], Nt, axis=2)
     # inverse transform
-    field = np.fft.ifftn(field_fft, axes=(0,1))
+    field = np.fft.ifftn(field_fft, axes=(0, 1))
     grid.set_temporal_field(field)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1130,7 +1130,7 @@ def get_propation_angle(dim, grid, k0):
 
 def make_periodic_on_grid(dim, kmax, grid, sg=4):
     r"""
-    Makes the laser periodic on the grid. This is done by applying a low-pass super-Gaussian filter to the spatially Fouier transformed field. 
+    Makes the laser periodic on the grid. This is done by applying a low-pass super-Gaussian filter to the spatially Fouier transformed field.
 
     Parameters
     ----------
@@ -1151,7 +1151,7 @@ def make_periodic_on_grid(dim, kmax, grid, sg=4):
         Super-Gaussian order of the filter, exp(-(k**2/kmax**2)**sg
     """
     assert dim == "xyt", "Only cartesian domains are currently supported."
-    
+
     field = grid.get_temporal_field()
     Nx, Ny, Nt = field.shape
 
@@ -1167,5 +1167,3 @@ def make_periodic_on_grid(dim, kmax, grid, sg=4):
     # inverse transform
     field = np.fft.ifftn(field_fft, axes=(0,1))
     grid.set_temporal_field(field)
-
-    

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1128,7 +1128,7 @@ def get_propation_angle(dim, grid, k0):
     angle_y = np.average(pphi_py, weights=env_abs2) / k0
     return [angle_x, angle_y]
 
-def make_periodic_on_grid(dim, kmax, grid, sg=4):
+def make_periodic_on_grid(dim, kmax, grid, n_order=8):
     r"""
     Makes the laser periodic on the grid. This is done by applying a low-pass super-Gaussian filter to the spatially Fouier transformed field.
 
@@ -1147,8 +1147,9 @@ def make_periodic_on_grid(dim, kmax, grid, sg=4):
     grid : a Grid object.
         It contains an ndarray (V/m) with the value of the envelope field and the associated metadata that defines the points at which the laser is defined.
 
-    sg : scalar
-        Super-Gaussian order of the filter, exp(-(k**2/kmax**2)**sg
+    n_order : scalar (optional)
+        Super-Gaussian order of the filter, exp(-(k**2/kmax**2)**(n_order/2))
+        If :math:`n=2` the super-Gaussian becomes a standard Gaussian function.
     """
     assert dim == "xyt", "Only cartesian domains are currently supported."
 
@@ -1162,7 +1163,7 @@ def make_periodic_on_grid(dim, kmax, grid, sg=4):
     ky = 2 * np.pi * np.fft.fftfreq(Ny, grid.dx[1])
     [ky_g,kx_g] = np.meshgrid(ky,kx)
     # filter
-    filt = np.exp(-((kx_g**2+ky_g**2)/(kmax**2))**sg)
+    filt = np.exp(-(kx_g**2+ky_g**2)/(kmax**2),n_order/2)
     field_fft *= np.repeat(filt[:,:,np.newaxis],Nt,axis=2)
     # inverse transform
     field = np.fft.ifftn(field_fft, axes=(0,1))

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1142,7 +1142,7 @@ def make_periodic_on_grid(dim, kmax, grid, sg_order=4):
     [ky_g,kx_g] = np.meshgrid(ky,kx)
     # filter
     filt = np.exp(-((kx_g**2+ky_g**2)/(kmax**2))**sg_order)
-    field_fft *= filt
+    field_fft *= np.repeat(filt[:,:,np.newaxis],Nt,axis=2)
     # inverse transform
     field_fft = np.fft.ifftshift(field_fft, axes=(0,1))
     field = np.fft.ifftn(field_fft, axes=(0,1))

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1141,7 +1141,7 @@ def make_periodic_on_grid(dim, kmax, grid, sg_order=4):
     ky = 2 * np.pi * np.fft.fftfreq(Ny, grid.dx[1])
     [ky_g,kx_g] = np.meshgrid(ky,kx)
     # filter
-    filt = np.exp(-((kx**2+ky**2)/(kmax**2))**sg_order)
+    filt = np.exp(-((kx_g**2+ky_g**2)/(kmax**2))**sg_order)
     field_fft *= filt
     # inverse transform
     field_fft = np.fft.ifftshift(field_fft, axes=(0,1))


### PR DESCRIPTION
Adds a utility to make the laser periodic over the spatial domain

Periodicity on the grid is enforced by a low-pass spatial Fourier filter. The filter is super-Gaussian with run-time specified super-Gaussian order and FHWM k in each direction.