### PR TITLE
Fix bug in openPMD reader when extracting central frequency

### DIFF
--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -83,11 +83,10 @@ class FromOpenPMDProfile(FromArrayProfile):
             array_list = convert_modes(array_list, geometry, is_envelope, verbose)
             dim = "xyt" if geometry == "cartesian" else "rt"
             # Detect whether Ex (index 0) or Ey (index 1) is strongest (major)
-            imajor = (
-                0
-                if np.max(np.abs(array_list[0])) >= np.max(np.abs(array_list[1]))
-                else 1
-            )
+            if np.max(np.abs(array_list[0])) >= np.max(np.abs(array_list[1])):
+                imajor = 0
+            else:
+                imajor = 1
             iminor = 1 - imajor
             # Convert major field to envelope, and measure frequency
             grid = create_grid(array_list[imajor], axes, dim, is_envelope=False)

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -82,12 +82,21 @@ class FromOpenPMDProfile(FromArrayProfile):
             #           to Ex & Ey at LASY mode decomposition.
             array_list = convert_modes(array_list, geometry, is_envelope, verbose)
             dim = "xyt" if geometry == "cartesian" else "rt"
-            env_array_list = []
-            for array in array_list:
-                grid = create_grid(array, axes, dim, is_envelope=False)
-                omg0 = field_to_envelope(grid, dim)
-                array = grid.get_temporal_field()
-                env_array_list.append(array)
+            # Detect whether Ex (index 0) or Ey (index 1) is strongest (major)
+            imajor = 0 if np.max(np.abs(array_list[0])) >= np.max(np.abs(array_list[1])) else 1
+            iminor = 1 - imajor
+            # Convert major field to envelope, and measure frequency
+            grid = create_grid(array_list[imajor], axes, dim, is_envelope=False)
+            omg0 = field_to_envelope(grid, dim)
+            array_major = grid.get_temporal_field()
+            # Convert other field to envelope, for the same frequency
+            grid = create_grid(array_list[iminor], axes, dim, is_envelope=False)
+            field_to_envelope(grid, dim, omg0)
+            array_minor = grid.get_temporal_field()
+            # Measure polarization state from Ex and Ey
+            env_array_list = [None, None]
+            env_array_list[imajor] = array_major
+            env_array_list[iminor] = array_minor
             array, pol = isolate_polarization(env_array_list, dim)
         wavelength = 2 * np.pi * c / omg0
 

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -83,7 +83,11 @@ class FromOpenPMDProfile(FromArrayProfile):
             array_list = convert_modes(array_list, geometry, is_envelope, verbose)
             dim = "xyt" if geometry == "cartesian" else "rt"
             # Detect whether Ex (index 0) or Ey (index 1) is strongest (major)
-            imajor = 0 if np.max(np.abs(array_list[0])) >= np.max(np.abs(array_list[1])) else 1
+            imajor = (
+                0
+                if np.max(np.abs(array_list[0])) >= np.max(np.abs(array_list[1]))
+                else 1
+            )
             iminor = 1 - imajor
             # Convert major field to envelope, and measure frequency
             grid = create_grid(array_list[imajor], axes, dim, is_envelope=False)

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -89,17 +89,15 @@ class FromOpenPMDProfile(FromArrayProfile):
                 imajor = 1
             iminor = 1 - imajor
             # Convert major field to envelope, and measure frequency
-            grid = create_grid(array_list[imajor], axes, dim, is_envelope=False)
-            omg0 = field_to_envelope(grid, dim)
-            array_major = grid.get_temporal_field()
+            grid_major = create_grid(array_list[imajor], axes, dim, is_envelope=False)
+            omg0 = field_to_envelope(grid_major, dim)
             # Convert other field to envelope, for the same frequency
-            grid = create_grid(array_list[iminor], axes, dim, is_envelope=False)
-            field_to_envelope(grid, dim, omg0)
-            array_minor = grid.get_temporal_field()
+            grid_minor = create_grid(array_list[iminor], axes, dim, is_envelope=False)
+            field_to_envelope(grid_minor, dim, omg0)
             # Measure polarization state from Ex and Ey
             env_array_list = [None, None]
-            env_array_list[imajor] = array_major
-            env_array_list[iminor] = array_minor
+            env_array_list[imajor] = grid_major.get_temporal_field()
+            env_array_list[iminor] = grid_minor.get_temporal_field()
             array, pol = isolate_polarization(env_array_list, dim)
         wavelength = 2 * np.pi * c / omg0
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -754,6 +754,7 @@ def field_to_envelope(grid, dim, omega0=None, phase_unwrap_nd=False):
 
     return omg0 if omega0 is None else None
 
+
 def hilbert_transform(field):
     """Make a hilbert transform of the field.
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -717,8 +717,8 @@ def field_to_envelope(grid, dim, omega0=None, phase_unwrap_nd=False):
                     Cylindrical (r) transversely, and temporal (t) longitudinally.
 
     omega0 : scalar
-        Central frequency of the field.
-        If None, this is measured from the field.
+        Central frequency at which the envelope will be defined.
+        If None, the central frequency measured from the field is used.
 
     phase_unwrap_nd : boolean (optional)
         If True, the phase unwrapping is n-dimensional (2- or 3-D depending on dim).

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -699,7 +699,7 @@ def vector_potential_to_field(grid, omega0, direct=True):
         return 1j * m_e * omega * c * field / e
 
 
-def field_to_envelope(grid, dim, phase_unwrap_nd=False):
+def field_to_envelope(grid, dim, omega0=None, phase_unwrap_nd=False):
     """Convert a field to its complex envelope representation by applying a Hilbert transform.
 
     Parameters
@@ -716,6 +716,10 @@ def field_to_envelope(grid, dim, phase_unwrap_nd=False):
         - ``'rt'`` : The laser pulse is represented on a 2D grid:
                     Cylindrical (r) transversely, and temporal (t) longitudinally.
 
+    omega0 : scalar
+        Central frequency of the field.
+        If None, this is measured from the field.
+
     phase_unwrap_nd : boolean (optional)
         If True, the phase unwrapping is n-dimensional (2- or 3-D depending on dim).
         If False, the phase unwrapping is done in t, treating each transverse cell
@@ -725,27 +729,30 @@ def field_to_envelope(grid, dim, phase_unwrap_nd=False):
     Returns
     -------
     scalar
-        The central angular frequency.
+        If input parameter omega0 was None, return the central angular frequency.
+        Otherwise, return None.
     """
     assert not grid.is_envelope
 
     # Get central wavelength from array
-    _, omg0_h = get_frequency(
-        grid,
-        dim=dim,
-        is_hilbert=False,
-        phase_unwrap_nd=phase_unwrap_nd,
-    )
+    if omega0 is None:
+        _, omg0 = get_frequency(
+            grid,
+            dim=dim,
+            is_hilbert=False,
+            phase_unwrap_nd=phase_unwrap_nd,
+        )
+    else:
+        omg0 = omega0
     # Hilbert transform
     field = hilbert_transform(grid.get_temporal_field())
     # Remove carrier frequency
-    field *= np.exp(1j * omg0_h * grid.axes[-1])
+    field *= np.exp(1j * omg0 * grid.axes[-1])
     # Store envelope
     grid.set_is_envelope(True)
     grid.set_temporal_field(field)
 
-    return omg0_h
-
+    return omg0 if omega0 is None else None
 
 def hilbert_transform(field):
     """Make a hilbert transform of the field.


### PR DESCRIPTION
In the `FromOpenPMDProfile` init in cylindrical geometry, the envelopes **and** frequencies of Ex and Ey was extracted separately, and the latest value calculated (for Ey) was used when setting up the final LASY profile. For an x-polarized laser pulse, this contained garbaged causing the frequency to be incorrect (and probably sometimes the polarization). This PR proposes a fix by determining which field contains most signal, getting the central frequency from there and using it in the definition of the envelope of the other field.

Thanks @delaossa for reporting and documenting (offline)!