### PR TITLE
Fix for some issues in `from_array_profile`

### DIFF
--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -73,7 +73,6 @@ class FromArrayProfile(Profile):
             if axes["r"][0] != 0.0:
                 # add mirrored point to the axis
                 r = xp.concatenate((-axes["r"][[0]], axes["r"]))
-                #r = xp.concatenate((xp.array([-axes["r"][0]]), axes["r"]))
                 # takes first element of the array in the radial dimension
                 subarray = self.array[:, 0, :]
                 # add it at the beginning to be the value at the mirrored point

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -73,7 +73,7 @@ class FromArrayProfile(Profile):
             if axes["r"][0] != 0.0:
                 # add mirrored point to the axis
                 r = xp.concatenate((-axes["r"][[0]], axes["r"]))
-                #r = xp.concatenate((xp.array([-axes["r"][0]]), axes["r"]))
+                # r = xp.concatenate((xp.array([-axes["r"][0]]), axes["r"]))
                 # takes first element of the array in the radial dimension
                 subarray = self.array[:, 0, :]
                 # add it at the beginning to be the value at the mirrored point

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -72,7 +72,8 @@ class FromArrayProfile(Profile):
             # to make correct interpolation within the first cell
             if axes["r"][0] != 0.0:
                 # add mirrored point to the axis
-                r = xp.concatenate(([-axes["r"][0]], axes["r"]))
+                r = xp.concatenate((-axes["r"][[0]], axes["r"]))
+                #r = xp.concatenate((xp.array([-axes["r"][0]]), axes["r"]))
                 # takes first element of the array in the radial dimension
                 subarray = self.array[:, 0, :]
                 # add it at the beginning to be the value at the mirrored point
@@ -94,7 +95,7 @@ class FromArrayProfile(Profile):
                     RegularGridInterpolator(
                         (r, axes["t"]),
                         xp.abs(self.array[imode, :, :])
-                        + 1.0j * xp.unwrap(xp.angle(self.array[imode, :, :]), axis=-1),
+                        + 1.0j * xp.unwrap(xp.angle(self.array[imode, :, :]), axis=0),
                         bounds_error=False,
                         fill_value=0.0,
                     )

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -870,7 +870,7 @@ def create_grid(array, axes, dim, is_envelope=True, position=0.0):
             n_azimuthal_modes=nm,
             is_envelope=is_envelope,
         )
-        assert xp.all(grid.axes[0] == axes["r"])
+        assert xp.allclose(grid.axes[0], axes["r"], rtol=1.0e-14)
         assert xp.allclose(grid.axes[1], axes["t"], rtol=1.0e-14)
         assert array.ndim == 3, (
             "Input array should be of dimension 3 [modes, radius, time]"

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -87,7 +87,7 @@ def write_to_openpmd_file(
         m.axis_labels = ["t", "r"]
 
     # Store metadata needed to reconstruct the field
-    m.set_attribute("angularFrequency", 2 * xp.pi * c / wavelength)
+    m.set_attribute("angularFrequency", to_cpu(2 * xp.pi * c / wavelength))
     m.set_attribute("polarization", to_cpu(pol))
     if save_as_vector_potential:
         m.set_attribute("envelopeField", "normalized_vector_potential")


### PR DESCRIPTION
Recently we've used lasy to pass laser from FBPIC to WARPX and I've noticed a few new issues that made our workflow crash:
- after passing to GPU support [this assertion](https://github.com/LASY-org/lasy/blob/d1bac094ff5b73f0756e9965716d38fb67be19aa/lasy/utils/laser_utils.py#L873) started giving False with differences of ~1e-300. Using `xp.all` with `==` condition on floats is in general risky, so I've changed it to a proper `xp.allclose`
- the use of `xp.concatinate` with GPU data [here](https://github.com/LASY-org/lasy/blob/d1bac094ff5b73f0756e9965716d38fb67be19aa/lasy/profiles/from_array_profile.py#L75) gives error as it needs strictly array structures, while numpy work with lists
- for interpolation [here](https://github.com/LASY-org/lasy/blob/d1bac094ff5b73f0756e9965716d38fb67be19aa/lasy/profiles/from_array_profile.py#L97) we use phase 1D unwrapping along `t`-axis which however leave phase along `r` quiet piecewise. Changing the unwrapping direction fixes the issue.
 
For the latter issue, this practically messes up the laser as following (need a resolved `get_full_field` data to see):
<img width="1600" height="1066" alt="Figure 1(11)" src="https://github.com/user-attachments/assets/eb40916e-3ed8-4048-9a09-106354139026" />

and the fixed version looks as it should:
<img width="1600" height="1066" alt="Figure 2(14)" src="https://github.com/user-attachments/assets/00d46c74-9bce-4fc0-b456-f18ea8395471" />



