### PR TITLE
Allows passing iteration number to `FromOpenPMDProfile`

### DIFF
--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -28,19 +28,32 @@ class FromOpenPMDProfile(FromArrayProfile):
         If specified, an envelope field is expected from the openPMD file. Otherwise, a full electric field is assumed.
         In the case of a full field, The transverse electric field (Ex & Ey or Er and Etheta) is read, and the polarization is measured from this.
 
+    iteration : int (optional)
+        The iteration to read from the openPMD file. If not specified, the last iteration is read.
+        The user can pass a `file_name` pattern such as `file_name="path/to/file%T.h5"`,
+        to loop over the iterations present in the set of files matching the pattern.
+
     verbose : bool (optional)
         If true, print some intermediate steps.
     """
 
-    def __init__(self, file_name, envelope_name=None, verbose=False):
+    def __init__(self, file_name, envelope_name=None, iteration=None,verbose=False):
         series = io.Series(file_name, io.Access.read_only)
         iterations = np.array(series.iterations)
-        i = series.iterations[iterations[-1]]
+        if iteration is None:
+            iteration = iterations[-1]
+        elif iteration not in iterations:
+            raise ValueError(
+                f"Iteration {iteration} not found in openPMD file {file_name}.\n"
+                f"Available iterations are: {iterations}.\n"
+                f"You can omit the iteration argument to read the last iteration.\n"
+            )
+        it = series.iterations[iteration]
         is_envelope = envelope_name is not None
         if is_envelope:
             if verbose:
                 print("Read envelope")
-            m = i.meshes[envelope_name]
+            m = it.meshes[envelope_name]
             geometry = m.get_attribute("geometry")
             dim = "xyt" if geometry == "cartesian" else "rt"
             omg0 = m.get_attribute("angularFrequency")
@@ -64,7 +77,7 @@ class FromOpenPMDProfile(FromArrayProfile):
                 grid = create_grid(array, axes, dim)
                 array = vector_potential_to_field(grid, omg0)
         else:
-            geometry = i.meshes["E"].get_attribute("geometry")
+            geometry = it.meshes["E"].get_attribute("geometry")
             if geometry == "cartesian":
                 field_list = ["E", "E"]
                 coord_list = ["x", "y"]
@@ -74,7 +87,7 @@ class FromOpenPMDProfile(FromArrayProfile):
             array_list = []
             for count, field in enumerate(field_list):
                 # Read the data
-                m = i.meshes[field]
+                m = it.meshes[field]
                 component = coord_list[count]
                 axes_order, axes, array = extract_array(m, series, component)
                 array_list.append(array)

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -23,7 +23,7 @@ class FromOpenPMDProfile(FromArrayProfile):
     file_name : string
         Name of openPMD file, including path, to read the laser field or envelope from.
         When the openPMD series contains 1 file per iteration, either specify the exact file name (e.g. ``file_name="/path/data_00001.h5"``) or a file pattern + iteration (e.g. ``file_name="/path/data%T.h5", iteration=1``).
-        When the openPMD series contains 1 file with all iterations, specify file name + iteration (e.g. ``file_name="/path/data.h5", iteration=1``).
+        When the openPMD series contains 1 file with all iterations, specify file name + optionally the iteration (e.g. ``file_name="/path/data.h5", iteration=1``).
 
     envelope_name : string (optional)
         The name of the envelope field (this is not prescribed by the openPMD standard for the envelope).

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -22,6 +22,8 @@ class FromOpenPMDProfile(FromArrayProfile):
     ----------
     file_name : string
         Name of openPMD file, including path, to read the laser field or envelope from.
+        When the openPMD series contains 1 file per iteration, either specify the exact file name (e.g. ``file_name="/path/data_00001.h5"``) or a file pattern + iteration (e.g. ``file_name="/path/data%T.h5", iteration=1``).
+        When the openPMD series contains 1 file with all iterations, specify file name + iteration (e.g. ``file_name="/path/data.h5", iteration=1``).
 
     envelope_name : string (optional)
         The name of the envelope field (this is not prescribed by the openPMD standard for the envelope).
@@ -30,8 +32,6 @@ class FromOpenPMDProfile(FromArrayProfile):
 
     iteration : int (optional)
         The iteration to read from the openPMD file. If not specified, the last iteration is read.
-        The user can pass a `file_name` pattern such as `file_name="path/to/file%T.h5"`,
-        to loop over the iterations present in the set of files matching the pattern.
 
     verbose : bool (optional)
         If true, print some intermediate steps.

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -37,7 +37,7 @@ class FromOpenPMDProfile(FromArrayProfile):
         If true, print some intermediate steps.
     """
 
-    def __init__(self, file_name, envelope_name=None, iteration=None,verbose=False):
+    def __init__(self, file_name, envelope_name=None, iteration=None, verbose=False):
         series = io.Series(file_name, io.Access.read_only)
         iterations = np.array(series.iterations)
         if iteration is None:


### PR DESCRIPTION
```
    iteration : int (optional)
        The iteration to read from the openPMD file. If not specified, the last iteration is read.
        The user can pass a `file_name` pattern such as `file_name="path/to/file%T.h5"`,
        to loop over the iterations present in the set of files matching the pattern.

```