### PR TITLE
Fix `FromOpenPMDProfile`

### DIFF
--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -109,7 +109,7 @@ class FromOpenPMDProfile(FromArrayProfile):
         # extract the envelope with a Hilbert transform
         if not is_envelope:
             grid = create_grid(F, axes, dim, is_envelope=is_envelope)
-            grid, omg0 = field_to_envelope(grid, dim, phase_unwrap_nd)
+            omg0 = field_to_envelope(grid, dim, phase_unwrap_nd)
             array = grid.get_temporal_field()[0]
         else:
             s = io.Series(path + "/" + prefix + "_%T.h5", io.Access.read_only)

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -72,7 +72,6 @@ class Grid:
         self.temporal_field_valid = False
         self.spectral_field = np.zeros(self.shape, dtype="complex128")
         self.spectral_field_valid = False
-
     def set_is_envelope(self, is_envelope):
         """
         Set is_envelope attribute. Also set dtype accordingly.

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -72,6 +72,7 @@ class Grid:
         self.temporal_field_valid = False
         self.spectral_field = np.zeros(self.shape, dtype="complex128")
         self.spectral_field_valid = False
+
     def set_is_envelope(self, is_envelope):
         """
         Set is_envelope attribute. Also set dtype accordingly.

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -614,7 +614,7 @@ def field_to_envelope(grid, dim, phase_unwrap_nd=False):
     assert not grid.is_envelope
 
     # Get central wavelength from array
-    omg0_h = get_frequency(
+    _, omg0_h = get_frequency(
         grid,
         dim=dim,
         is_hilbert=False,

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -609,7 +609,7 @@ def field_to_envelope(grid, dim, phase_unwrap_nd=False):
     Returns
     -------
     tuple
-        A tuple with the envelope array and the central wavelength.
+        The central wavelength.
     """
     assert not grid.is_envelope
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -585,12 +585,13 @@ def vector_potential_to_field(grid, omega0, direct=True):
 
 
 def field_to_envelope(grid, dim, phase_unwrap_nd=False):
-    """Get the complex envelope of a field by applying a Hilbert transform.
+    """Convert a field to its complex envelope representation by applying a Hilbert transform.
 
     Parameters
     ----------
     grid : Grid
-        The field from which to extract the envelope.
+        The Grid object on which the field is replaced with an envelope.
+        This object is modified by the function.
 
     dim : string
         Dimensionality of the array. Options are:
@@ -608,8 +609,8 @@ def field_to_envelope(grid, dim, phase_unwrap_nd=False):
 
     Returns
     -------
-    tuple
-        The central wavelength.
+    scalar
+        The central angular frequency.
     """
     assert not grid.is_envelope
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -457,8 +457,8 @@ def get_frequency(
         if dim == "xyt" and phase_unwrap_nd:
             print("WARNING: using 3D phase unwrapping, this can be expensive")
 
-        h = field if is_hilbert else hilbert_transform(grid)
-        h = np.squeeze(field)
+        h = field if is_hilbert else hilbert_transform(field)
+        h = np.squeeze(h)
         if phase_unwrap_nd:
             try:
                 from skimage.restoration import unwrap_phase
@@ -613,23 +613,18 @@ def field_to_envelope(grid, dim, phase_unwrap_nd=False):
     """
     assert not grid.is_envelope
 
-    field = grid.get_temporal_field()
-
-    # hilbert transform needs inverted time axis.
-    field = hilbert_transform(field)
-
     # Get central wavelength from array
-    omg_h, omg0_h = get_frequency(
+    omg0_h = get_frequency(
         grid,
         dim=dim,
-        is_hilbert=True,
+        is_hilbert=False,
         phase_unwrap_nd=phase_unwrap_nd,
     )
-    field *= np.exp(1j * omg0_h * grid.axes[-1])
+    field = grid.get_temporal_field() * np.exp(1j * omg0_h * grid.axes[-1])
     grid.set_is_envelope(True)
     grid.set_temporal_field(field)
 
-    return grid, omg0_h
+    return omg0_h
 
 
 def hilbert_transform(field):

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -458,7 +458,7 @@ def get_frequency(
             print("WARNING: using 3D phase unwrapping, this can be expensive")
 
         h = field if is_hilbert else hilbert_transform(field)
-        h = np.squeeze(h)
+
         if phase_unwrap_nd:
             try:
                 from skimage.restoration import unwrap_phase
@@ -620,7 +620,11 @@ def field_to_envelope(grid, dim, phase_unwrap_nd=False):
         is_hilbert=False,
         phase_unwrap_nd=phase_unwrap_nd,
     )
-    field = grid.get_temporal_field() * np.exp(1j * omg0_h * grid.axes[-1])
+    # Hilbert transform
+    field = hilbert_transform(grid.get_temporal_field())
+    # Remove carrier frequency
+    field *= np.exp(1j * omg0_h * grid.axes[-1])
+    # Store envelope
     grid.set_is_envelope(True)
     grid.set_temporal_field(field)
 
@@ -628,7 +632,7 @@ def field_to_envelope(grid, dim, phase_unwrap_nd=False):
 
 
 def hilbert_transform(field):
-    """Make a hilbert transform of the grid field.
+    """Make a hilbert transform of the field.
 
     Currently the arrays need to be flipped along t (both the input field and
     its transform) to get the imaginary part (and thus the phase) with the
@@ -636,8 +640,8 @@ def hilbert_transform(field):
 
     Parameters
     ----------
-    grid : Grid
-        The lasy grid whose field should be transformed.
+    field : 3d numpy array
+        The field whose field should be transformed.
     """
     return hilbert(field[:, :, ::-1])[:, :, ::-1]
 


### PR DESCRIPTION
`get_frequency` and `field_to_envelope` broke recently, which caused issue #358. This PR proposes a fix. A slightly more elegant solution could be used if `Grid` could store a Hilbert transform, which is complex but not an envelope, and the current logic assumes is_complex iff is_envelope.

`field_to_envelope` used to return a grid. With this fix, it modifies the input grid in-place, and returns only the central frequency.

Thanks @delaossa for the clear and nice reproducer in #358! On this example, the measured wavelength is now 803.9 nanometers.