### PR TITLE
Allows reading laser envelope from Wake-T

### DIFF
--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -68,9 +68,7 @@ class FromArrayProfile(Profile):
             )
         else:  # dim = "rt"
             assert axes_order in [["r", "t"], ["t", "r"]]
-            assert len(array.shape) == 3, (
-                "Field array is not 3D."
-            )
+            assert len(array.shape) == 3, "Field array is not 3D."
 
             if axes_order == ["t", "r"]:
                 self.array = np.swapaxes(array, 1, 2)
@@ -81,8 +79,10 @@ class FromArrayProfile(Profile):
             # to make correct interpolation within the first cell
             if axes["r"][0] != 0.0:
                 r = np.concatenate(([-axes["r"][0]], axes["r"]))
-                subarray = array[:,0,:]  # takes first element in second dimension
-                array = np.concatenate((subarray[:, np.newaxis, :], array), axis=1)  # add it at the beginning 
+                subarray = array[:, 0, :]  # takes first element in second dimension
+                array = np.concatenate(
+                    (subarray[:, np.newaxis, :], array), axis=1
+                )  # add it at the beginning
             else:
                 r = axes["r"]
 

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -68,9 +68,12 @@ class FromArrayProfile(Profile):
             )
         else:  # dim = "rt"
             assert axes_order in [["r", "t"], ["t", "r"]]
+            assert len(array.shape) == 3, (
+                "Field array is not 3D."
+            )
 
             if axes_order == ["t", "r"]:
-                self.array = np.swapaxes(array, 0, 2)
+                self.array = np.swapaxes(array, 1, 2)
             else:
                 self.array = array
 
@@ -78,7 +81,8 @@ class FromArrayProfile(Profile):
             # to make correct interpolation within the first cell
             if axes["r"][0] != 0.0:
                 r = np.concatenate(([-axes["r"][0]], axes["r"]))
-                array = np.concatenate(([array[0]], array))
+                subarray = array[:,0,:]  # takes first element in second dimension
+                array = np.concatenate((subarray[:, np.newaxis, :], array), axis=1)  # add it at the beginning 
             else:
                 r = axes["r"]
 
@@ -86,11 +90,10 @@ class FromArrayProfile(Profile):
             # However, when reading lasy envelope files, the array is 3D.
             # First dimension corresponds to the azimuthal mode decomposition.
             # For now, this only fix profiles with one mode.
-            if len(array.shape) == 3:
-                assert array.shape[0] == 1, (
-                    "Handling `rt` profiles with more than one azimuthal mode still needs to be implemented."
-                )
-                array = array[0]
+            assert array.shape[0] == 1, (
+                "Handling `rt` profiles with more than one azimuthal mode still needs to be implemented."
+            )
+            array = array[0]
 
             self.combined_field_interp = RegularGridInterpolator(
                 (r, axes["t"]),

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -1,7 +1,7 @@
 import numpy as np
 import openpmd_api as io
 from openpmd_viewer import OpenPMDTimeSeries
-from scipy.constants import c
+from scipy.constants import c, m_e, e
 
 from lasy.utils.laser_utils import create_grid, field_to_envelope
 from lasy.utils.openpmd_input import reorder_array
@@ -57,6 +57,10 @@ class FromOpenPMDProfile(FromArrayProfile):
         corresponding to the plane of observation given by `theta`;
         otherwise it returns a full 3D Cartesian array.
 
+    lambda0 : float or None, optional
+        Use this as the central wavelength.
+        Only used when envelope=True.
+
     phase_unwrap_nd : boolean (optional)
         If True, the phase unwrapping is n-dimensional (2- or 3-D depending on dim).
         If False, the phase unwrapping is done in t, treating each transverse cell
@@ -75,8 +79,10 @@ class FromOpenPMDProfile(FromArrayProfile):
         field,
         coord=None,
         is_envelope=None,
+        is_waket=None,
         prefix=None,
         theta=None,
+        lambda0=None,
         phase_unwrap_nd=False,
         verbose=False,
     ):
@@ -110,7 +116,16 @@ class FromOpenPMDProfile(FromArrayProfile):
         if not is_envelope:
             grid = create_grid(F, axes, dim, is_envelope=is_envelope)
             grid, omg0 = field_to_envelope(grid, dim, phase_unwrap_nd)
-            array = grid.get_temporal_field()[0]
+            array = grid.get_temporal_field()
+        elif lambda0 > 0:
+            k0 = 2 * np.pi / lambda0
+            omg0 = k0 * c
+            array = (m_e * c**2 * k0 / e) * F
+        elif is_waket:
+            s = io.Series(path + "/" + prefix + "%T.h5", io.Access.read_only)
+            it = s.iterations[iteration]
+            omg0 = it.meshes["a"].get_attribute("angularFrequency")
+            array = F
         else:
             s = io.Series(path + "/" + prefix + "_%T.h5", io.Access.read_only)
             it = s.iterations[iteration]

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -1,7 +1,7 @@
 import numpy as np
 import openpmd_api as io
 from openpmd_viewer import OpenPMDTimeSeries
-from scipy.constants import c, m_e, e
+from scipy.constants import c, e, m_e
 
 from lasy.utils.laser_utils import create_grid, field_to_envelope
 from lasy.utils.openpmd_input import reorder_array

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -117,20 +117,21 @@ class FromOpenPMDProfile(FromArrayProfile):
             grid = create_grid(F, axes, dim, is_envelope=is_envelope)
             grid, omg0 = field_to_envelope(grid, dim, phase_unwrap_nd)
             array = grid.get_temporal_field()
-        elif lambda0 > 0:
-            k0 = 2 * np.pi / lambda0
-            omg0 = k0 * c
-            array = (m_e * c**2 * k0 / e) * F
-        elif is_waket:
-            s = io.Series(path + "/" + prefix + "%T.h5", io.Access.read_only)
-            it = s.iterations[iteration]
-            omg0 = it.meshes["a"].get_attribute("angularFrequency")
-            array = F
         else:
-            s = io.Series(path + "/" + prefix + "_%T.h5", io.Access.read_only)
+            if is_waket:
+                filepath = path + "/" + prefix + "%T.h5"
+            else:
+                filepath = path + "/" + prefix + "_%T.h5"
+            s = io.Series(filepath, io.Access.read_only)
             it = s.iterations[iteration]
-            omg0 = it.meshes["laserEnvelope"].get_attribute("angularFrequency")
+            omg0 = it.meshes[field].get_attribute("angularFrequency")
             array = F
+
+        if lambda0:
+            omg0 = 2 * np.pi * c / lambda0
+
+        if field == "a":
+            array = (m_e * c * omg0 / e) * array
 
         wavelength = 2 * np.pi * c / omg0
         if verbose:

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -543,7 +543,7 @@ def field_to_vector_potential(grid, omega0):
 
 def vector_potential_to_field(grid, omega0, direct=True):
     """
-    Convert envelope from electric field (V/m) to normalized vector potential.
+    Convert envelope from vector potential to electric field (V/m).
 
     Parameters
     ----------


### PR DESCRIPTION
Reading Wake-T files with `FromOpenPMDProfile` was not working well.
This PR includes a patch to make it work. 
It may serve as a basis to discuss a better and more general implementation of `FromOpenPMDProfile` and `FromArrayProfile` classes.

- A first issue was in the way that this method access the `angularFrequency` attribute in the hdf5 file, which is very specific for `LASY` envelope files only. Now, a new variable `is_waket` can be passed to `FromOpenPMDProfile` to read the Wake-T file. We should generalize the method. In the meantime this serves as a patch.
- Second issue was in the parent class `FromArrayProfile`, which still treated the field array as 2D in some cases. This PR implement that the field array is always 3D.
- A third and separate issue is on the way the laser `angularFrequency` is calculated when reading from a non-envelope laser file, such as the ones provided by FBPIC. In these cases, `FromOpenPMDProfile` obtains the central frequency with the `field_to_envelope` method. However, I have observed non-sensical values of this parameter. This affected the vector potential, `a`, to electric field, `E`, envelope transformation when reading Wake-T files, which needs the right value for the central angular frequency of the laser.
- To allow for a proper `a` to `E` transformation when reading from Wake-T envelope files, and to circumvent the problem on the previous point, this PR allows `lambda0` to be passed directly to `FromOpenPMDProfile`, so this value will be used instead of the one calculated by `field_to_envelope`.