### PR TITLE
Detect polarization state in openPMD file describing the full field

### DIFF
--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -7,7 +7,7 @@ from lasy.utils.laser_utils import (
     field_to_envelope,
     vector_potential_to_field,
 )
-from lasy.utils.openpmd_helper import convert_modes, extract_array
+from lasy.utils.openpmd_helper import convert_modes, extract_array, isolate_polarization
 
 from .from_array_profile import FromArrayProfile
 
@@ -65,8 +65,8 @@ class FromOpenPMDProfile(FromArrayProfile):
         else:
             geometry = i.meshes["E"].get_attribute("geometry")
             if geometry == "cartesian":
-                field_list = ["E"]
-                coord_list = ["x"]
+                field_list = ["E", "E"]
+                coord_list = ["x", "y"]
             else:  # thetaMode
                 field_list = ["E", "E"]
                 coord_list = ["r", "t"]
@@ -77,12 +77,17 @@ class FromOpenPMDProfile(FromArrayProfile):
                 component = coord_list[count]
                 axes_order, axes, array = extract_array(m, series, component)
                 array_list.append(array)
-            array = convert_modes(array_list, geometry, is_envelope, verbose)
+            # Convert from Er & Etheta at openPMD mode decomposition
+            #           to Ex & Ey at LASY mode decomposition.
+            array_list = convert_modes(array_list, geometry, is_envelope, verbose)
             dim = "xyt" if geometry == "cartesian" else "rt"
-            grid = create_grid(array, axes, dim, is_envelope=False)
-            omg0 = field_to_envelope(grid, dim)
-            array = grid.get_temporal_field()
-            pol = (1, 0)
+            env_array_list = []
+            for array in array_list:
+                grid = create_grid(array, axes, dim, is_envelope=False)
+                omg0 = field_to_envelope(grid, dim)
+                array = grid.get_temporal_field()
+                env_array_list.append(array)
+            array, pol = isolate_polarization(env_array_list, dim)
         wavelength = 2 * np.pi * c / omg0
 
         super().__init__(

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -56,7 +56,8 @@ class FromOpenPMDProfile(FromArrayProfile):
                     + ", see https://github.com/openPMD/openPMD-standard/blob/upcoming-2.0.0/EXT_LaserEnvelope.md. Assumed 'normalized_vector_potential' and (1,0), respectively."
                 )
             axes_order, axes, array = extract_array(m, series)
-            array = convert_modes([array], geometry, is_envelope, verbose)
+            arrays = convert_modes([array], geometry, is_envelope, verbose)
+            array = arrays[0]
             if envelopeField == "normalized_vector_potential":
                 if verbose:
                     print("Convert from vector potential to electric field")

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -26,7 +26,7 @@ class FromOpenPMDProfile(FromArrayProfile):
     envelope_name : string (optional)
         The name of the envelope field (this is not prescribed by the openPMD standard for the envelope).
         If specified, an envelope field is expected from the openPMD file. Otherwise, a full electric field is assumed.
-        In the case of a full field, linear polarization in x is assumed for the moment, this can be generalized on demand.
+        In the case of a full field, The transverse electric field (Ex & Ey or Er and Etheta) is read, and the polarization is measured from this.
 
     verbose : bool (optional)
         If true, print some intermediate steps.

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -247,13 +247,12 @@ def convert_modes(arr_list, geometry, is_env, verbose=False):
 
     Returns
     -------
-    array_out : 3D array
-        The array converted to LASY mode decomposition.
+    arrays_out : list of 3D array
+        The arrays converted to LASY mode decomposition.
         This is still the full field, not yet the envelope.
     """
     if geometry == "cartesian":
-        assert len(arr_list) == 1
-        return arr_list[0]
+        return arr_list
     nmodes_in = (arr_list[0].shape[0] + 1) // 2
     if verbose:
         print("nmodes_in:", nmodes_in)
@@ -272,6 +271,7 @@ def convert_modes(arr_list, geometry, is_env, verbose=False):
             array_out[-imode, :, :] = 0.5 * (
                 array_in[2 * imode - 1] - 1j * array_in[2 * imode]
             )
+        return [array_out]
     else:
         # arr_list contains 2 elements, Er and Etheta, that need to be
         # combined into Ex. At this point, still operating on full field.
@@ -283,7 +283,8 @@ def convert_modes(arr_list, geometry, is_env, verbose=False):
         nmodes_out = nmodes_in - 1
         if verbose:
             print("nmodes_out:", nmodes_in)
-        array_out = np.zeros(shape=(2 * nmodes_out - 1, *Er_in.shape[1:]))
+        Ex_out = np.zeros(shape=(2 * nmodes_out - 1, *Er_in.shape[1:]))
+        Ey_out = np.zeros(shape=(2 * nmodes_out - 1, *Er_in.shape[1:]))
         # The _in arrays have real and imag parts separated, so we add them
         # together by hand
         for imode in range(nmodes_out):
@@ -291,13 +292,63 @@ def convert_modes(arr_list, geometry, is_env, verbose=False):
             # The +1 is conversion from Er & Etheta representation to Ex
             # output exp(i*m*theta) modes: for some reasons, all data goes in
             # m >= 0 modes
-            array_out[imode, :, :] = 0.5 * (
+            Ex_out[imode, :, :] = 0.5 * (
                 Er_in[2 * (imode + 1) - 1, :, :] - Et_in[2 * (imode + 1), :, :]
+            )
+            Ey_out[imode, :, :] = 0.5 * (
+                Er_in[2 * (imode + 1), :, :] + Et_in[2 * (imode + 1) - 1, :, :]
             )
             # Here we assume that mode 0 is only plasma, so we never use it
             if imode >= 2:
-                array_out[imode, :, :] += 0.5 * (
+                Ex_out[imode, :, :] += 0.5 * (
                     Er_in[2 * (imode - 1) - 1, :, :] + Et_in[2 * (imode - 1), :, :]
                 )
+                Ey_out[imode, :, :] += 0.5 * (
+                    - Er_in[2 * (imode - 1), :, :] + Et_in[2 * (imode - 1) - 1, :, :]
+                )
+        return [Ex_out, Ey_out]
 
-    return array_out
+def isolate_polarization(arrays, dim):
+    """
+    Extract single array and polarization vector from Ex and Ey.
+
+    Parameters
+    ----------
+    arrays : list of 2 3D numpy arrays
+        Envelopes of Ex and Ey.
+
+    dim : string
+        Dimensionality of the array. Options are:
+
+        - 'xyt': The laser pulse is represented on a 3D grid:
+                 Cartesian (x,y) transversely, and temporal (t) longitudinally.
+        - 'rt' : The laser pulse is represented on a 2D grid:
+                 Cylindrical (r) transversely, and temporal (t) longitudinally.
+
+    Returns
+    -------
+    array : 3D numpy array
+        Laser envelope at LASY convention
+
+    pol : tuple of 2 elements
+        Polarization vector (px, py), both px and py are complex numbers.
+    """
+    Ex, Ey = arrays # Ex and Ey envelopes
+    if dim == "rt":
+        print("Cylindrical input with full field: polarization is extract from mode 0 only")
+        Ex = Ex[0]
+        Ey = Ey[0]
+    rho2 = np.abs(Ex)**2 + np.abs(Ey**2)
+    # Amplitude of polarization vectors
+    rho_x = np.sqrt(np.sum(np.abs(Ex)**2) / np.sum(rho2))
+    rho_y = np.sqrt(np.sum(np.abs(Ey)**2) / np.sum(rho2))
+    # Phase in x is assumed 0. This is a convention.
+    phi_x = 0
+    phi_y = np.average( np.angle(Ey) - np.angle(Ex), weights=rho2 )
+    px = rho_x * np.exp(1j * phi_x)
+    py = rho_y * np.exp(1j * phi_y)
+    pol = (px, py)
+    print("polarization state detected: (px, py) =", pol)
+    array = arrays[0]/px if rho_x >= rho_y else arrays[1]/py
+
+    return array, pol

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -304,9 +304,10 @@ def convert_modes(arr_list, geometry, is_env, verbose=False):
                     Er_in[2 * (imode - 1) - 1, :, :] + Et_in[2 * (imode - 1), :, :]
                 )
                 Ey_out[imode, :, :] += 0.5 * (
-                    - Er_in[2 * (imode - 1), :, :] + Et_in[2 * (imode - 1) - 1, :, :]
+                    -Er_in[2 * (imode - 1), :, :] + Et_in[2 * (imode - 1) - 1, :, :]
                 )
         return [Ex_out, Ey_out]
+
 
 def isolate_polarization(arrays, dim):
     """
@@ -333,22 +334,24 @@ def isolate_polarization(arrays, dim):
     pol : tuple of 2 elements
         Polarization vector (px, py), both px and py are complex numbers.
     """
-    Ex, Ey = arrays # Ex and Ey envelopes
+    Ex, Ey = arrays  # Ex and Ey envelopes
     if dim == "rt":
-        print("Cylindrical input with full field: polarization is extract from mode 0 only")
+        print(
+            "Cylindrical input with full field: polarization is extract from mode 0 only"
+        )
         Ex = Ex[0]
         Ey = Ey[0]
-    rho2 = np.abs(Ex)**2 + np.abs(Ey**2)
+    rho2 = np.abs(Ex) ** 2 + np.abs(Ey**2)
     # Amplitude of polarization vectors
-    rho_x = np.sqrt(np.sum(np.abs(Ex)**2) / np.sum(rho2))
-    rho_y = np.sqrt(np.sum(np.abs(Ey)**2) / np.sum(rho2))
+    rho_x = np.sqrt(np.sum(np.abs(Ex) ** 2) / np.sum(rho2))
+    rho_y = np.sqrt(np.sum(np.abs(Ey) ** 2) / np.sum(rho2))
     # Phase in x is assumed 0. This is a convention.
     phi_x = 0
-    phi_y = np.average( np.angle(Ey) - np.angle(Ex), weights=rho2 )
+    phi_y = np.average(np.angle(Ey) - np.angle(Ex), weights=rho2)
     px = rho_x * np.exp(1j * phi_x)
     py = rho_y * np.exp(1j * phi_y)
     pol = (px, py)
     print("polarization state detected: (px, py) =", pol)
-    array = arrays[0]/px if rho_x >= rho_y else arrays[1]/py
+    array = arrays[0] / px if rho_x >= rho_y else arrays[1] / py
 
     return array, pol

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -224,16 +224,16 @@ def convert_modes(arr_list, geometry, is_env, verbose=False):
     """
     Convert from openPMD mode decomposition to LASY mode decomposition.
 
-    Convert from openPMD mode decomposition in cos(m*theta) and sin(m*theta), stored, m in [0, Nmodes] to LASY mode decomposition exp(i*m*theta) m in [-Nmodes+1,Nmodes-1] (array of complex numbers, see https://github.com/LASY-org/lasy/blob/development/README.md):
-     - Electromagnetic + cylindrical: we assume Er and Etheta
+    Convert from openPMD mode decomposition of the electric field in cos(m*theta) and sin(m*theta), stored, m in [0, Nmodes] to LASY mode decomposition exp(i*m*theta) m in [-Nmodes+1,Nmodes-1] (array of complex numbers, see https://github.com/LASY-org/lasy/blob/development/README.md):
+     - Electromagnetic + cylindrical: we assume Er and Etheta, and construct Ex and Ey.
         https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#required-attributes-for-each-mesh-record. Complex modes, the real and imag part are stored in 2 real arrays.
-     - Envelope + cylindrical: we assume the array is Ex (in principle, we should measure the polarization). Complex modes, stored as arrays of complex numbers. See openPMD link above aas well as https://github.com/openPMD/openPMD-standard/blob/upcoming-2.0.0/EXT_LaserEnvelope.md.
+     - Envelope + cylindrical: we assume the array is E + polarization. Complex modes, stored as arrays of complex numbers. See openPMD link above aas well as https://github.com/openPMD/openPMD-standard/blob/upcoming-2.0.0/EXT_LaserEnvelope.md.
      - Cartesian: do not do anything.
 
     Parameters
     ----------
     arr_list : list of Numpy arrays
-        List of 3D arrays to be converted. They are processed independently.
+        List of 3D arrays to be converted.
 
     geometry : string
         Geometry of input data from openPMD standard, "cartesian" or "thetaMode" supported.
@@ -253,6 +253,7 @@ def convert_modes(arr_list, geometry, is_env, verbose=False):
     """
     if geometry == "cartesian":
         return arr_list
+
     nmodes_in = (arr_list[0].shape[0] + 1) // 2
     if verbose:
         print("nmodes_in:", nmodes_in)
@@ -341,7 +342,7 @@ def isolate_polarization(arrays, dim):
         )
         Ex = Ex[0]
         Ey = Ey[0]
-    rho2 = np.abs(Ex) ** 2 + np.abs(Ey**2)
+    rho2 = np.abs(Ex)**2 + np.abs(Ey)**2
     # Amplitude of polarization vectors
     rho_x = np.sqrt(np.sum(np.abs(Ex) ** 2) / np.sum(rho2))
     rho_y = np.sqrt(np.sum(np.abs(Ey) ** 2) / np.sum(rho2))

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -342,7 +342,7 @@ def isolate_polarization(arrays, dim):
         )
         Ex = Ex[0]
         Ey = Ey[0]
-    rho2 = np.abs(Ex)**2 + np.abs(Ey)**2
+    rho2 = np.abs(Ex) ** 2 + np.abs(Ey) ** 2
     # Amplitude of polarization vectors
     rho_x = np.sqrt(np.sum(np.abs(Ex) ** 2) / np.sum(rho2))
     rho_y = np.sqrt(np.sum(np.abs(Ey) ** 2) / np.sum(rho2))


### PR DESCRIPTION
Regardless of the geometry of the openPMD file, the envelopes of Ex and Ey are extracted, and the polarization state is computed from this. A template FBPIC simulation provided by @delaossa returns the same intensity and phase for
- x polarization, plotting `envelope * px`
- y polarization, plotting `envelope * py`
- circular polarization, plotting `envelope`

The respective polarizations measured are below. Not so pretty but should be accurate.
```
polarization state detected: (px, py) = (np.complex128(0.9999999987982302+0j), np.complex128(-3.097860927267846e-05-3.7998223012977074e-05j))
polarization state detected: (px, py) = (np.complex128(4.472425754808187e-05+0j), np.complex128(-0.6983963205453237+0.7157112388725595j))
polarization state detected: (px, py) = (np.complex128(0.7071100816508172+0j), np.complex128(0.03221246161526771-0.7063693720317009j))
```  