### PR TITLE
Rectangle

### DIFF
--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -3,11 +3,11 @@ from lasy.optical_elements.optical_element import OpticalElement
 
 class IntensityMask(OpticalElement):
     """
-    Class for a radially symmetric intensity mask.
+    Class for a round or rectangular intensity mask.
 
     This creates an optical element which acts to mask out the intensity of a laser pulse.
-    The mask is radially symmetric and can either mask intensity beyond a user defined radius, thus acting as
-    an aperture. Alternatively, the optica can mask intensity within a user defined radius, acting in this case as
+    The mask is either round or rectangular and can either mask intensity beyond a user defined radius or width, thus acting as
+    an aperture. Alternatively, the optica can mask intensity within a user defined radius or width, acting in this case as
     an optic with a hole.
 
     Parameters

--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -14,7 +14,7 @@ class IntensityMask(OpticalElement):
     ----------
     R : float (in meter) or tuple (floats)
         The radius of the mask for round masks or half-width and half-height for rectangular masks as tuple.
-        If the shape is rectangular and only one number is given, a quadratic shape is assumed. 
+        If the shape is rectangular and only one number is given, a quadratic shape is assumed.
     center: tuple (floats)
         Center of the mask. Default is (0,0)
     mask_type: string
@@ -31,7 +31,7 @@ class IntensityMask(OpticalElement):
         assert shape in ["round", "rectangular"], (
             "shape must be 'round' or 'rectangular'"
         )
-        
+
         self.R = R
         self.center = center
         self.mask_type = mask_type
@@ -40,7 +40,7 @@ class IntensityMask(OpticalElement):
             assert type(self.R)==float (
             "Radius cannot be a tuple'"
         )
-        
+
     def amplitude_multiplier(self, x, y, omega):
         """
         Return the amplitude multiplier.
@@ -74,6 +74,3 @@ class IntensityMask(OpticalElement):
             return mask.astype(float)  # 1 inside, 0 outside
         else:  # "hole"
             return (~mask).astype(float)  # 0 inside, 1 outside
-
-            
-

--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -62,13 +62,13 @@ class IntensityMask(OpticalElement):
             mask = r_squared <= self.R**2  # True inside, False outside
 
         if self.shape=='rectangular':
-            if type(self.R)==float
+            if type(self.R)==float:
                 halfwidth=self.R
                 halfheight=self.R
             if type(self.R)==tuple:
                 halfwidth=self.R[0]
                 halfheight=self.R[1]
-            mask = ((x-self.center[0]) <= halfwidth) and ((x-self.center[0]) >= -halfwidth) and ((y-self.center[y]) <= halfheight) and ((y-self.center[y]) >= halfheight)) # True inside, False outside
+            mask = ((x-self.center[0]) <= halfwidth) & ((x-self.center[0]) >= -halfwidth) & ((y-self.center[1]) <= halfheight) & ((y-self.center[1]) >= halfheight) # True inside, False outside
 
         if self.mask_type == "aperture":
             return mask.astype(float)  # 1 inside, 0 outside

--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -36,8 +36,8 @@ class IntensityMask(OpticalElement):
         self.center = center
         self.mask_type = mask_type
         self.shape = shape
-        if shape==round:
-            assert R.type==float (
+        if self.shape=='round':
+            assert type(self.R)==float (
             "Radius cannot be a tuple'"
         )
         
@@ -57,17 +57,17 @@ class IntensityMask(OpticalElement):
             Contains the value of the multiplier at the specified points.
             This array has the same shape as the array omega.
         """
-        if shape=='round':
+        if self.shape=='round':
             r_squared = (x - self.center[0]) ** 2 + (y - self.center[1]) ** 2
             mask = r_squared <= self.R**2  # True inside, False outside
 
-        if shape=='rectangular':
-            if R.type==float
-                halfwidth=R
-                halfheight=R
-            if R.type==tuple:
-                halfwidth=R[0]
-                halfheight=R[1]
+        if self.shape=='rectangular':
+            if type(self.R)==float
+                halfwidth=self.R
+                halfheight=self.R
+            if type(self.R)==tuple:
+                halfwidth=self.R[0]
+                halfheight=self.R[1]
             mask = ((x-self.center[0]) <= halfwidth) and ((x-self.center[0]) >= -halfwidth) and ((y-self.center[y]) <= halfheight) and ((y-self.center[y]) >= halfheight)) # True inside, False outside
 
         if self.mask_type == "aperture":

--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -37,7 +37,7 @@ class IntensityMask(OpticalElement):
         self.mask_type = mask_type
         self.shape = shape
         if self.shape == "round":
-            assert type(self.R) == float("Radius cannot be a tuple'")
+            assert type(self.R) != tuple("Radius cannot be a tuple'")
 
     def amplitude_multiplier(self, x, y, omega):
         """
@@ -70,7 +70,7 @@ class IntensityMask(OpticalElement):
                 ((x - self.center[0]) <= halfwidth)
                 & ((x - self.center[0]) >= -halfwidth)
                 & ((y - self.center[1]) <= halfheight)
-                & ((y - self.center[1]) >= halfheight)
+                & ((y - self.center[1]) >= -halfheight)
             )  # True inside, False outside
 
         if self.mask_type == "aperture":

--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -12,23 +12,35 @@ class IntensityMask(OpticalElement):
 
     Parameters
     ----------
-    R : float (in meter)
-        The radius of the mask
+    R : float (in meter) or tuple (floats)
+        The radius of the mask for round masks or half-width and half-height for rectangular masks as tuple.
+        If the shape is rectangular and only one number is given, a quadratic shape is assumed. 
     center: tuple (floats)
         Center of the mask. Default is (0,0)
     mask_type: string
         Should be 'aperture' (default, allows light inside) or 'hole' (allows light outside).
+    shape: string
+        Should be 'round' (default, for round apertures) or 'rectangular' (for rectangular apertures).
 
     """
 
-    def __init__(self, R, center=(0, 0), mask_type="aperture"):
+    def __init__(self, R, center=(0, 0), mask_type="aperture",shape="round"):
         assert mask_type in ["aperture", "hole"], (
             "mask_type must be 'aperture' or 'hole'"
         )
+        assert shape in ["round", "rectangular"], (
+            "shape must be 'round' or 'rectangular'"
+        )
+        
         self.R = R
         self.center = center
         self.mask_type = mask_type
-
+        self.shape = shape
+        if shape==round:
+            assert R.type==float (
+            "Radius cannot be a tuple'"
+        )
+        
     def amplitude_multiplier(self, x, y, omega):
         """
         Return the amplitude multiplier.
@@ -45,10 +57,23 @@ class IntensityMask(OpticalElement):
             Contains the value of the multiplier at the specified points.
             This array has the same shape as the array omega.
         """
-        r_squared = (x - self.center[0]) ** 2 + (y - self.center[1]) ** 2
-        mask = r_squared <= self.R**2  # True inside, False outside
+        if shape=='round':
+            r_squared = (x - self.center[0]) ** 2 + (y - self.center[1]) ** 2
+            mask = r_squared <= self.R**2  # True inside, False outside
+
+        if shape=='rectangular':
+            if R.type==float
+                halfwidth=R
+                halfheight=R
+            if R.type==tuple:
+                halfwidth=R[0]
+                halfheight=R[1]
+            mask = ((x-self.center[0]) <= halfwidth) and ((x-self.center[0]) >= -halfwidth) and ((y-self.center[y]) <= halfheight) and ((y-self.center[y]) >= halfheight)) # True inside, False outside
 
         if self.mask_type == "aperture":
             return mask.astype(float)  # 1 inside, 0 outside
         else:  # "hole"
             return (~mask).astype(float)  # 0 inside, 1 outside
+
+            
+

--- a/lasy/optical_elements/intensity_mask.py
+++ b/lasy/optical_elements/intensity_mask.py
@@ -24,7 +24,7 @@ class IntensityMask(OpticalElement):
 
     """
 
-    def __init__(self, R, center=(0, 0), mask_type="aperture",shape="round"):
+    def __init__(self, R, center=(0, 0), mask_type="aperture", shape="round"):
         assert mask_type in ["aperture", "hole"], (
             "mask_type must be 'aperture' or 'hole'"
         )
@@ -36,10 +36,8 @@ class IntensityMask(OpticalElement):
         self.center = center
         self.mask_type = mask_type
         self.shape = shape
-        if self.shape=='round':
-            assert type(self.R)==float (
-            "Radius cannot be a tuple'"
-        )
+        if self.shape == "round":
+            assert type(self.R) == float("Radius cannot be a tuple'")
 
     def amplitude_multiplier(self, x, y, omega):
         """
@@ -57,18 +55,23 @@ class IntensityMask(OpticalElement):
             Contains the value of the multiplier at the specified points.
             This array has the same shape as the array omega.
         """
-        if self.shape=='round':
+        if self.shape == "round":
             r_squared = (x - self.center[0]) ** 2 + (y - self.center[1]) ** 2
             mask = r_squared <= self.R**2  # True inside, False outside
 
-        if self.shape=='rectangular':
-            if type(self.R)==float:
-                halfwidth=self.R
-                halfheight=self.R
-            if type(self.R)==tuple:
-                halfwidth=self.R[0]
-                halfheight=self.R[1]
-            mask = ((x-self.center[0]) <= halfwidth) & ((x-self.center[0]) >= -halfwidth) & ((y-self.center[1]) <= halfheight) & ((y-self.center[1]) >= halfheight) # True inside, False outside
+        if self.shape == "rectangular":
+            if type(self.R) == float:
+                halfwidth = self.R
+                halfheight = self.R
+            if type(self.R) == tuple:
+                halfwidth = self.R[0]
+                halfheight = self.R[1]
+            mask = (
+                ((x - self.center[0]) <= halfwidth)
+                & ((x - self.center[0]) >= -halfwidth)
+                & ((y - self.center[1]) <= halfheight)
+                & ((y - self.center[1]) >= halfheight)
+            )  # True inside, False outside
 
         if self.mask_type == "aperture":
             return mask.astype(float)  # 1 inside, 0 outside


### PR DESCRIPTION
Updated the intensity_mask optical element, to allow for rectangular apertures.

A new string input parameter allows to distinguish between rectangular and round apertures, the default is round.

If the aperture is rectangular, the feature R (radius, if the aperture is round) can also be passed as a tuple, that specifies the halfwidth and the halfheight. If only a single value is given and the aperture is rectangular, a quadratic shape is assumed.

Only the definition of the mask is differs for rectangular in comparison to round apertures.