### PR TITLE
[mini] Fix the bug in Issue #377: Add original duration into the argument of get_phi2

### DIFF
--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -972,7 +972,7 @@ def get_w0(grid, dim):
     return sigma
 
 
-def get_phi2(dim, grid):
+def get_phi2(dim, grid, tau):
     r"""
     Calculate the group-delay dispersion of the laser.
 
@@ -989,12 +989,13 @@ def get_phi2(dim, grid):
     grid : a Grid object.
         It contains an ndarray (V/m) with the value of the envelope field and the associated metadata that defines the points at which the laser is defined.
 
+    tau : float in second 
+        The original duration before GDD optics/ without temporal chirp. This argument may be cancelled in the future with an improvement of the algorithm,
     Returns
     -------
     phi2 : Group-delay dispersion in :math:`\Phi^{(2)} = \frac{d\omega_0}{dt}` (second^-2)
     varphi2 : Group-delay dispersion in :math:`\varphi^{(2)}=\frac{dt_0}{d\omega}` (second^2)
     """
-    tau = 2 * get_duration(grid, dim)
     env = grid.get_temporal_field()
     env_abs2 = np.abs(env**2)
     # Calculate group-delayed dispersion

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -990,7 +990,7 @@ def get_phi2(dim, grid, tau):
         It contains an ndarray (V/m) with the value of the envelope field and the associated metadata that defines the points at which the laser is defined.
 
     tau : float in second
-        The original duration before GDD optics/ without temporal chirp. This argument may be cancelled in the future with an improvement of the algorithm.
+        The original duration before GDD optics/ without temporal chirp. This argument may be removed in the future with an improvement of the algorithm.
 
     Returns
     -------

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -990,7 +990,7 @@ def get_phi2(dim, grid, tau):
         It contains an ndarray (V/m) with the value of the envelope field and the associated metadata that defines the points at which the laser is defined.
 
     tau : float in second
-        The original duration before GDD optics/ without temporal chirp. This argument may be cancelled in the future with an improvement of the algorithm,
+        The original duration before GDD optics/ without temporal chirp. This argument may be cancelled in the future with an improvement of the algorithm.
 
     Returns
     -------

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1004,7 +1004,16 @@ def get_phi2(dim, grid, tau):
     pphi_pt = np.gradient(phi_envelop, grid.dx[-1], axis=2)
     pphi_pt2 = np.gradient(pphi_pt, grid.dx[-1], axis=2)
     phi2 = np.average(pphi_pt2, weights=env_abs2)
-    varphi2 = np.max(np.roots([4 * phi2, -4, tau**4 * phi2]))
+    # varphi2 = np.max(np.roots([4 * phi2, -4, tau**4 * phi2]))
+    dt = laser_3d.grid.dx[-1]
+    Nt = laser_3d.grid.shape[-1]
+    omega = 2 * np.pi * np.fft.fftfreq(Nt, dt)+2*scc.pi*scc.c/wavelength
+    env_spec = laser_3d.grid.get_spectral_field()*np.exp(-1j*omega*laser_3d.grid.lo[-1]
+    env_spec_abs2 = np.abs(env_spec**2)
+    phi_envelop_spec= np.unwrap(np.angle(env_spec),axis = -1)
+    local_t = np.gradient(phi_envelop_spec, omega, axis=2)
+    pt_pomega = np.gradient(local_t, omega, axis=2)
+    varphi2 = np.average(pt_pomega, weights=np.abs(env_spec)**2)
     return phi2, varphi2
 
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -989,8 +989,9 @@ def get_phi2(dim, grid, tau):
     grid : a Grid object.
         It contains an ndarray (V/m) with the value of the envelope field and the associated metadata that defines the points at which the laser is defined.
 
-    tau : float in second 
+    tau : float in second
         The original duration before GDD optics/ without temporal chirp. This argument may be cancelled in the future with an improvement of the algorithm,
+
     Returns
     -------
     phi2 : Group-delay dispersion in :math:`\Phi^{(2)} = \frac{d\omega_0}{dt}` (second^-2)

--- a/tests/test_STC.py
+++ b/tests/test_STC.py
@@ -99,7 +99,7 @@ err_imag = np.average(
     / np.array(env_combined.imag)
 )
 
-Phi2_3d, phi2_3d = get_phi2(laser_3d.dim, laser_3d.grid)
+Phi2_3d, phi2_3d = get_phi2(laser_3d.dim, laser_3d.grid,tau)
 [zeta_x, zeta_y], [nu_x, nu_y] = get_zeta(
     laser_3d.dim, laser_3d.grid, 2.0 * np.pi / 0.6e-6
 )

--- a/tests/test_STC.py
+++ b/tests/test_STC.py
@@ -99,7 +99,7 @@ err_imag = np.average(
     / np.array(env_combined.imag)
 )
 
-Phi2_3d, phi2_3d = get_phi2(laser_3d.dim, laser_3d.grid,tau)
+Phi2_3d, phi2_3d = get_phi2(laser_3d.dim, laser_3d.grid, tau)
 [zeta_x, zeta_y], [nu_x, nu_y] = get_zeta(
     laser_3d.dim, laser_3d.grid, 2.0 * np.pi / 0.6e-6
 )


### PR DESCRIPTION
When introducing STC, the laser duration may be changed by both spatial and angular chirp.

The spatial chirp $\zeta$ will stretch a Gaussian pulse as $\tau' = (\tau_0^2+\frac{4\zeta^2}{w_0^2})^{1/2}$.

The temporal chirp, i.e GDD, will stretch a Gaussian pulse as $\tau= [\tau'^2+\frac{4(\varphi^{(2)})^2}{\tau'^2}]^{1/2}$.

Previously, the function ```get_phi2``` assumes that $\tau'\approx \tau_0$. It's true when the pulse is based on a Gaussian shape longitudinally(The influence on Gaussian laser duration from spatial chirp is always minor). However, as pointed out in Issue #377, when implement ```PolynomialSpectralPhase``` on the laser, the pulse may be drastically stretched by both spatial and temporal chirps. This causes an error.

I tried to calculate the GDD in spectrum field as $\langle \frac{\partial^2 \varphi}{\partial \omega^2} \rangle$, but in this way turns out to be really sensitive to the box size and resolution, which originated from two times of derivative in the same direction plus numerical FFT. Considering $\tau'$ is also not a trivial to calculate, currently the solution is to add one argument to input the original value of $\tau_0$ for user to use.

The final optimal solution remains to be discussed...