### PR TITLE
Fix propagator issue

### DIFF
--- a/lasy/propagators/angular_spectrum_propagator.py
+++ b/lasy/propagators/angular_spectrum_propagator.py
@@ -121,12 +121,11 @@ class AngularSpectrumPropagator(Propagator):
             field, dt = self._propagate_xyt(distance, grid_in)
 
         # update the grid
+        grid_out.set_spectral_field(field)
         grid_out.position += distance
         grid_out.axes[-1] += dt
         grid_out.lo[-1] += dt
         grid_out.hi[-1] += dt
-
-        grid_out.set_spectral_field(field)
 
         return grid_out
 

--- a/lasy/utils/fft_wrapper.py
+++ b/lasy/utils/fft_wrapper.py
@@ -102,6 +102,7 @@ def fft(which, arr_in, axes_in, from_domain):
     axes_out = frequency_axis(which, axes_in, from_domain)
     return arr_out, axes_out
 
+
 def frequency_axis(which, axes_in, from_domain):
     """
     Perform FFT on a 3D array.

--- a/lasy/utils/fft_wrapper.py
+++ b/lasy/utils/fft_wrapper.py
@@ -56,15 +56,103 @@ def fft(which, arr_in, axes_in, from_domain):
         if min(axes_in[0].size, axes_in[1].size) < 2:
             print("fft of size 1: do nothing")
             return arr_in, axes_in
+
+        # Set right FFT functions
+        if inverse:
+            xfft = np.fft.ifft2
+        else:
+            xfft = np.fft.fft2
+
+        # Do the FFT
+        arr = np.copy(arr_in)
+        if shift_before:
+            arr = xfftshift(arr, axes=(0, 1))
+        arr_out = xfft(arr, axes=(0, 1))
+
+        # Shift after FFT
+        if shift_after:
+            arr_out = xfftshift(arr_out, axes=(0, 1))
+
+    else:  # which == "longitudinal"
+        # Exit if only 1 element
+        if axes_in.size <= 1:
+            print("fft of size 1: do nothing")
+            return arr_in, axes_in
+
+        # Set right FFT functions
+        if inverse:
+            xfft = np.fft.ifft
+        else:
+            xfft = np.fft.fft
+
+        # Do the FFT
+        arr = np.copy(arr_in)
+        if shift_before:
+            arr = xfftshift(arr, axes=-1)
+        arr_out = xfft(arr, axis=-1)
+
+        # Shift after FFT
+        if shift_after:
+            arr_out = xfftshift(arr_out, axes=-1)
+
+    axes_out = frequency_axis(which, axes_in, from_domain)
+    return arr_out, axes_out
+
+def frequency_axis(which, axes_in, from_domain):
+    """
+    Perform FFT on a 3D array.
+
+    We use the following conventions:
+     - From physical space (x&y or t) to frequency space (kx&ky or omega), the FFT done is data_freq = ifft(ifftshift(data_phys))
+     - From frequency space (kx&ky or omega) to physical space (x&y or t), the FFT done is data_phys = fftshift(fft(data_freq))
+
+    Parameters
+    ----------
+    which : string
+        "transverse" for FFTs in the 2 transverse directions (x,y or kx,ky)
+        "longitudinal" for longitudinal direction (t or omega)
+
+    axes_in : list of 1d arrays
+        List of axes along which the FFT is to be performed:
+        2 elements for which="transverse", 1 for which="longitudinal"
+
+    from_domain : string
+        "real" of the FFT is done from real domain (x,y) or (t) to frequency domain (kx, ky) or (omega)
+        "frequency" for the opposite way
+
+    Returns
+    -------
+    arr_out : ndarray
+        3D array after FFT
+
+    axes_out : list of 1d arrays
+        if which="transverse", 2 1d arrays for the transverse transformed axes
+        if which="longitudinal", 1 1d array for the longitudinal transformed axis
+    """
+    # Checks, read parameters and set defaults
+    assert which in ["transverse", "longitudinal"]
+    assert from_domain in ["real", "frequency"]
+
+    # Set conventions:
+    # - From real to frequency, use ifft & fftshift on input data.
+    # - From frequency to real, use fft & fftshift on output data.
+    if from_domain == "real":
+        shift_before = True
+        shift_after = False
+        inverse = True
+    else:
+        shift_before = False
+        shift_after = True
+        inverse = False
+
+    if which == "transverse":
         dx = axes_in[0][1] - axes_in[0][0]
         dy = axes_in[1][1] - axes_in[1][0]
 
         # Set right FFT functions
         if inverse:
-            xfft = np.fft.ifft2
             xfftshift = np.fft.ifftshift
         else:
-            xfft = np.fft.fft2
             xfftshift = np.fft.fftshift
 
         # Build output axes data
@@ -76,47 +164,25 @@ def fft(which, arr_in, axes_in, from_domain):
             axes_out[0] *= 2 * np.pi
             axes_out[1] *= 2 * np.pi
 
-        # Do the FFT
-        arr = np.copy(arr_in)
-        if shift_before:
-            arr = xfftshift(arr, axes=(0, 1))
-        arr_out = xfft(arr, axes=(0, 1))
-
         # Shift after FFT
         if shift_after:
             axes_out[0] = xfftshift(axes_out[0])
             axes_out[1] = xfftshift(axes_out[1])
-            arr_out = xfftshift(arr_out, axes=(0, 1))
 
     else:  # which == "longitudinal"
-        # Exit if only 1 element
-        if axes_in.size <= 1:
-            print("fft of size 1: do nothing")
-            return arr_in, axes_in
         d = axes_in[1] - axes_in[0]
 
         # Set right FFT functions
         if inverse:
-            xfft = np.fft.ifft
             xfftshift = np.fft.ifftshift
         else:
-            xfft = np.fft.fft
             xfftshift = np.fft.fftshift
 
         # Build output axes data
         axes_out = np.fft.fftfreq(axes_in.size, d)
-        if from_domain == "real":
-            axes_out *= 2 * np.pi
-
-        # Do the FFT
-        arr = np.copy(arr_in)
-        if shift_before:
-            arr = xfftshift(arr, axes=-1)
-        arr_out = xfft(arr, axis=-1)
 
         # Shift after FFT
         if shift_after:
             axes_out = xfftshift(axes_out)
-            arr_out = xfftshift(arr_out, axes=-1)
 
-    return arr_out, axes_out
+    return axes_out

--- a/lasy/utils/fft_wrapper.py
+++ b/lasy/utils/fft_wrapper.py
@@ -142,11 +142,9 @@ def frequency_axis(which, axes_in, from_domain):
     # - From real to frequency, use ifft & fftshift on input data.
     # - From frequency to real, use fft & fftshift on output data.
     if from_domain == "real":
-        shift_before = True
         shift_after = False
         inverse = True
     else:
-        shift_before = False
         shift_after = True
         inverse = False
 

--- a/lasy/utils/fft_wrapper.py
+++ b/lasy/utils/fft_wrapper.py
@@ -128,9 +128,6 @@ def frequency_axis(which, axes_in, from_domain):
 
     Returns
     -------
-    arr_out : ndarray
-        3D array after FFT
-
     axes_out : list of 1d arrays
         if which="transverse", 2 1d arrays for the transverse transformed axes
         if which="longitudinal", 1 1d array for the longitudinal transformed axis

--- a/lasy/utils/fft_wrapper.py
+++ b/lasy/utils/fft_wrapper.py
@@ -59,11 +59,11 @@ def fft(which, arr_in, axes_in, from_domain):
 
         # Set right FFT functions
         if inverse:
-            xfftshift = np.fft.ifftshift
             xfft = np.fft.ifft2
+            xfftshift = np.fft.ifftshift
         else:
-            xfftshift = np.fft.fftshift
             xfft = np.fft.fft2
+            xfftshift = np.fft.fftshift
 
         # Do the FFT
         arr = np.copy(arr_in)
@@ -83,11 +83,11 @@ def fft(which, arr_in, axes_in, from_domain):
 
         # Set right FFT functions
         if inverse:
-            xfftshift = np.fft.ifftshift
             xfft = np.fft.ifft
+            xfftshift = np.fft.ifftshift
         else:
-            xfftshift = np.fft.fftshift
             xfft = np.fft.fft
+            xfftshift = np.fft.fftshift
 
         # Do the FFT
         arr = np.copy(arr_in)
@@ -100,6 +100,7 @@ def fft(which, arr_in, axes_in, from_domain):
             arr_out = xfftshift(arr_out, axes=-1)
 
     axes_out = frequency_axis(which, axes_in, from_domain)
+
     return arr_out, axes_out
 
 
@@ -183,6 +184,8 @@ def frequency_axis(which, axes_in, from_domain):
 
         # Build output axes data
         axes_out = np.fft.fftfreq(axes_in.size, d)
+        if from_domain == "real":
+            axes_out *= 2 * np.pi
 
         # Shift after FFT
         if shift_after:

--- a/lasy/utils/fft_wrapper.py
+++ b/lasy/utils/fft_wrapper.py
@@ -147,6 +147,9 @@ def frequency_axis(which, axes_in, from_domain):
         inverse = False
 
     if which == "transverse":
+        # Exit if only 1 element
+        if min(axes_in[0].size, axes_in[1].size) < 2:
+            return axes_in
         dx = axes_in[0][1] - axes_in[0][0]
         dy = axes_in[1][1] - axes_in[1][0]
 
@@ -171,6 +174,9 @@ def frequency_axis(which, axes_in, from_domain):
             axes_out[1] = xfftshift(axes_out[1])
 
     else:  # which == "longitudinal"
+        # Exit if only 1 element
+        if axes_in.size <= 1:
+            return axes_in
         d = axes_in[1] - axes_in[0]
 
         # Set right FFT functions

--- a/lasy/utils/fft_wrapper.py
+++ b/lasy/utils/fft_wrapper.py
@@ -59,8 +59,10 @@ def fft(which, arr_in, axes_in, from_domain):
 
         # Set right FFT functions
         if inverse:
+            xfftshift = np.fft.ifftshift
             xfft = np.fft.ifft2
         else:
+            xfftshift = np.fft.fftshift
             xfft = np.fft.fft2
 
         # Do the FFT
@@ -81,8 +83,10 @@ def fft(which, arr_in, axes_in, from_domain):
 
         # Set right FFT functions
         if inverse:
+            xfftshift = np.fft.ifftshift
             xfft = np.fft.ifft
         else:
+            xfftshift = np.fft.fftshift
             xfft = np.fft.fft
 
         # Do the FFT

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .fft_wrapper import fft
+from .fft_wrapper import fft, frequency_axis
 
 time_axis_indx = -1
 
@@ -175,6 +175,8 @@ class Grid:
         assert field.shape == self.spectral_field.shape
         assert field.dtype == "complex128"
         self.spectral_field[:, :, :] = field
+        if not hasattr(self, "spectral_axis"):
+            self.spectral_axis = frequency_axis("longitudinal", self.axes[-1], "real")
         self.spectral_field_valid = True
         self.temporal_field_valid = False  # Invalidates the temporal field
 

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -175,8 +175,6 @@ class Grid:
         assert field.shape == self.spectral_field.shape
         assert field.dtype == "complex128"
         self.spectral_field[:, :, :] = field
-        if not hasattr(self, "spectral_axis"):
-            self.spectral_axis = frequency_axis("longitudinal", self.axes[-1], "real")
         self.spectral_field_valid = True
         self.temporal_field_valid = False  # Invalidates the temporal field
 
@@ -222,6 +220,8 @@ class Grid:
         # We return a copy, so that the user cannot modify
         # the original field, unless set_spectral_field is called
         assert self.is_envelope
+        if not hasattr(self, "spectral_axis"):
+            self.spectral_axis = frequency_axis("longitudinal", self.axes[-1], "real")
         if self.spectral_field_valid:
             return self.spectral_field.copy(), self.spectral_axis.copy()
         elif self.temporal_field_valid:


### PR DESCRIPTION
The propagator was setting the spectral field in a corner case where the spectral axis was not set properly. This fixes it, and in addition lets the FFT wrapper return only the spectral axis.