### PR TITLE
Added `get_dispersion()` function and corresponding tests

### DIFF
--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1392,7 +1392,7 @@ def get_dispersion(grid, dim, omega0, order, omega_eval=None, method="sum"):
     .. math::
         \Phi^{(n)} = \frac{\partial^{n} \phi(\omega)}{\partial \omega^{n}}
 
-    where n is the order to which the disperison is calculated (in s^{n}/rad).
+    where n is the order to which the disperison is calculated (in s^n/rad).
 
     E.g. `order`=1, calculates the group delay (GD), `order`=2 calculates group delay dispersion (GDD) and `order`=3 calculates the third order dispersion (TOD).
 
@@ -1427,10 +1427,10 @@ def get_dispersion(grid, dim, omega0, order, omega_eval=None, method="sum"):
     Returns
     -------
     disp: ndarray of floats (1D)
-        n-th order dispersion over the entire spectral range (in s^{n}/rad)
+        n-th order dispersion over the entire spectral range (in s^n/rad)
 
     disp0: float
-        n-th order dispersion at the center frequency (in s^{n}/rad)
+        n-th order dispersion at the center frequency (in s^n/rad)
 
     """
     # calculate the spectral phase of the laser pulse

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1493,9 +1493,9 @@ def get_gdd(grid, dim, omega0, omega_eval=None, method="sum"):
 
     # get the GDD at the specified frequency or the envelope's frequency
     omega_eval = omega_eval if omega_eval is not None else omega0
-    
+
     assert (omega_eval < omega[-1]) and (omega_eval > omega.min())
-    
+
     gdd0 = np.interp(omega_eval, omega, gdd)
     return gdd, gdd0
 
@@ -1552,9 +1552,9 @@ def get_tod(grid, dim, omega0, omega_eval=None, method="sum"):
 
     # get the GDD at the specified frequency or the envelope's frequency
     omega_eval = omega_eval if omega_eval is not None else omega0
-    
+
     assert (omega_eval < omega[-1]) and (omega_eval > omega.min())
-    
+
     tod0 = np.interp(omega_eval, omega, tod)
-    
+
     return gdd, tod0

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1392,7 +1392,7 @@ def get_dispersion(grid, dim, omega0, order, omega_eval=None, method="sum"):
     .. math::
         \Phi^{(n)} = \frac{\partial^{n} \phi(\omega)}{\partial \omega^{n}}
 
-    where n is the order to which the disperison is calculated (in s^{order/rad).
+    where n is the order to which the disperison is calculated (in s^{n}/rad).
 
     E.g. `order`=1, calculates the group delay (GD), `order`=2 calculates group delay dispersion (GDD) and `order`=3 calculates the third order dispersion (TOD).
 
@@ -1427,10 +1427,10 @@ def get_dispersion(grid, dim, omega0, order, omega_eval=None, method="sum"):
     Returns
     -------
     disp: ndarray of floats (1D)
-        n-th order dispersion over the entire spectral range (in s^{order}/rad)
+        n-th order dispersion over the entire spectral range (in s^{n}/rad)
 
     disp0: float
-        n-th dispersion at the center frequency (in s^{order}/rad)
+        n-th order dispersion at the center frequency (in s^{n}/rad)
 
     """
     # calculate the spectral phase of the laser pulse

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1385,7 +1385,64 @@ def get_spectral_phase(grid, dim, omega0, method="sum", ordering="zero_center"):
     return phase, omega
 
 
-def get_gdd(grid, dim, omega0, omega_gdd=None, method="sum"):
+def get_gd(grid, dim, omega0, omega_eval=None, method="sum"):
+    r"""
+    Calculate the group delay (GD) of the laser.
+
+    .. math::
+        GD = \frac{\partial \phi(\omega)}{\partial \omega}
+
+
+    Parameters
+    ----------
+    grid : Grid
+        The grid with the field to analyze.
+
+    dim : string
+        Dimensionality of the array. Options are:
+
+        - ``'xyt'``: The laser pulse is represented on a 3D grid:
+                    Cartesian (x,y) transversely, and temporal (t) longitudinally.
+        - ``'rt'`` : The laser pulse is represented on a 2D grid:
+                    Cylindrical (r) transversely, and temporal (t) longitudinally.
+
+    omega0 : float
+        Angular frequency at which the laser envelope is defined.
+
+    omega_eval : float, optional
+        Central angular frequency at which the GDD is calculated, if `None`, `omega0` is used.
+
+    method : string, optional
+        Method of retrieving the phase that is used for calculating the GD. Options are:
+
+        - ``'sum'``: Calculates the spectral phase of the spatially summed field (default).
+        - ``'on-axis'``: Calculates the on-axis spectral phase.
+
+    Returns
+    -------
+    gdd: ndarray of floats (1D)
+        Group delay over the entire spectral range (in s^2)
+
+    gdd0: float
+        Group delay at the center frequency (in s^2)
+
+    """
+    # calculate the spectral phase of the laser pulse
+    phase, omega = get_spectral_phase(grid, dim, omega0=omega0, method=method)
+
+    # calculate the second derivative wrt. angular frequency
+    gd = np.gradient(phase, omega, axis=-1, edge_order=1)
+
+    # get the GDD at the specified frequency or the envelope's frequency
+    omega_eval = omega_eval if omega_eval is not None else omega0
+
+    assert (omega_eval < omega[-1]) and (omega_eval > omega.min())
+
+    gd0 = np.interp(omega_eval, omega, gd)
+    return gd, gd0
+
+
+def get_gdd(grid, dim, omega0, omega_eval=None, method="sum"):
     r"""
     Calculate the group delay dispersion (GDD) of the laser.
 
@@ -1409,7 +1466,7 @@ def get_gdd(grid, dim, omega0, omega_gdd=None, method="sum"):
     omega0 : float
         Angular frequency at which the laser envelope is defined.
 
-    omega_gdd : float, optional
+    omega_eval : float, optional
         Central angular frequency at which the GDD is calculated, if `None`, `omega0` is used.
 
     method : string, optional
@@ -1435,6 +1492,69 @@ def get_gdd(grid, dim, omega0, omega_gdd=None, method="sum"):
     gdd = np.gradient(gd, omega, axis=-1)
 
     # get the GDD at the specified frequency or the envelope's frequency
-    omega_eval = omega_gdd if omega_gdd is not None else omega0
+    omega_eval = omega_eval if omega_eval is not None else omega0
+    
+    assert (omega_eval < omega[-1]) and (omega_eval > omega.min())
+    
     gdd0 = np.interp(omega_eval, omega, gdd)
     return gdd, gdd0
+
+
+def get_tod(grid, dim, omega0, omega_eval=None, method="sum"):
+    r"""
+    Calculate the third order dispersion (TOD) of the laser.
+
+    .. math::
+        TOD = \frac{\partial^3 \phi(\omega)}{\partial \omega^3}
+
+
+    Parameters
+    ----------
+    grid : Grid
+        The grid with the field to analyze.
+
+    dim : string
+        Dimensionality of the array. Options are:
+
+        - ``'xyt'``: The laser pulse is represented on a 3D grid:
+                    Cartesian (x,y) transversely, and temporal (t) longitudinally.
+        - ``'rt'`` : The laser pulse is represented on a 2D grid:
+                    Cylindrical (r) transversely, and temporal (t) longitudinally.
+
+    omega0 : float
+        Angular frequency at which the laser envelope is defined.
+
+    omega_gdd : float, optional
+        Central angular frequency at which the GDD is calculated, if `None`, `omega0` is used.
+
+    method : string, optional
+        Method of retrieving the phase that is used for calculating the TOD. Options are:
+
+        - ``'sum'``: Calculates the spectral phase of the spatially summed field (default).
+        - ``'on-axis'``: Calculates the on-axis spectral phase.
+
+    Returns
+    -------
+    tod: ndarray of floats (1D)
+        Third order dispersion over the entire spectral range (in s^3)
+
+    tod0: float
+        Third order dispersion at the center frequency (in s^3)
+
+    """
+    # calculate the spectral phase of the laser pulse
+    phase, omega = get_spectral_phase(grid, dim, method=method, omega0=omega0)
+
+    # calculate the second derivative wrt. angular frequency
+    gd = np.gradient(phase, omega, axis=-1)
+    gdd = np.gradient(gd, omega, axis=-1)
+    tod = np.gradient(gdd, omega, axis=-1)
+
+    # get the GDD at the specified frequency or the envelope's frequency
+    omega_eval = omega_eval if omega_eval is not None else omega0
+    
+    assert (omega_eval < omega[-1]) and (omega_eval > omega.min())
+    
+    tod0 = np.interp(omega_eval, omega, tod)
+    
+    return gdd, tod0

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1384,14 +1384,16 @@ def get_spectral_phase(grid, dim, omega0, method="sum", ordering="zero_center"):
     # return the phase and omega arrays
     return phase, omega
 
-
-def get_gd(grid, dim, omega0, omega_eval=None, method="sum"):
+def get_dispersion(grid, dim, omega0, order, omega_eval=None, method="sum"):
     r"""
-    Calculate the group delay (GD) of the laser.
+    Calculate the n-th order dispersion polynomial of the laser.
 
     .. math::
-        GD = \frac{\partial \phi(\omega)}{\partial \omega}
+        \Phi^{(n)} = \frac{\partial^{n} \phi(\omega)}{\partial \omega^{n}}
 
+    where n is the order to which the disperison is calculated (in s^{order/rad).
+
+    E.g. `order`=1, calculates the group delay (GD), `order`=2 calculates group delay dispersion (GDD) and `order`=3 calculates the third order dispersion (TOD).
 
     Parameters
     ----------
@@ -1409,152 +1411,38 @@ def get_gd(grid, dim, omega0, omega_eval=None, method="sum"):
     omega0 : float
         Angular frequency at which the laser envelope is defined.
 
+    order : integer
+        Dispersion polynomial order that should be calculated.
+
     omega_eval : float, optional
-        Central angular frequency at which the GDD is calculated, if `None`, `omega0` is used.
+        Central angular frequency at which the dispersion polynomial is calculated, if `None`, `omega0` is used.
 
     method : string, optional
-        Method of retrieving the phase that is used for calculating the GD. Options are:
+        Method of retrieving the phase that is used for calculating the dispersion. Options are:
 
         - ``'sum'``: Calculates the spectral phase of the spatially summed field (default).
         - ``'on-axis'``: Calculates the on-axis spectral phase.
 
     Returns
     -------
-    gdd: ndarray of floats (1D)
-        Group delay over the entire spectral range (in s^2)
+    disp: ndarray of floats (1D)
+        n-th order dispersion over the entire spectral range (in s^{order}/rad)
 
-    gdd0: float
-        Group delay at the center frequency (in s^2)
-
-    """
-    # calculate the spectral phase of the laser pulse
-    phase, omega = get_spectral_phase(grid, dim, omega0=omega0, method=method)
-
-    # calculate the second derivative wrt. angular frequency
-    gd = np.gradient(phase, omega, axis=-1, edge_order=1)
-
-    # get the GDD at the specified frequency or the envelope's frequency
-    omega_eval = omega_eval if omega_eval is not None else omega0
-
-    assert (omega_eval < omega[-1]) and (omega_eval > omega.min())
-
-    gd0 = np.interp(omega_eval, omega, gd)
-    return gd, gd0
-
-
-def get_gdd(grid, dim, omega0, omega_eval=None, method="sum"):
-    r"""
-    Calculate the group delay dispersion (GDD) of the laser.
-
-    .. math::
-        GDD = \frac{\partial^2 \phi(\omega)}{\partial \omega^2}
-
-
-    Parameters
-    ----------
-    grid : Grid
-        The grid with the field to analyze.
-
-    dim : string
-        Dimensionality of the array. Options are:
-
-        - ``'xyt'``: The laser pulse is represented on a 3D grid:
-                    Cartesian (x,y) transversely, and temporal (t) longitudinally.
-        - ``'rt'`` : The laser pulse is represented on a 2D grid:
-                    Cylindrical (r) transversely, and temporal (t) longitudinally.
-
-    omega0 : float
-        Angular frequency at which the laser envelope is defined.
-
-    omega_eval : float, optional
-        Central angular frequency at which the GDD is calculated, if `None`, `omega0` is used.
-
-    method : string, optional
-        Method of retrieving the phase that is used for calculating the GDD. Options are:
-
-        - ``'sum'``: Calculates the spectral phase of the spatially summed field (default).
-        - ``'on-axis'``: Calculates the on-axis spectral phase.
-
-    Returns
-    -------
-    gdd: ndarray of floats (1D)
-        Group delay dispersion over the entire spectral range (in s^2)
-
-    gdd0: float
-        Group delay dispersion at the center frequency (in s^2)
+    disp0: float
+        n-th dispersion at the center frequency (in s^{order}/rad)
 
     """
     # calculate the spectral phase of the laser pulse
     phase, omega = get_spectral_phase(grid, dim, method=method, omega0=omega0)
 
-    # calculate the second derivative wrt. angular frequency
-    gd = np.gradient(phase, omega, axis=-1)
-    gdd = np.gradient(gd, omega, axis=-1)
+    # calculate the n-th order derivative wrt. angular frequency
+    disp = np.gradient(phase, omega, axis=-1)
+    for _ in range(order-1):
+        disp = np.gradient(disp, omega, axis=-1)
 
-    # get the GDD at the specified frequency or the envelope's frequency
+    # get the dispersion at the specified frequency of the envelope's frequency
     omega_eval = omega_eval if omega_eval is not None else omega0
 
-    assert (omega_eval < omega[-1]) and (omega_eval > omega.min())
+    disp0 = interp1d(omega, disp, bounds_error=True)(omega_eval) 
 
-    gdd0 = np.interp(omega_eval, omega, gdd)
-    return gdd, gdd0
-
-
-def get_tod(grid, dim, omega0, omega_eval=None, method="sum"):
-    r"""
-    Calculate the third order dispersion (TOD) of the laser.
-
-    .. math::
-        TOD = \frac{\partial^3 \phi(\omega)}{\partial \omega^3}
-
-
-    Parameters
-    ----------
-    grid : Grid
-        The grid with the field to analyze.
-
-    dim : string
-        Dimensionality of the array. Options are:
-
-        - ``'xyt'``: The laser pulse is represented on a 3D grid:
-                    Cartesian (x,y) transversely, and temporal (t) longitudinally.
-        - ``'rt'`` : The laser pulse is represented on a 2D grid:
-                    Cylindrical (r) transversely, and temporal (t) longitudinally.
-
-    omega0 : float
-        Angular frequency at which the laser envelope is defined.
-
-    omega_gdd : float, optional
-        Central angular frequency at which the GDD is calculated, if `None`, `omega0` is used.
-
-    method : string, optional
-        Method of retrieving the phase that is used for calculating the TOD. Options are:
-
-        - ``'sum'``: Calculates the spectral phase of the spatially summed field (default).
-        - ``'on-axis'``: Calculates the on-axis spectral phase.
-
-    Returns
-    -------
-    tod: ndarray of floats (1D)
-        Third order dispersion over the entire spectral range (in s^3)
-
-    tod0: float
-        Third order dispersion at the center frequency (in s^3)
-
-    """
-    # calculate the spectral phase of the laser pulse
-    phase, omega = get_spectral_phase(grid, dim, method=method, omega0=omega0)
-
-    # calculate the second derivative wrt. angular frequency
-    gd = np.gradient(phase, omega, axis=-1)
-    gdd = np.gradient(gd, omega, axis=-1)
-    tod = np.gradient(gdd, omega, axis=-1)
-
-    # get the GDD at the specified frequency or the envelope's frequency
-    omega_eval = omega_eval if omega_eval is not None else omega0
-
-    assert (omega_eval < omega[-1]) and (omega_eval > omega.min())
-
-    tod0 = np.interp(omega_eval, omega, tod)
-
-    return gdd, tod0
+    return disp, disp0 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1390,11 +1390,11 @@ def get_dispersion(grid, dim, omega0, order, omega_eval=None, method="sum"):
     Calculate the n-th order dispersion polynomial of the laser.
 
     .. math::
-        \Phi^{(n)} = \frac{\partial^{n} \phi(\omega)}{\partial \omega^{n}}
+        \Phi^{(n)} = \frac{\partial^n \phi(\omega)}{\partial \omega^n}
 
     where n is the order to which the disperison is calculated (in s^n/rad).
 
-    E.g. `order`=1, calculates the group delay (GD), `order`=2 calculates group delay dispersion (GDD) and `order`=3 calculates the third order dispersion (TOD).
+    E.g. 'order'=1, calculates the group delay (GD), 'order'=2 calculates group delay dispersion (GDD) and 'order'=3 calculates the third order dispersion (TOD).
 
     Parameters
     ----------

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1394,7 +1394,7 @@ def get_dispersion(grid, dim, omega0, order, omega_eval=None, method="sum"):
 
     where n is the order to which the disperison is calculated (in s^n/rad).
 
-    E.g. 'order'=1, calculates the group delay (GD), 'order'=2 calculates group delay dispersion (GDD) and 'order'=3 calculates the third order dispersion (TOD).
+    E.g. order=1, calculates the group delay (GD), order=2 calculates group delay dispersion (GDD) and order=3 calculates the third-order dispersion (TOD).
 
     Parameters
     ----------

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1384,6 +1384,7 @@ def get_spectral_phase(grid, dim, omega0, method="sum", ordering="zero_center"):
     # return the phase and omega arrays
     return phase, omega
 
+
 def get_dispersion(grid, dim, omega0, order, omega_eval=None, method="sum"):
     r"""
     Calculate the n-th order dispersion polynomial of the laser.
@@ -1437,12 +1438,12 @@ def get_dispersion(grid, dim, omega0, order, omega_eval=None, method="sum"):
 
     # calculate the n-th order derivative wrt. angular frequency
     disp = np.gradient(phase, omega, axis=-1)
-    for _ in range(order-1):
+    for _ in range(order - 1):
         disp = np.gradient(disp, omega, axis=-1)
 
     # get the dispersion at the specified frequency of the envelope's frequency
     omega_eval = omega_eval if omega_eval is not None else omega0
 
-    disp0 = interp1d(omega, disp, bounds_error=True)(omega_eval) 
+    disp0 = interp1d(omega, disp, bounds_error=True)(omega_eval)
 
-    return disp, disp0 
+    return disp, disp0

--- a/tests/test_STC.py
+++ b/tests/test_STC.py
@@ -14,7 +14,7 @@ from lasy.profiles.combined_profile import CombinedLongitudinalTransverseProfile
 from lasy.profiles.gaussian_profile import GaussianProfile
 from lasy.profiles.longitudinal import GaussianLongitudinalProfile
 from lasy.profiles.transverse import GaussianTransverseProfile
-from lasy.utils.laser_utils import get_beta, get_gdd, get_zeta
+from lasy.utils.laser_utils import get_beta, get_dispersion, get_zeta
 
 wavelength = 0.6e-6  # m
 pol = (1, 0)
@@ -99,8 +99,8 @@ err_imag = np.average(
     / np.array(env_combined.imag)
 )
 
-gdd_3d, gdd0_3d = get_gdd(
-    grid=laser_3d.grid, dim=laser_3d.dim, omega0=laser_3d.profile.omega0
+gdd_3d, gdd0_3d = get_dispersion(
+    grid=laser_3d.grid, dim=laser_3d.dim, omega0=laser_3d.profile.omega0, order=2
 )
 [zeta_x, zeta_y], [nu_x, nu_y] = get_zeta(
     laser_3d.dim, laser_3d.grid, 2.0 * np.pi / 0.6e-6

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -2,9 +2,17 @@ import numpy as np
 from scipy.constants import c, epsilon_0
 
 from lasy.laser import Laser
-from lasy.profiles.gaussian_profile import GaussianProfile
-from lasy.utils.laser_utils import compute_laser_energy, get_duration, get_spectrum, get_gd, get_gdd, get_tod
 from lasy.optical_elements.polynomial_spectral_phase import PolynomialSpectralPhase
+from lasy.profiles.gaussian_profile import GaussianProfile
+from lasy.utils.laser_utils import (
+    compute_laser_energy,
+    get_duration,
+    get_gd,
+    get_gdd,
+    get_spectrum,
+    get_tod,
+)
+
 
 def get_gaussian_profile():
     # Cases with Gaussian laser
@@ -38,8 +46,7 @@ def test_laser_analysis_utils():
         laser = get_gaussian_laser(dim)
 
         # Check that energy computed from spectrum agrees with `compute_laser_energy`.
-        spectrum, omega = get_spectrum(
-            laser.grid, dim, omega0=laser.profile.omega0)
+        spectrum, omega = get_spectrum(laser.grid, dim, omega0=laser.profile.omega0)
         d_omega = omega[1] - omega[0]
         spectrum_energy = np.sum(spectrum) * d_omega
         energy = compute_laser_energy(dim, laser.grid)
@@ -47,20 +54,26 @@ def test_laser_analysis_utils():
 
         # Check that laser duration agrees with the given one.
         tau_rms = get_duration(laser.grid, dim)
-        np.testing.assert_approx_equal(
-            2 * tau_rms, laser.profile.tau, significant=3)
+        np.testing.assert_approx_equal(2 * tau_rms, laser.profile.tau, significant=3)
 
         # Check that the spectral phase terms are calculated correctly.
         gd = 10e-15
         gdd = 50e-30
         tod = 100e-45
         laser_chirped = get_gaussian_laser(dim)
-        dazzler = PolynomialSpectralPhase(omega0=laser_chirped.profile.omega0,
-                                          delay=gd, gdd=gdd, tod=tod)
+        dazzler = PolynomialSpectralPhase(
+            omega0=laser_chirped.profile.omega0, delay=gd, gdd=gdd, tod=tod
+        )
         laser_chirped.apply_optics(dazzler)
-        _, gd_evaluated = get_gd(laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0)
-        _, gdd_evaluated = get_gdd(laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0)
-        _, tod_evaluated = get_tod(laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0)
+        _, gd_evaluated = get_gd(
+            laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0
+        )
+        _, gdd_evaluated = get_gdd(
+            laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0
+        )
+        _, tod_evaluated = get_tod(
+            laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0
+        )
 
         assert np.isclose(gd, gd_evaluated, atol=laser_chirped.grid.dx[-1])
         assert np.isclose(gdd, gdd_evaluated, atol=0)

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -6,9 +6,10 @@ from lasy.optical_elements.polynomial_spectral_phase import PolynomialSpectralPh
 from lasy.profiles.gaussian_profile import GaussianProfile
 from lasy.utils.laser_utils import (
     compute_laser_energy,
+    get_dispersion,
     get_duration,
     get_spectrum,
-    get_dispersion)
+)
 
 
 def get_gaussian_profile():

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -3,8 +3,8 @@ from scipy.constants import c, epsilon_0
 
 from lasy.laser import Laser
 from lasy.profiles.gaussian_profile import GaussianProfile
-from lasy.utils.laser_utils import compute_laser_energy, get_duration, get_spectrum
-
+from lasy.utils.laser_utils import compute_laser_energy, get_duration, get_spectrum, get_gd, get_gdd, get_tod
+from lasy.optical_elements.polynomial_spectral_phase import PolynomialSpectralPhase
 
 def get_gaussian_profile():
     # Cases with Gaussian laser

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -7,11 +7,8 @@ from lasy.profiles.gaussian_profile import GaussianProfile
 from lasy.utils.laser_utils import (
     compute_laser_energy,
     get_duration,
-    get_gd,
-    get_gdd,
     get_spectrum,
-    get_tod,
-)
+    get_dispersion)
 
 
 def get_gaussian_profile():
@@ -65,14 +62,14 @@ def test_laser_analysis_utils():
             omega0=laser_chirped.profile.omega0, delay=gd, gdd=gdd, tod=tod
         )
         laser_chirped.apply_optics(dazzler)
-        _, gd_evaluated = get_gd(
-            laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0
+        _, gd_evaluated = get_dispersion(
+            laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0, order=1
         )
-        _, gdd_evaluated = get_gdd(
-            laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0
+        _, gdd_evaluated = get_dispersion(
+            laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0, order=2
         )
-        _, tod_evaluated = get_tod(
-            laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0
+        _, tod_evaluated = get_dispersion(
+            laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0, order=3
         )
 
         assert np.isclose(gd, gd_evaluated, atol=laser_chirped.grid.dx[-1])

--- a/tests/test_laser_utils.py
+++ b/tests/test_laser_utils.py
@@ -38,7 +38,8 @@ def test_laser_analysis_utils():
         laser = get_gaussian_laser(dim)
 
         # Check that energy computed from spectrum agrees with `compute_laser_energy`.
-        spectrum, omega = get_spectrum(laser.grid, dim, omega0=laser.profile.omega0)
+        spectrum, omega = get_spectrum(
+            laser.grid, dim, omega0=laser.profile.omega0)
         d_omega = omega[1] - omega[0]
         spectrum_energy = np.sum(spectrum) * d_omega
         energy = compute_laser_energy(dim, laser.grid)
@@ -46,7 +47,24 @@ def test_laser_analysis_utils():
 
         # Check that laser duration agrees with the given one.
         tau_rms = get_duration(laser.grid, dim)
-        np.testing.assert_approx_equal(2 * tau_rms, laser.profile.tau, significant=3)
+        np.testing.assert_approx_equal(
+            2 * tau_rms, laser.profile.tau, significant=3)
+
+        # Check that the spectral phase terms are calculated correctly.
+        gd = 10e-15
+        gdd = 50e-30
+        tod = 100e-45
+        laser_chirped = get_gaussian_laser(dim)
+        dazzler = PolynomialSpectralPhase(omega0=laser_chirped.profile.omega0,
+                                          delay=gd, gdd=gdd, tod=tod)
+        laser_chirped.apply_optics(dazzler)
+        _, gd_evaluated = get_gd(laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0)
+        _, gdd_evaluated = get_gdd(laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0)
+        _, tod_evaluated = get_tod(laser_chirped.grid, dim, omega0=laser_chirped.profile.omega0)
+
+        assert np.isclose(gd, gd_evaluated, atol=laser_chirped.grid.dx[-1])
+        assert np.isclose(gdd, gdd_evaluated, atol=0)
+        assert np.isclose(tod, tod_evaluated, atol=0)
 
 
 def test_laser_normalization_utils():


### PR DESCRIPTION
Added functions to analyze the group delay (GD) and third order dispersion (TOD), analogously to the previously added function `get_gdd()` (see PR #383 ). The useage is exactly the same in all three functions, an example is shown below:

```python
from lasy.laser import Laser
from lasy.profiles import GaussianProfile
from lasy.optical_elements import PolynomialSpectralPhase
from lasy.utils.laser_utils import get_gd, get_gdd, get_tod

w0 = 1e-3
tau = 30e-15
energy = 1
wavelength = 0.8e-6
pol = (1,0)
t_peak = 0

profile = GaussianProfile(wavelength, pol, laser_energy=energy, w0=w0, tau=tau, t_peak=t_peak)

dim='xyt'
lo = (-5e-3, -5e-3, -300e-15)
hi = (5e-3, 5e-3, 300e-15)
npoints = (100, 100, 200)

laser = Laser(dim=dim, lo=lo, hi=hi, npoints=npoints, profile=profile)

gd_value = 15e-15
gdd_value = -100e-30
tod_value = 1000e-45

# Create a polynomial spectral phase with the specified parameters
dazzler = PolynomialSpectralPhase(laser.profile.omega0, delay=gd_value, gdd=gdd_value, tod=tod_value)

# Apply the polynomial spectral phase to the laser
laser.apply_optics(dazzler)

# Calculate the applied phase terms 
gd_evaluated= get_gd(grid=laser.grid, dim=laser.dim, omega0=laser.profile.omega0)[1]
gdd_evaluated = get_gdd(grid=laser.grid, dim=laser.dim, omega0=laser.profile.omega0)[1]
tod_evaluated = get_tod(grid=laser.grid, dim=laser.dim, omega0=laser.profile.omega0)[1]

print('gd:', gd_value*1e15, ', gd eval:', gd_evaluated*1e15)
print('gdd:', gdd_value*1e30, ', gdd eval:', gdd_evaluated*1e30)
print('tod:', tod_value*1e45, ', tod eval:', tod_evaluated*1e45)
```

In addition to this, tests for all three functions were added to `tests/test_laser_utils.py`, and some very minor cleaning of `get_gdd()` was done to keep things as consistent as possible.


A limitation that may be worth discussing is that the current implementation of`get_gd()` is "only" accurate to within 1 temporal grid cell, while the other functions (higher order derivatives) are accurate to <10e-8 relative level. This means that the calculated group delay can be off by up to a few femtoseconds depending on the exact grid spacing that is used. For most applications this is probably no problem, but may be worth discussing or improving if necessary. The origin of this limited accuracy seems to be related to numerical noise in parts of the spectral phase, where no spectral intensity is present.