### PR TITLE
[mini] Fixes bug stopping zernike aberrations from being added in `rt`

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -185,8 +185,10 @@ class Laser:
             r, omega = np.meshgrid(self.grid.axes[0], self.omega_1d, indexing="ij")
             # The line below assumes that amplitude_multiplier
             # is cylindrically symmetric, hence we pass
-            # `r` as `x` and 0 as `y`
-            multiplier = optical_element.amplitude_multiplier(r, 0, omega)
+            # `r` as `x` and an array of 0s as `y`
+            multiplier = optical_element.amplitude_multiplier(
+                r, np.zeros_like(r), omega
+            )
             # The azimuthal modes are the components of the Fourier transform
             # along theta (FT_theta). Because the multiplier is assumed to be
             # cylindrically symmetric (i.e. theta-independent):

--- a/lasy/optical_elements/zernike_aberrations.py
+++ b/lasy/optical_elements/zernike_aberrations.py
@@ -62,12 +62,18 @@ class ZernikeAberrations(OpticalElement):
         rr = np.sqrt(x**2 + y**2)
         phase = np.zeros_like(rr)
 
-        _, _, nw = x.shape
+        nw = x.shape[-1]
 
         for j in list(self.zernike_amplitudes):
-            phase += self.zernike_amplitudes[j] * np.tile(
-                zernike(x[:, :, 0], y[:, :, 0], self.pupil_coords, j)[:, :, np.newaxis],
-                (1, 1, nw),
+            # Create the zernike phase and ensure it has the same number of dimensions as phase
+            zernike_phase = zernike(x[..., 0], y[..., 0], self.pupil_coords, j)[
+                ..., None
+            ]  # Expand last axis
+
+            # Increase the length of the frequency dimension such that the shape is suitable to be added
+            # to the phase array, then add it
+            phase += self.zernike_amplitudes[j] * np.broadcast_to(
+                zernike_phase, phase.shape
             )
 
         return np.exp(1j * phase)

--- a/lasy/optical_elements/zernike_aberrations.py
+++ b/lasy/optical_elements/zernike_aberrations.py
@@ -62,7 +62,6 @@ class ZernikeAberrations(OpticalElement):
         rr = np.sqrt(x**2 + y**2)
         phase = np.zeros_like(rr)
 
-
         for j in list(self.zernike_amplitudes):
             # Create the zernike phase and ensure it has the same number of dimensions as phase
             zernike_phase = zernike(x[..., 0], y[..., 0], self.pupil_coords, j)[

--- a/lasy/optical_elements/zernike_aberrations.py
+++ b/lasy/optical_elements/zernike_aberrations.py
@@ -62,7 +62,6 @@ class ZernikeAberrations(OpticalElement):
         rr = np.sqrt(x**2 + y**2)
         phase = np.zeros_like(rr)
 
-        nw = x.shape[-1]
 
         for j in list(self.zernike_amplitudes):
             # Create the zernike phase and ensure it has the same number of dimensions as phase


### PR DESCRIPTION
The current `ZernikeAberration` optical element allows one to add user defined Zernike Aberrations to a laser pulse. In `xyt` this seems to work fine. In `rt` the code fails due to the array sizes being different. Of course for most Zernike aberrations, this is fine as our optical elements currently only accept radially symmetric optics in `rt`, but for radially symmetric aberrations like defocus, we should be able to use the Zernike Aberrations. This small PR fixes that issue