### PR TITLE
[mini] Fix issue with flipped spectrum

### DIFF
--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -113,7 +113,7 @@ class LongitudinalProfileFromData(LongitudinalProfile):
             t_amplitude = (
                 np.fft.ifftshift(
                     np.fft.fft(
-                        np.fft.fftshift(freq_amplitude * np.exp(-1j * freq_phase))
+                        np.fft.fftshift(freq_amplitude * np.exp(1j * freq_phase))
                     )
                 )
                 / dt

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -111,9 +111,9 @@ class LongitudinalProfileFromData(LongitudinalProfile):
 
             # Inverse Fourier Transform to the time domain
             t_amplitude = (
-                np.fft.fftshift(
-                    np.fft.ifft(
-                        np.fft.ifftshift(freq_amplitude * np.exp(-1j * freq_phase))
+                np.fft.ifftshift(
+                    np.fft.fft(
+                        np.fft.fftshift(freq_amplitude * np.exp(-1j * freq_phase))
                     )
                 )
                 / dt


### PR DESCRIPTION
@delaossa and @Paaaaarth identified an issue with the `LongitudinalProfileFromData` class, in which when an asymmetric spectrum was passed as an input, the retrieved spectrum from the `Laser` object was flipped (see #352 ).

After looking into this, it seems to arise from different conventions for the fourier transform from spectral to temporal space. `LongitudinalProfileFromData` moves from spectral to temporal space with an inverse fourier transform, while in the `Grid` and indeed in the `get_spectrum` function, this process involves a fourier transform.

The fix is to replace the inverse fourier transform in `LongitudinalProfileFromData` with a fourier transform (similarly the `fftshift and `ifftshift` have to be replaced).