### PR TITLE
Add environment variable to switch backend

### DIFF
--- a/lasy/backend.py
+++ b/lasy/backend.py
@@ -1,4 +1,26 @@
-try:
+import os
+
+lasy_backend = "AUTO"
+if "LASY_BACKEND" in os.environ:
+    assert os.environ["LASY_BACKEND"] in ["NP", "CP", "AUTO"], \
+        "The enviroment variable 'LASY_BACKEND' must be one of " + \
+        "'NP' (NumPy), 'CP' (CuPy) or 'AUTO'!"
+    lasy_backend = os.environ["LASY_BACKEND"]
+
+if lasy_backend == "AUTO":
+    try:
+        import cupy as xp
+        from cupyx.scipy.interpolate import RegularGridInterpolator
+        from cupyx.scipy.signal import hilbert, zoom_fft
+        from cupyx.scipy.special import j0
+        # xp.is_available() might cause a CUDARuntimeError
+        lasy_backend = "CP" if xp.is_available() else "NP"
+    except Exception:
+        lasy_backend = "NP"
+
+print("LASY: using backend", lasy_backend)
+
+if lasy_backend == "CP":
     import cupy as xp
     from cupyx.scipy.interpolate import RegularGridInterpolator
     from cupyx.scipy.signal import hilbert, zoom_fft
@@ -24,7 +46,7 @@ try:
         else:
             return arr
 
-except ImportError:
+else:
     import numpy as xp
     from scipy.interpolate import RegularGridInterpolator
     from scipy.signal import hilbert, zoom_fft
@@ -42,6 +64,7 @@ except ImportError:
 
 
 __all__ = [
+    "lasy_backend",
     "use_cupy",
     "xp",
     "to_cpu",

--- a/lasy/backend.py
+++ b/lasy/backend.py
@@ -11,9 +11,6 @@ if "LASY_BACKEND" in os.environ:
 if lasy_backend == "AUTO":
     try:
         import cupy
-        import cupyx.scipy.interpolate
-        import cupyx.scipy.signal
-        import cupyx.scipy.special
 
         # xp.is_available() might cause a CUDARuntimeError
         lasy_backend = "CP" if cupy.is_available() else "NP"

--- a/lasy/backend.py
+++ b/lasy/backend.py
@@ -8,28 +8,27 @@ if "LASY_BACKEND" in os.environ:
     )
     lasy_backend = os.environ["LASY_BACKEND"]
 
-cupy_imported = False
 if lasy_backend == "AUTO":
     try:
-        import cupy as xp  # noqa
-        from cupyx.scipy.interpolate import RegularGridInterpolator  # noqa
-        from cupyx.scipy.signal import hilbert, zoom_fft  # noqa
-        from cupyx.scipy.special import j0  # noqa
-
-        # xp.is_available() might cause a CUDARuntimeError
-        lasy_backend = "CP" if xp.is_available() else "NP"
-        cupy_imported = True
-    except Exception:
-        lasy_backend = "NP"
-
-print("LASY: using backend", lasy_backend)  # noqa
-
-if lasy_backend == "CP":
-    if not cupy_imported:
         import cupy as xp
         from cupyx.scipy.interpolate import RegularGridInterpolator
         from cupyx.scipy.signal import hilbert, zoom_fft
         from cupyx.scipy.special import j0
+
+        # xp.is_available() might cause a CUDARuntimeError
+        lasy_backend = "CP" if xp.is_available() else "NP"
+
+        xp, RegularGridInterpolator, hilbert, zoom_fft, j0 # workaround for pyflakes
+    except Exception:
+        lasy_backend = "NP"
+
+    print("LASY: using backend", lasy_backend)
+
+if lasy_backend == "CP":
+    import cupy as xp
+    from cupyx.scipy.interpolate import RegularGridInterpolator
+    from cupyx.scipy.signal import hilbert, zoom_fft
+    from cupyx.scipy.special import j0
 
     use_cupy = True
 

--- a/lasy/backend.py
+++ b/lasy/backend.py
@@ -10,13 +10,13 @@ if "LASY_BACKEND" in os.environ:
 
 if lasy_backend == "AUTO":
     try:
-        import cupy as xp
-        from cupyx.scipy.interpolate import RegularGridInterpolator
-        from cupyx.scipy.signal import hilbert, zoom_fft
-        from cupyx.scipy.special import j0
+        import cupy
+        import cupyx.scipy.interpolate
+        import cupyx.scipy.signal
+        import cupyx.scipy.special
 
         # xp.is_available() might cause a CUDARuntimeError
-        lasy_backend = "CP" if xp.is_available() else "NP"
+        lasy_backend = "CP" if cupy.is_available() else "NP"
     except Exception:
         lasy_backend = "NP"
 

--- a/lasy/backend.py
+++ b/lasy/backend.py
@@ -2,9 +2,10 @@ import os
 
 lasy_backend = "AUTO"
 if "LASY_BACKEND" in os.environ:
-    assert os.environ["LASY_BACKEND"] in ["NP", "CP", "AUTO"], \
-        "The enviroment variable 'LASY_BACKEND' must be one of " + \
-        "'NP' (NumPy), 'CP' (CuPy) or 'AUTO'!"
+    assert os.environ["LASY_BACKEND"] in ["NP", "CP", "AUTO"], (
+        "The enviroment variable 'LASY_BACKEND' must be one of "
+        + "'NP' (NumPy), 'CP' (CuPy) or 'AUTO'!"
+    )
     lasy_backend = os.environ["LASY_BACKEND"]
 
 if lasy_backend == "AUTO":
@@ -13,6 +14,7 @@ if lasy_backend == "AUTO":
         from cupyx.scipy.interpolate import RegularGridInterpolator
         from cupyx.scipy.signal import hilbert, zoom_fft
         from cupyx.scipy.special import j0
+
         # xp.is_available() might cause a CUDARuntimeError
         lasy_backend = "CP" if xp.is_available() else "NP"
     except Exception:

--- a/lasy/backend.py
+++ b/lasy/backend.py
@@ -8,22 +8,28 @@ if "LASY_BACKEND" in os.environ:
     )
     lasy_backend = os.environ["LASY_BACKEND"]
 
+cupy_imported = False
 if lasy_backend == "AUTO":
     try:
-        import cupy
+        import cupy as xp
+        from cupyx.scipy.interpolate import RegularGridInterpolator
+        from cupyx.scipy.signal import hilbert, zoom_fft
+        from cupyx.scipy.special import j0
 
         # xp.is_available() might cause a CUDARuntimeError
-        lasy_backend = "CP" if cupy.is_available() else "NP"
+        lasy_backend = "CP" if xp.is_available() else "NP"
+        cupy_imported = True
     except Exception:
         lasy_backend = "NP"
 
-print("LASY: using backend", lasy_backend)
+print("LASY: using backend", lasy_backend) # py/print-during-import
 
 if lasy_backend == "CP":
-    import cupy as xp
-    from cupyx.scipy.interpolate import RegularGridInterpolator
-    from cupyx.scipy.signal import hilbert, zoom_fft
-    from cupyx.scipy.special import j0
+    if not cupy_imported:
+        import cupy as xp
+        from cupyx.scipy.interpolate import RegularGridInterpolator
+        from cupyx.scipy.signal import hilbert, zoom_fft
+        from cupyx.scipy.special import j0
 
     use_cupy = True
 

--- a/lasy/backend.py
+++ b/lasy/backend.py
@@ -11,10 +11,10 @@ if "LASY_BACKEND" in os.environ:
 cupy_imported = False
 if lasy_backend == "AUTO":
     try:
-        import cupy as xp
-        from cupyx.scipy.interpolate import RegularGridInterpolator
-        from cupyx.scipy.signal import hilbert, zoom_fft
-        from cupyx.scipy.special import j0
+        import cupy as xp  # NOLINT
+        from cupyx.scipy.interpolate import RegularGridInterpolator  # NOLINT
+        from cupyx.scipy.signal import hilbert, zoom_fft  # NOLINT
+        from cupyx.scipy.special import j0  # NOLINT
 
         # xp.is_available() might cause a CUDARuntimeError
         lasy_backend = "CP" if xp.is_available() else "NP"
@@ -22,7 +22,7 @@ if lasy_backend == "AUTO":
     except Exception:
         lasy_backend = "NP"
 
-print("LASY: using backend", lasy_backend)  # py/print-during-import
+print("LASY: using backend", lasy_backend)  # NOLINT
 
 if lasy_backend == "CP":
     if not cupy_imported:

--- a/lasy/backend.py
+++ b/lasy/backend.py
@@ -11,10 +11,10 @@ if "LASY_BACKEND" in os.environ:
 cupy_imported = False
 if lasy_backend == "AUTO":
     try:
-        import cupy as xp  # NOLINT
-        from cupyx.scipy.interpolate import RegularGridInterpolator  # NOLINT
-        from cupyx.scipy.signal import hilbert, zoom_fft  # NOLINT
-        from cupyx.scipy.special import j0  # NOLINT
+        import cupy as xp  # noqa
+        from cupyx.scipy.interpolate import RegularGridInterpolator  # noqa
+        from cupyx.scipy.signal import hilbert, zoom_fft  # noqa
+        from cupyx.scipy.special import j0  # noqa
 
         # xp.is_available() might cause a CUDARuntimeError
         lasy_backend = "CP" if xp.is_available() else "NP"
@@ -22,7 +22,7 @@ if lasy_backend == "AUTO":
     except Exception:
         lasy_backend = "NP"
 
-print("LASY: using backend", lasy_backend)  # NOLINT
+print("LASY: using backend", lasy_backend)  # noqa
 
 if lasy_backend == "CP":
     if not cupy_imported:

--- a/lasy/backend.py
+++ b/lasy/backend.py
@@ -18,7 +18,7 @@ if lasy_backend == "AUTO":
         # xp.is_available() might cause a CUDARuntimeError
         lasy_backend = "CP" if xp.is_available() else "NP"
 
-        xp, RegularGridInterpolator, hilbert, zoom_fft, j0 # workaround for pyflakes
+        xp, RegularGridInterpolator, hilbert, zoom_fft, j0  # workaround for pyflakes
     except Exception:
         lasy_backend = "NP"
 

--- a/lasy/backend.py
+++ b/lasy/backend.py
@@ -22,7 +22,7 @@ if lasy_backend == "AUTO":
     except Exception:
         lasy_backend = "NP"
 
-print("LASY: using backend", lasy_backend) # py/print-during-import
+print("LASY: using backend", lasy_backend)  # py/print-during-import
 
 if lasy_backend == "CP":
     if not cupy_imported:


### PR DESCRIPTION
This PR adds the ability to switch the LASY backend using the environment variable `LASY_BACKEND`.
Available options are:
- `NP` (NumPy)
- `CP` (CuPy)
- `AUTO` (default) to try to import CuPy, but use NumPy if that fails.

A print statement is added announcing the chosen backend. Additionally, a `xp.is_available()` check is added to the try-except block to test if a GPU is installed. If not, a CUDARuntimeError is raised and NumPy is used. Previously, LASY would have tried to use CuPy and crashed in that case.