### PR TITLE
fix argument order in axiprop fresnel propagator

### DIFF
--- a/lasy/propagators/axiprop_propagators.py
+++ b/lasy/propagators/axiprop_propagators.py
@@ -474,7 +474,14 @@ class AxipropFresnelPropagator(Propagator):
             )
 
     def propagate(
-        self, distance, grid_in, dim, omega0, grid_out=None, verbose=True, nr_boundary=0
+        self,
+        grid_in,
+        dim,
+        omega0,
+        distance=None,
+        grid_out=None,
+        verbose=True,
+        nr_boundary=0,
     ):
         r"""
         Propagate laser pulse in z direction by a given distance.


### PR DESCRIPTION
Currently the Axiprop Fresnel wrapper doesn't work due to the different order of arguments defined in the propagate method. This PR fixes it