### PR TITLE
New Optical Element: Zernike Aberrations

### DIFF
--- a/docs/source/api/optical_elements/index.rst
+++ b/docs/source/api/optical_elements/index.rst
@@ -8,3 +8,4 @@ Optical elements
    polynomial_spectral_phase
    axiparabola
    axicon
+   zernike_aberrations

--- a/docs/source/api/optical_elements/zernike_aberrations.rst
+++ b/docs/source/api/optical_elements/zernike_aberrations.rst
@@ -1,0 +1,5 @@
+Zernike Aberrations
+===================
+
+.. autoclass:: lasy.optical_elements.ZernikeAberrations
+    :members:

--- a/lasy/optical_elements/__init__.py
+++ b/lasy/optical_elements/__init__.py
@@ -4,4 +4,10 @@ from .parabolic_mirror import ParabolicMirror
 from .polynomial_spectral_phase import PolynomialSpectralPhase
 from .zernike_aberrations import ZernikeAberrations
 
-__all__ = ["ParabolicMirror", "PolynomialSpectralPhase", "Axiparabola", "Axicon","ZernikeAberrations"]
+__all__ = [
+    "ParabolicMirror",
+    "PolynomialSpectralPhase",
+    "Axiparabola",
+    "Axicon",
+    "ZernikeAberrations",
+]

--- a/lasy/optical_elements/__init__.py
+++ b/lasy/optical_elements/__init__.py
@@ -2,5 +2,6 @@ from .axicon import Axicon
 from .axiparabola import Axiparabola
 from .parabolic_mirror import ParabolicMirror
 from .polynomial_spectral_phase import PolynomialSpectralPhase
+from .zernike_aberrations import ZernikeAberrations
 
-__all__ = ["ParabolicMirror", "PolynomialSpectralPhase", "Axiparabola", "Axicon"]
+__all__ = ["ParabolicMirror", "PolynomialSpectralPhase", "Axiparabola", "Axicon","ZernikeAberrations"]

--- a/lasy/optical_elements/zernike_aberrations.py
+++ b/lasy/optical_elements/zernike_aberrations.py
@@ -1,0 +1,68 @@
+import numpy as np
+from scipy.constants import c
+
+from .optical_element import OpticalElement
+from lasy.utils.zernike import zernike
+
+class ZernikeAberrations(OpticalElement):
+    r"""
+    Class for an optic applying a set of Zernike aberrations.
+
+    More precisely, the amplitude multiplier corresponds to:
+
+    .. math::
+
+        T(\boldsymbol{x}_\perp,\omega) = \exp( i \Sum_j a_i Z_j(\boldsymbol{x}_\perp))
+
+    where
+    :math:`\boldsymbol{x}_\perp` is the transverse coordinate (orthogonal
+    to the propagation direction). :math:`Z_j` is the j-th Zernike polynomial,
+    ordered according the OSA/ANSI indexing. The Zernike polynomials are normalized
+    such that their integral over the unit disk is equal to :math:`\pi`. In the above
+    formula, the total phase added to the pulse is a weighted sum of these Zernike
+    polynomials with weights :math:`a_j`. 
+
+    For more information see: https://en.wikipedia.org/wiki/Zernike_polynomials
+
+
+    Parameters
+    ----------
+    pupil_coords : tuple of floats (meters)
+        A tuple of floats (cgx,cgy,r) with the first two elements corresponding to the center
+        point and third element the radius of the pupil on which the zernike polynomial is 
+        defined.
+    zernike_amplitudes : dict
+        A dictionary with integer keys representing the OSA/ANSI indexing of the 
+        individual Zernike Polynomials. The values corresponding to these keys
+        are floats giving the amplitudes / weights of the relevant Zernike polynomials. 
+    
+    """
+
+    def __init__(self, pupil_coords, zernike_amplitudes):
+        self.pupil_coords = pupil_coords
+        self.zernike_amplitudes = zernike_amplitudes
+
+    def amplitude_multiplier(self, x, y, omega):
+        """
+        Return the amplitude multiplier.
+
+        Parameters
+        ----------
+        x, y, omega : ndarrays of floats
+            Define points on which to evaluate the multiplier.
+            These arrays need to all have the same shape.
+            
+        Returns
+        -------
+        multiplier : ndarray of complex numbers
+            Contains the value of the multiplier at the specified points.
+            This array has the same shape as the array omega.
+        """
+        rr = np.sqrt(x**2 + y**2)
+        phase = np.zeros_like(rr)
+
+        for j in self.zernike_amplitudes:
+            phase += self.zernike_amplitudes[j]*zernike(x, y, self.pupil_coords, j)
+
+
+        return np.exp( 1j * phase )

--- a/lasy/optical_elements/zernike_aberrations.py
+++ b/lasy/optical_elements/zernike_aberrations.py
@@ -62,7 +62,9 @@ class ZernikeAberrations(OpticalElement):
         rr = np.sqrt(x**2 + y**2)
         phase = np.zeros_like(rr)
 
-        for j in self.zernike_amplitudes:
-            phase += self.zernike_amplitudes[j] * zernike(x, y, self.pupil_coords, j)
+        _,_,nw = x.shape
+
+        for j in list(self.zernike_amplitudes):
+            phase += self.zernike_amplitudes[j] * np.tile(zernike(x[:,:,0], y[:,:,0], self.pupil_coords, j)[:,:,np.newaxis],(1,1,nw))
 
         return np.exp(1j * phase)

--- a/lasy/optical_elements/zernike_aberrations.py
+++ b/lasy/optical_elements/zernike_aberrations.py
@@ -1,8 +1,9 @@
 import numpy as np
-from scipy.constants import c
+
+from lasy.utils.zernike import zernike
 
 from .optical_element import OpticalElement
-from lasy.utils.zernike import zernike
+
 
 class ZernikeAberrations(OpticalElement):
     r"""
@@ -20,7 +21,7 @@ class ZernikeAberrations(OpticalElement):
     ordered according the OSA/ANSI indexing. The Zernike polynomials are normalized
     such that their integral over the unit disk is equal to :math:`\pi`. In the above
     formula, the total phase added to the pulse is a weighted sum of these Zernike
-    polynomials with weights :math:`a_j`. 
+    polynomials with weights :math:`a_j`.
 
     For more information see: https://en.wikipedia.org/wiki/Zernike_polynomials
 
@@ -29,13 +30,13 @@ class ZernikeAberrations(OpticalElement):
     ----------
     pupil_coords : tuple of floats (meters)
         A tuple of floats (cgx,cgy,r) with the first two elements corresponding to the center
-        point and third element the radius of the pupil on which the zernike polynomial is 
+        point and third element the radius of the pupil on which the zernike polynomial is
         defined.
     zernike_amplitudes : dict
-        A dictionary with integer keys representing the OSA/ANSI indexing of the 
+        A dictionary with integer keys representing the OSA/ANSI indexing of the
         individual Zernike Polynomials. The values corresponding to these keys
-        are floats giving the amplitudes / weights of the relevant Zernike polynomials. 
-    
+        are floats giving the amplitudes / weights of the relevant Zernike polynomials.
+
     """
 
     def __init__(self, pupil_coords, zernike_amplitudes):
@@ -51,7 +52,7 @@ class ZernikeAberrations(OpticalElement):
         x, y, omega : ndarrays of floats
             Define points on which to evaluate the multiplier.
             These arrays need to all have the same shape.
-            
+
         Returns
         -------
         multiplier : ndarray of complex numbers
@@ -62,7 +63,6 @@ class ZernikeAberrations(OpticalElement):
         phase = np.zeros_like(rr)
 
         for j in self.zernike_amplitudes:
-            phase += self.zernike_amplitudes[j]*zernike(x, y, self.pupil_coords, j)
+            phase += self.zernike_amplitudes[j] * zernike(x, y, self.pupil_coords, j)
 
-
-        return np.exp( 1j * phase )
+        return np.exp(1j * phase)

--- a/lasy/optical_elements/zernike_aberrations.py
+++ b/lasy/optical_elements/zernike_aberrations.py
@@ -13,7 +13,7 @@ class ZernikeAberrations(OpticalElement):
 
     .. math::
 
-        T(\boldsymbol{x}_\perp,\omega) = \exp( i \Sum_j a_i Z_j(\boldsymbol{x}_\perp))
+        T(\boldsymbol{x}_\perp,\omega) = \exp( i \sum_j a_j Z_j(\boldsymbol{x}_\perp))
 
     where
     :math:`\boldsymbol{x}_\perp` is the transverse coordinate (orthogonal

--- a/lasy/optical_elements/zernike_aberrations.py
+++ b/lasy/optical_elements/zernike_aberrations.py
@@ -62,9 +62,12 @@ class ZernikeAberrations(OpticalElement):
         rr = np.sqrt(x**2 + y**2)
         phase = np.zeros_like(rr)
 
-        _,_,nw = x.shape
+        _, _, nw = x.shape
 
         for j in list(self.zernike_amplitudes):
-            phase += self.zernike_amplitudes[j] * np.tile(zernike(x[:,:,0], y[:,:,0], self.pupil_coords, j)[:,:,np.newaxis],(1,1,nw))
+            phase += self.zernike_amplitudes[j] * np.tile(
+                zernike(x[:, :, 0], y[:, :, 0], self.pupil_coords, j)[:, :, np.newaxis],
+                (1, 1, nw),
+            )
 
         return np.exp(1j * phase)

--- a/lasy/utils/zernike.py
+++ b/lasy/utils/zernike.py
@@ -25,7 +25,7 @@ def get_zernike_nm(j):
     return int(m), int(n)
 
 
-def zernike(x, y, pupilCoords, j):
+def zernike(x, y, pupil_coords, j):
     """
     Calculate the Zernike Polynomials to arbitrary order.
 
@@ -36,7 +36,7 @@ def zernike(x, y, pupilCoords, j):
     x, y : ndarrays (meters)
         The position at which to calculate the profile
 
-    pupilCoords : tuple of floats (meters)
+    pupil_coords : tuple of floats (meters)
         A tuple of floats (cgx,cgy,r) with the first two elements corresponding to the center
         of the zernike mode and the third the radius of the mode
 
@@ -49,7 +49,7 @@ def zernike(x, y, pupilCoords, j):
         The Zernike mode
     """
     # Setup
-    (cgx, cgy, r) = pupilCoords
+    (cgx, cgy, r) = pupil_coords
     rho = np.sqrt((x - cgx) ** 2 + (y - cgy) ** 2) / r
     theta = np.arctan2(y - cgy, x - cgx)
 


### PR DESCRIPTION
Add an optical element to apply Zernike polynomials to a given pulse. 

Currently this makes use of the already existing `zernike.py` utils file. The user provides the pupil coordinates over which the Zernike polynomial is defined and then provides a dictionary with the OSA/ANSI indexing as the keys and zernike amplitudes as the value.