### PR TITLE
Fix zernike RmnGenerator on GPU

### DIFF
--- a/lasy/utils/zernike.py
+++ b/lasy/utils/zernike.py
@@ -1,4 +1,5 @@
 import math
+
 import numpy as np
 
 from lasy.backend import xp

--- a/lasy/utils/zernike.py
+++ b/lasy/utils/zernike.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 
 from lasy.backend import xp
 
@@ -98,7 +99,7 @@ def RmnGenerator(n, m, rho):
         Rmn = xp.ones_like(rho)
     elif (n - m) % 2 == 0:
         # Even, Rmn is not 0
-        k = xp.linspace(0, int((n - m) / 2), int((n - m) / 2) + 1).astype(int)
+        k = np.linspace(0, int((n - m) / 2), int((n - m) / 2) + 1).astype(int)
         Rmn = xp.zeros_like(rho)
         for i in k:
             Rmn = Rmn + ((-1) ** i * math.factorial(n - i)) / (


### PR DESCRIPTION
#458 broke the `test_gsalgo.py` test when running the tests on GPU. For the `k` array we can simply use a numpy array as it should be small and not needed on the GPU. With a cupy array `math.factorial(n - i)` dosen't work because `i` is still a value on the GPU.