### PR TITLE
Fixes for writing CW pulses to openPMD

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -300,6 +300,8 @@ class Laser:
             self.grid,
             self.profile.lambda0,
             self.profile.pol,
+            self.profile.is_cw,
+            self.profile.is_plane_wave,
             save_as_vector_potential,
         )
         self.output_iteration += 1

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 
 import openpmd_api as io
 from scipy.constants import c
@@ -65,7 +66,7 @@ def write_to_openpmd_file(
     full_filepath = os.path.join(
         write_dir, "{}_%05T.{}".format(file_prefix, file_format)
     )
-    
+
     os.makedirs(write_dir, exist_ok=True)
     series = io.Series(full_filepath, io.Access.create)
     series.set_software("lasy", lasy_version)
@@ -84,9 +85,11 @@ def write_to_openpmd_file(
         if save_as_vector_potential:
             sys.exit("Cannot convert CW laser field to vector potential.")
         else:
-            m.grid_spacing = [ 
+            m.grid_spacing = [
                 (hi - lo) / (npoints - 1)
-                for hi, lo, npoints in zip(grid.hi[0:2], grid.lo[0:2], grid.npoints[0:2])
+                for hi, lo, npoints in zip(
+                    grid.hi[0:2], grid.lo[0:2], grid.npoints[0:2]
+                )
             ][::-1]
     m.grid_global_offset = grid.lo[::-1]
     m.grid_global_offset[0] += grid.position / c

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -1,4 +1,4 @@
-import os
+import os, sys
 
 import openpmd_api as io
 from scipy.constants import c
@@ -65,6 +65,7 @@ def write_to_openpmd_file(
     full_filepath = os.path.join(
         write_dir, "{}_%05T.{}".format(file_prefix, file_format)
     )
+    
     os.makedirs(write_dir, exist_ok=True)
     series = io.Series(full_filepath, io.Access.create)
     series.set_software("lasy", lasy_version)
@@ -73,10 +74,20 @@ def write_to_openpmd_file(
 
     # Define the mesh
     m = i.meshes["laserEnvelope"]
-    m.grid_spacing = [
-        (hi - lo) / (npoints - 1)
-        for hi, lo, npoints in zip(grid.hi, grid.lo, grid.npoints)
-    ][::-1]
+    try:
+        m.grid_spacing = [
+            (hi - lo) / (npoints - 1)
+            for hi, lo, npoints in zip(grid.hi, grid.lo, grid.npoints)
+        ][::-1]
+    except:
+        print("Warning: Exporting CW laser to openPMD.")
+        if save_as_vector_potential:
+            sys.exit("Cannot convert CW laser field to vector potential.")
+        else:
+            m.grid_spacing = [ 
+                (hi - lo) / (npoints - 1)
+                for hi, lo, npoints in zip(grid.hi[0:2], grid.lo[0:2], grid.npoints[0:2])
+            ][::-1]
     m.grid_global_offset = grid.lo[::-1]
     m.grid_global_offset[0] += grid.position / c
     if dim == "xyt":

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -19,6 +19,8 @@ def write_to_openpmd_file(
     grid,
     wavelength,
     pol,
+    is_cw,
+    is_plane_wave,
     save_as_vector_potential=False,
 ):
     """
@@ -56,6 +58,12 @@ def write_to_openpmd_file(
     pol : list of 2 complex numbers
         Polarization vector that multiplies array to get the Ex and Ey arrays.
 
+    is_cw : bool
+        Whether the laser is a continuous wave.
+
+    is_plane_wave : bool
+        Whether the laser is a plane wave.
+
     save_as_vector_potential : bool (optional)
         Whether the envelope is converted to normalized vector potential
         before writing to file.
@@ -75,12 +83,14 @@ def write_to_openpmd_file(
 
     # Define the mesh
     m = i.meshes["laserEnvelope"]
-    try:
+
+    if not is_cw and not is_plane_wave:
+        # If the laser is not CW and not plane wave, we can export the full field
         m.grid_spacing = [
             (hi - lo) / (npoints - 1)
             for hi, lo, npoints in zip(grid.hi, grid.lo, grid.npoints)
         ][::-1]
-    except ZeroDivisionError:
+    elif is_cw and not is_plane_wave:
         print("Warning: Exporting CW laser to openPMD.")
         if save_as_vector_potential:
             sys.exit("Cannot convert CW laser field to vector potential.")
@@ -91,6 +101,12 @@ def write_to_openpmd_file(
                     grid.hi[0:2], grid.lo[0:2], grid.npoints[0:2]
                 )
             ][::-1]
+    else:  # is_plane_wave
+        print("Warning: Exporting plane wave laser to openPMD.")
+        if save_as_vector_potential:
+            sys.exit("Cannot convert plane wave laser field to vector potential.")
+        else:
+            m.grid_spacing = [(grid.hi[-1] - grid.lo[-1]) / (grid.npoints[-1] - 1)]
     m.grid_global_offset = grid.lo[::-1]
     m.grid_global_offset[0] += grid.position / c
     if dim == "xyt":

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -80,7 +80,7 @@ def write_to_openpmd_file(
             (hi - lo) / (npoints - 1)
             for hi, lo, npoints in zip(grid.hi, grid.lo, grid.npoints)
         ][::-1]
-    except:
+    except ZeroDivisionError:
         print("Warning: Exporting CW laser to openPMD.")
         if save_as_vector_potential:
             sys.exit("Cannot convert CW laser field to vector potential.")


### PR DESCRIPTION
Previously, writing the laser pulse to an openPMD file would fail in the case of a CW pulse. 

The laser pulse may still be saved as a field, but the user is warned that they are saving a CW pulse (since most PIC codes need temporal information). A CW pulse cannot be saved as a vector potential, so this is now properly caught. 