### PR TITLE
[mini]Fix a bug when weight approaches zero in get_zeta function

### DIFF
--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1011,12 +1011,9 @@ def get_zeta(dim, grid, k0):
     weight_y_3d = np.transpose(env_spec_abs2, (2, 0, 1))
     sum_x = np.sum(weight_x_3d, axis=2)
     sum_y = np.sum(weight_y_3d, axis=2)
-    if np.any(sum_x == 0) or np.any(sum_y == 0):
-        print("Warning: Zero weight sum encountered!")
-    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (sum_x + 1e-20)
-    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (
-        sum_y + 1e-20
-    )  # Add a small epsilon
+    eps_wgt = 1e-20 if np.any(sum_x == 0) or np.any(sum_y == 0) else 0
+    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (sum_x + eps_wgt)
+    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (sum_y + eps_wgt) 
     # Calculate spatial chirp zeta
     derivative_x_zeta = np.gradient(xda, omega, axis=0)
     derivative_y_zeta = np.gradient(yda, omega, axis=0)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1011,9 +1011,9 @@ def get_zeta(dim, grid, k0):
     weight_y_3d = np.transpose(env_spec_abs2, (2, 0, 1))
     weight_x_2d = np.sum(weight_x_3d, axis=2)
     weight_y_2d = np.sum(weight_y_3d, axis=2)
-    eps_wgt = 1e-20 if np.any(weight_x_2d == 0) or np.any(weight_y_2d == 0) else 0
-    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (weight_x_2d + eps_wgt)
-    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (weight_y_2d + eps_wgt)
+    # Calculate xda and yda, avoiding division by zero
+    xda = np.where(weight_x_2d != 0, np.sum(grid.axes[0] * weight_x_3d, axis=2) / weight_x_2d, 0)
+    yda = np.where(weight_y_2d != 0, np.sum(grid.axes[1] * weight_y_3d, axis=2) / weight_y_2d, 0)
     # Calculate spatial chirp zeta
     derivative_x_zeta = np.gradient(xda, omega, axis=0)
     derivative_y_zeta = np.gradient(yda, omega, axis=0)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1014,8 +1014,12 @@ def get_zeta(dim, grid, k0):
     if np.any(sum_x == 0) or np.any(sum_y == 0):
         print("Warning: Zero weight sum encountered!")
     # Handle this case, e.g., by setting the result to a default value or skipping
-    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (sum_x + 1e-20)  # Add a small epsilon
-    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (sum_y + 1e-20)  # Add a small epsilon
+    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (
+        sum_x + 1e-20
+    )  # Add a small epsilon
+    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (
+        sum_y + 1e-20
+    )  # Add a small epsilon
     # Calculate spatial chirp zeta
     derivative_x_zeta = np.gradient(xda, omega, axis=0)
     derivative_y_zeta = np.gradient(yda, omega, axis=0)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1009,11 +1009,11 @@ def get_zeta(dim, grid, k0):
     # Calculate dx0 and dy0 in (x,y,omega) space
     weight_x_3d = np.transpose(env_spec_abs2, (2, 1, 0))
     weight_y_3d = np.transpose(env_spec_abs2, (2, 0, 1))
-    sum_x = np.sum(weight_x_3d, axis=2)
-    sum_y = np.sum(weight_y_3d, axis=2)
-    eps_wgt = 1e-20 if np.any(sum_x == 0) or np.any(sum_y == 0) else 0
-    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (sum_x + eps_wgt)
-    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (sum_y + eps_wgt)
+    weight_x_2d = np.sum(weight_x_3d, axis=2)
+    weight_y_2d = np.sum(weight_y_3d, axis=2)
+    eps_wgt = 1e-20 if np.any(weight_x_2d == 0) or np.any(weight_y_2d == 0) else 0
+    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (weight_x_2d + eps_wgt)
+    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (weight_y_2d + eps_wgt)
     # Calculate spatial chirp zeta
     derivative_x_zeta = np.gradient(xda, omega, axis=0)
     derivative_y_zeta = np.gradient(yda, omega, axis=0)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1012,8 +1012,12 @@ def get_zeta(dim, grid, k0):
     weight_x_2d = np.sum(weight_x_3d, axis=2)
     weight_y_2d = np.sum(weight_y_3d, axis=2)
     # Calculate xda and yda, avoiding division by zero
-    xda = np.where(weight_x_2d != 0, np.sum(grid.axes[0] * weight_x_3d, axis=2) / weight_x_2d, 0)
-    yda = np.where(weight_y_2d != 0, np.sum(grid.axes[1] * weight_y_3d, axis=2) / weight_y_2d, 0)
+    xda = np.where(
+        weight_x_2d != 0, np.sum(grid.axes[0] * weight_x_3d, axis=2) / weight_x_2d, 0
+    )
+    yda = np.where(
+        weight_y_2d != 0, np.sum(grid.axes[1] * weight_y_3d, axis=2) / weight_y_2d, 0
+    )
     # Calculate spatial chirp zeta
     derivative_x_zeta = np.gradient(xda, omega, axis=0)
     derivative_y_zeta = np.gradient(yda, omega, axis=0)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1013,9 +1013,7 @@ def get_zeta(dim, grid, k0):
     sum_y = np.sum(weight_y_3d, axis=2)
     if np.any(sum_x == 0) or np.any(sum_y == 0):
         print("Warning: Zero weight sum encountered!")
-    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (
-        sum_x + 1e-20
-    )
+    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (sum_x + 1e-20)
     yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (
         sum_y + 1e-20
     )  # Add a small epsilon

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1014,8 +1014,8 @@ def get_zeta(dim, grid, k0):
     if np.any(sum_x == 0) or np.any(sum_y == 0):
         print("Warning: Zero weight sum encountered!")
     # Handle this case, e.g., by setting the result to a default value or skipping
-    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (sum_x + 1e-12)  # Add a small epsilon
-    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (sum_y + 1e-12)  # Add a small epsilon
+    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (sum_x + 1e-20)  # Add a small epsilon
+    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (sum_y + 1e-20)  # Add a small epsilon
     # Calculate spatial chirp zeta
     derivative_x_zeta = np.gradient(xda, omega, axis=0)
     derivative_y_zeta = np.gradient(yda, omega, axis=0)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1009,8 +1009,13 @@ def get_zeta(dim, grid, k0):
     # Calculate dx0 and dy0 in (x,y,omega) space
     weight_x_3d = np.transpose(env_spec_abs2, (2, 1, 0))
     weight_y_3d = np.transpose(env_spec_abs2, (2, 0, 1))
-    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / np.sum(weight_x_3d, axis=2)
-    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / np.sum(weight_y_3d, axis=2)
+    sum_x = np.sum(weight_x_3d, axis=2)
+    sum_y = np.sum(weight_y_3d, axis=2)
+    if np.any(sum_x == 0) or np.any(sum_y == 0):
+        print("Warning: Zero weight sum encountered!")
+    # Handle this case, e.g., by setting the result to a default value or skipping
+    xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (sum_x + 1e-12)  # Add a small epsilon
+    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (sum_y + 1e-12)  # Add a small epsilon
     # Calculate spatial chirp zeta
     derivative_x_zeta = np.gradient(xda, omega, axis=0)
     derivative_y_zeta = np.gradient(yda, omega, axis=0)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1013,7 +1013,7 @@ def get_zeta(dim, grid, k0):
     sum_y = np.sum(weight_y_3d, axis=2)
     eps_wgt = 1e-20 if np.any(sum_x == 0) or np.any(sum_y == 0) else 0
     xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (sum_x + eps_wgt)
-    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (sum_y + eps_wgt) 
+    yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (sum_y + eps_wgt)
     # Calculate spatial chirp zeta
     derivative_x_zeta = np.gradient(xda, omega, axis=0)
     derivative_y_zeta = np.gradient(yda, omega, axis=0)

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1013,10 +1013,9 @@ def get_zeta(dim, grid, k0):
     sum_y = np.sum(weight_y_3d, axis=2)
     if np.any(sum_x == 0) or np.any(sum_y == 0):
         print("Warning: Zero weight sum encountered!")
-    # Handle this case, e.g., by setting the result to a default value or skipping
     xda = np.sum(grid.axes[0] * weight_x_3d, axis=2) / (
         sum_x + 1e-20
-    )  # Add a small epsilon
+    )
     yda = np.sum(grid.axes[1] * weight_y_3d, axis=2) / (
         sum_y + 1e-20
     )  # Add a small epsilon


### PR DESCRIPTION
This PR fixed a bug observed when using ```get_zeta``` function  in CI test of HIPACE++ PR#1196.
Sometimes the weight of the average here could be zero, which causes the result of zeta to be NaN. This is now avoided by add an np.where condition to check it.