### PR TITLE
Fix for PR #369 refractive index

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,11 @@ with open("./tests/requirements.txt") as f:
 setup(
     name="lasy",
     version=lasy.__version__,
-    packages=find_packages("."),
+    packages=find_packages("."),    
+    include_package_data=True,
+    package_data={
+        "lasy": ["**/*.json"],
+    },
     description="LAser pulse manipulation made eaSY",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("./tests/requirements.txt") as f:
 setup(
     name="lasy",
     version=lasy.__version__,
-    packages=find_packages("."),    
+    packages=find_packages("."),
     include_package_data=True,
     package_data={
         "lasy": ["**/*.json"],


### PR DESCRIPTION
Modified setup.py to install .json files (e.g. refractive_index_db.json).

Update to PR #369 to automatically install database information stored in refractive_index_db.json. Small modification to setup.py so that the refractive data is automatically installed when using pip.