### PR TITLE
Follow up on #469 to fix return of interpolated ```FromArrayProfile```

### DIFF
--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -59,18 +59,11 @@ class FromArrayProfile(Profile):
         if dim == "xyt":
             assert axes_order == ["x", "y", "t"]
 
-            self.field_interp_real = RegularGridInterpolator(
+            self.field_interp = RegularGridInterpolator(
                 (axes["x"], axes["y"], axes["t"]),
-                self.array.real,
+                self.array,
                 bounds_error=False,
-                fill_value=0.0,
-            )
-
-            self.field_interp_imag = RegularGridInterpolator(
-                (axes["x"], axes["y"], axes["t"]),
-                self.array.imag,
-                bounds_error=False,
-                fill_value=0.0,
+                fill_value=0.0 + 0.0j,
             )
 
         else:  # dim = "rt"
@@ -111,10 +104,7 @@ class FromArrayProfile(Profile):
     def evaluate(self, x, y, t):
         """Return the envelope field of the scaled profile."""
         if self.dim == "xyt":
-            combined_field = self.field_interp_real(
-                (x, y, t)
-            ) + 1.0j * self.field_interp_imag((x, y, t))
-            return combined_field
+            return self.field_interp((x,y,t))
         else:
             r = xp.sqrt(x**2 + y**2)
             theta = xp.angle(x + 1j * y)

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -104,7 +104,7 @@ class FromArrayProfile(Profile):
     def evaluate(self, x, y, t):
         """Return the envelope field of the scaled profile."""
         if self.dim == "xyt":
-            return self.field_interp((x,y,t))
+            return self.field_interp((x, y, t))
         else:
             r = xp.sqrt(x**2 + y**2)
             theta = xp.angle(x + 1j * y)

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -114,6 +114,7 @@ class FromArrayProfile(Profile):
             combined_field = self.field_interp_real(
                 (x, y, t)
             ) + 1.0j * self.field_interp_imag((x, y, t))
+            return combined_field
         else:
             r = xp.sqrt(x**2 + y**2)
             theta = xp.angle(x + 1j * y)


### PR DESCRIPTION
The issue observed by @AlexanderSinn in https://github.com/LASY-org/lasy/pull/469#issuecomment-4325607120 seems to be caused by an incorrect return of the `xyt` field after the interpolation method was adapted in #469. This PR adds a separate ```return combined_field```after evaluating the interpolated `xyt` field.