### PR TITLE
[mini] Store position separately

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -368,21 +368,16 @@ class Laser:
             )
             spectral_field = np.moveaxis(transform_data, 0, -1).copy()
 
-        # Choose the time translation assuming propagation at v=c
-        translate_time = distance / c
-
         # This translation (e.g. delay in time, compared to t=0, associated
         # with the propagation) is not automatically handled by the above
         # propagators, so it needs to be added by hand.
         # Note: subtracting by omega0 is only a global phase convention,
         # that derives from the definition of the envelope in lasy.
-        spectral_field *= np.exp(-1j * spectral_axis * translate_time)
+        spectral_field *= np.exp(-1j * spectral_axis * distance / c)
         self.grid.set_spectral_field(spectral_field)
 
         # Translate the domain
-        self.grid.lo[time_axis_indx] += translate_time
-        self.grid.hi[time_axis_indx] += translate_time
-        self.grid.axes[time_axis_indx] += translate_time
+        self.grid.position += distance
 
     def write_to_file(
         self,

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -57,10 +57,7 @@ class FromOpenPMDProfile(FromArrayProfile):
             geometry = m.get_attribute("geometry")
             dim = "xyt" if geometry == "cartesian" else "rt"
             omg0 = m.get_attribute("angularFrequency")
-            try:
-                position = m.grid_global_offset[0] * c
-            except Exception:
-                position = 0.0
+            position = m.grid_global_offset[0] * c
             try:
                 envelopeField = m.get_attribute("envelopeField")
                 pol = m.get_attribute("polarization")

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -58,7 +58,7 @@ class FromOpenPMDProfile(FromArrayProfile):
             dim = "xyt" if geometry == "cartesian" else "rt"
             omg0 = m.get_attribute("angularFrequency")
             try:
-                position = m.get_attribute("position")
+                position = m.grid_global_offset[0] * c
             except Exception:
                 position = 0.
             try:

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -60,7 +60,7 @@ class FromOpenPMDProfile(FromArrayProfile):
             try:
                 position = m.get_attribute("position")
             except Exception:
-                position = 0.
+                position = 0.0
             try:
                 envelopeField = m.get_attribute("envelopeField")
                 pol = m.get_attribute("polarization")

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -58,6 +58,10 @@ class FromOpenPMDProfile(FromArrayProfile):
             dim = "xyt" if geometry == "cartesian" else "rt"
             omg0 = m.get_attribute("angularFrequency")
             try:
+                position = m.get_attribute("position")
+            except Exception:
+                position = 0.
+            try:
                 envelopeField = m.get_attribute("envelopeField")
                 pol = m.get_attribute("polarization")
             except Exception:
@@ -74,7 +78,7 @@ class FromOpenPMDProfile(FromArrayProfile):
             if envelopeField == "normalized_vector_potential":
                 if verbose:
                     print("Convert from vector potential to electric field")
-                grid = create_grid(array, axes, dim)
+                grid = create_grid(array, axes, dim, position=position)
                 array = vector_potential_to_field(grid, omg0)
         else:
             geometry = it.meshes["E"].get_attribute("geometry")

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -56,7 +56,7 @@ class Grid:
         is_envelope=True,
         is_cw=False,
         is_plane_wave=False,
-        position=0.,
+        position=0.0,
     ):
         # Metadata
         ndims = 2 if dim == "rt" else 3

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -41,6 +41,9 @@ class Grid:
 
     is_plane_wave : bool (optional)
         Whether the laser pulse transverse profile is a plane wave laer profile or not.
+
+    position : scalar (optional)
+        Longitudinal (z) position in a beamline at which the pulse is defined.
     """
 
     def __init__(
@@ -53,6 +56,7 @@ class Grid:
         is_envelope=True,
         is_cw=False,
         is_plane_wave=False,
+        position=0.,
     ):
         # Metadata
         ndims = 2 if dim == "rt" else 3
@@ -122,6 +126,7 @@ class Grid:
         self.temporal_field_valid = False
         self.spectral_field = np.zeros(self.shape, dtype="complex128")
         self.spectral_field_valid = False
+        self.position = position
 
     def set_is_envelope(self, is_envelope):
         """

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -823,7 +823,7 @@ def weighted_std(values, weights=None):
     return std
 
 
-def create_grid(array, axes, dim, is_envelope=True):
+def create_grid(array, axes, dim, is_envelope=True, position=0.0):
     """Create a lasy grid from a numpy array.
 
     Parameters
@@ -852,7 +852,7 @@ def create_grid(array, axes, dim, is_envelope=True):
         lo = (axes["x"][0], axes["y"][0], axes["t"][0])
         hi = (axes["x"][-1], axes["y"][-1], axes["t"][-1])
         npoints = (axes["x"].size, axes["y"].size, axes["t"].size)
-        grid = Grid(dim, lo, hi, npoints, is_envelope=is_envelope)
+        grid = Grid(dim, lo, hi, npoints, is_envelope=is_envelope, position=position)
         assert np.allclose(grid.axes[0], axes["x"])
         assert np.allclose(grid.axes[1], axes["y"])
         assert np.allclose(grid.axes[2], axes["t"], rtol=1.0e-14)

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -88,6 +88,7 @@ def write_to_openpmd_file(
     # Store metadata needed to reconstruct the field
     m.set_attribute("angularFrequency", 2 * np.pi * c / wavelength)
     m.set_attribute("polarization", pol)
+    m.set_attribute("position", grid.position)
     if save_as_vector_potential:
         m.set_attribute("envelopeField", "normalized_vector_potential")
         m.unit_dimension = {}

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -78,6 +78,7 @@ def write_to_openpmd_file(
         for hi, lo, npoints in zip(grid.hi, grid.lo, grid.npoints)
     ][::-1]
     m.grid_global_offset = grid.lo[::-1]
+    m.grid_global_offset[0] += grid.position / c
     if dim == "xyt":
         m.geometry = io.Geometry.cartesian
         m.axis_labels = ["t", "y", "x"]
@@ -88,7 +89,6 @@ def write_to_openpmd_file(
     # Store metadata needed to reconstruct the field
     m.set_attribute("angularFrequency", 2 * np.pi * c / wavelength)
     m.set_attribute("polarization", pol)
-    m.set_attribute("position", grid.position)
     if save_as_vector_potential:
         m.set_attribute("envelopeField", "normalized_vector_potential")
         m.unit_dimension = {}


### PR DESCRIPTION
Currently, the grid object contains a time axis that contains both the comoving coordinate for the longitudinal profile of the laser pulse and the position at which the laser pulse is defined. Hence, if the laser is defined on a grid `[tmin, tmax]`, propagating by distance `d` means we shift the grid to `[tmin+d/c, tmax+d/c]`. This is entirely correct, but it requires a bit of handling in the propagators, and makes it slightly less obvious when propagating in a medium with group velocity `vg<c`. This small PR proposes to split these two elements, and keep `[tmin, tmax]` centred around `0` while encoding the distance propagated in a separate attribute `grid.position`, also written to file. The user is responsible for defining the origin of this position axis (as before). ~~I think this could be added to the openPMD standard for laser envelope.~~ in openPMD, this is encoded in `grid_global_offset`.