### PR TITLE
Add documentation for intensity mask

### DIFF
--- a/docs/source/api/optical_elements/index.rst
+++ b/docs/source/api/optical_elements/index.rst
@@ -4,6 +4,7 @@ Optical elements
 .. toctree::
    :maxdepth: 1
 
+   intensity_mask
    parabolic_mirror
    polynomial_spectral_phase
    axiparabola

--- a/docs/source/api/optical_elements/intensity_mask.rst
+++ b/docs/source/api/optical_elements/intensity_mask.rst
@@ -1,0 +1,5 @@
+Intensity mask
+==============
+
+.. autoclass:: lasy.optical_elements.IntensityMask
+    :members:


### PR DESCRIPTION
The intensity mask was missing from the Read-the-docs documentation.