### PR TITLE
[mini] [bugfix] Remove Default Argument in abcd.py

### DIFF
--- a/lasy/propagators/abcd.py
+++ b/lasy/propagators/abcd.py
@@ -22,7 +22,7 @@ class ABCD:
 
     """
 
-    def __init__(self, abcd=xp.array([[1, 0], [0, 1]])):
+    def __init__(self, abcd=None):
         super().__init__()
         self.abcd = abcd
 


### PR DESCRIPTION
The default argument in `abcd.py` is causing issues when trying to use a numpy backend on a machine which is capable of cupy. 

The default argument is evaluated at class definition time — i.e., at import. So even though you might be trying to run with a NumPy backend, the xp variable is already bound to CuPy when the module is parsed, and CuPy immediately tries to allocate a GPU array. In my case I did have cupy, but an old driver (hence wanting to use numpy backend).