### PR TITLE
New Optical Element - Intensity Mask

### DIFF
--- a/lasy/optical_elements/__init__.py
+++ b/lasy/optical_elements/__init__.py
@@ -2,5 +2,6 @@ from .axicon import Axicon
 from .axiparabola import Axiparabola
 from .parabolic_mirror import ParabolicMirror
 from .polynomial_spectral_phase import PolynomialSpectralPhase
+from .intensity_mask import IntensityMask
 
-__all__ = ["ParabolicMirror", "PolynomialSpectralPhase", "Axiparabola", "Axicon"]
+__all__ = ["ParabolicMirror", "PolynomialSpectralPhase", "Axiparabola", "Axicon", "IntensityMask"]

--- a/lasy/optical_elements/__init__.py
+++ b/lasy/optical_elements/__init__.py
@@ -1,7 +1,13 @@
 from .axicon import Axicon
 from .axiparabola import Axiparabola
+from .intensity_mask import IntensityMask
 from .parabolic_mirror import ParabolicMirror
 from .polynomial_spectral_phase import PolynomialSpectralPhase
-from .intensity_mask import IntensityMask
 
-__all__ = ["ParabolicMirror", "PolynomialSpectralPhase", "Axiparabola", "Axicon", "IntensityMask"]
+__all__ = [
+    "ParabolicMirror",
+    "PolynomialSpectralPhase",
+    "Axiparabola",
+    "Axicon",
+    "IntensityMask",
+]

--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -1,6 +1,3 @@
-import numpy as np
-from scipy.constants import c
-
 from lasy.optical_elements.optical_element import OpticalElement
 
 
@@ -20,7 +17,9 @@ class IntensityMask(OpticalElement):
     """
 
     def __init__(self, R, center=(0, 0), aperture_type="aperture"):
-        assert aperture_type in ["aperture", "hole"], "aperture_type must be 'aperture' or 'hole'"
+        assert aperture_type in ["aperture", "hole"], (
+            "aperture_type must be 'aperture' or 'hole'"
+        )
         self.R = R
         self.center = center
         self.aperture_type = aperture_type
@@ -44,7 +43,7 @@ class IntensityMask(OpticalElement):
             Contains the value of the multiplier at the specified points.
             This array has the same shape as the array omega.
         """
-        r_squared = (x - self.center[0])**2 + (y - self.center[1])**2
+        r_squared = (x - self.center[0]) ** 2 + (y - self.center[1]) ** 2
         mask = r_squared <= self.R**2  # True inside, False outside
 
         if self.aperture_type == "aperture":

--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -3,26 +3,31 @@ from lasy.optical_elements.optical_element import OpticalElement
 
 class IntensityMask(OpticalElement):
     """
-    Class for adding an radially symmetric intensity mask that acts as an aperture or a hole.
+    Class for a radially symmetric intensity mask.
+    
+    This creates an optical element which acts to mask out the intensity of a laser pulse. 
+    The mask is radially symmetric and can either mask intensity beyond a user defined radius, thus acting as
+    an aperture. Alternatively, the optica can mask intensity within a user defined radius, acting in this case as 
+    an optic with a hole.
 
     Parameters
     ----------
     R : float (in meter)
-        The Radius of the mask
+        The radius of the mask
     center: tuple (floats)
         Center of the mask. Default is (0,0)
-    aperture_type: string
+    mask_type: string
         Should be 'aperture' (default, allows light inside) or 'hole' (allows light outside).
 
     """
 
-    def __init__(self, R, center=(0, 0), aperture_type="aperture"):
-        assert aperture_type in ["aperture", "hole"], (
-            "aperture_type must be 'aperture' or 'hole'"
+    def __init__(self, R, center=(0, 0), mask_type="aperture"):
+        assert mask_type in ["aperture", "hole"], (
+            "mask_type must be 'aperture' or 'hole'"
         )
         self.R = R
         self.center = center
-        self.aperture_type = aperture_type
+        self.mask_type = mask_type
 
     def amplitude_multiplier(self, x, y, omega):
         """
@@ -46,7 +51,7 @@ class IntensityMask(OpticalElement):
         r_squared = (x - self.center[0]) ** 2 + (y - self.center[1]) ** 2
         mask = r_squared <= self.R**2  # True inside, False outside
 
-        if self.aperture_type == "aperture":
+        if self.mask_type == "aperture":
             return mask.astype(float)  # 1 inside, 0 outside
         else:  # "hole"
             return (~mask).astype(float)  # 0 inside, 1 outside

--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -1,0 +1,53 @@
+import numpy as np
+from scipy.constants import c
+
+from lasy.optical_elements.optical_element import OpticalElement
+
+
+class IntensityMask(OpticalElement):
+    """
+    Class for adding an radially symmetric intensity mask that acts as an aperture or a hole.
+
+    Parameters
+    ----------
+    R : float (in meter)
+        The Radius of the mask
+    center: tuple (floats)
+        Center of the mask. Default is (0,0)
+    aperture_type: string
+        Should be 'aperture' (default, allows light inside) or 'hole' (allows light outside).
+
+    """
+
+    def __init__(self, R, center=(0, 0), aperture_type="aperture"):
+        assert aperture_type in ["aperture", "hole"], "aperture_type must be 'aperture' or 'hole'"
+        self.R = R
+        self.center = center
+        self.aperture_type = aperture_type
+
+    def amplitude_multiplier(self, x, y, omega):
+        """
+        Return the amplitude multiplier.
+
+        Parameters
+        ----------
+        x, y, omega : ndarrays of floats
+            Define points on which to evaluate the multiplier.
+            These arrays need to all have the same shape.
+        omega0 : float (in rad/s)
+            Central angular frequency, as used for the definition
+            of the laser envelope.
+
+        Returns
+        -------
+        multiplier : ndarray of complex numbers
+            Contains the value of the multiplier at the specified points.
+            This array has the same shape as the array omega.
+        """
+        r_squared = (x - self.center[0])**2 + (y - self.center[1])**2
+        mask = r_squared <= self.R**2  # True inside, False outside
+
+        if self.aperture_type == "aperture":
+            return mask.astype(float)  # 1 inside, 0 outside
+        else:  # "hole"
+            return (~mask).astype(float)  # 0 inside, 1 outside

--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -38,9 +38,6 @@ class IntensityMask(OpticalElement):
         x, y, omega : ndarrays of floats
             Define points on which to evaluate the multiplier.
             These arrays need to all have the same shape.
-        omega0 : float (in rad/s)
-            Central angular frequency, as used for the definition
-            of the laser envelope.
 
         Returns
         -------

--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -4,10 +4,10 @@ from lasy.optical_elements.optical_element import OpticalElement
 class IntensityMask(OpticalElement):
     """
     Class for a radially symmetric intensity mask.
-    
-    This creates an optical element which acts to mask out the intensity of a laser pulse. 
+
+    This creates an optical element which acts to mask out the intensity of a laser pulse.
     The mask is radially symmetric and can either mask intensity beyond a user defined radius, thus acting as
-    an aperture. Alternatively, the optica can mask intensity within a user defined radius, acting in this case as 
+    an aperture. Alternatively, the optica can mask intensity within a user defined radius, acting in this case as
     an optic with a hole.
 
     Parameters


### PR DESCRIPTION
Adds functionality to mask out the intensity of different regions of the beam. This could for example be used to mimic the effect of an aperture or a optic with a hole ( see issue #345) 