### PR TITLE
Change default for vector potential to field conversion

### DIFF
--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -663,7 +663,7 @@ def field_to_vector_potential(grid, omega0):
     return -1j * e * grid.get_temporal_field() / (m_e * omega * c)
 
 
-def vector_potential_to_field(grid, omega0, direct=True):
+def vector_potential_to_field(grid, omega0, direct=False):
     """
     Convert envelope from electric field (V/m) to normalized vector potential.
 

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -665,7 +665,7 @@ def field_to_vector_potential(grid, omega0):
 
 def vector_potential_to_field(grid, omega0, direct=False):
     """
-    Convert envelope from electric field (V/m) to normalized vector potential.
+    Convert envelope from normalized vector potential to electric field (V/m).
 
     Parameters
     ----------


### PR DESCRIPTION
We noticed that the `direct` method to convert from vector potential to field, although it should be slightly more accurate physically, can be quite wrong if the longitudinal resolution isn't long enough. This PR changes the default to use the other method, which seems more robust.