### PR TITLE
Add interp_method to all the interpolators

### DIFF
--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -45,9 +45,15 @@ class FromArrayProfile(Profile):
         Gives the name and ordering of the axes in the array.
         Currently, only implemented for 3D, and supported values are
         ['x', 'y', 't'] and ['t', 'y', 'x'].
+
+    interp_method : String
+        Interpolation method used to evaluate the array-defined field on the grid.
+        Supported options are "linear", "nearest", "slinear", "cubic",
+        "quintic", and "pchip". The default is "linear", but higher-order
+        methods may improve accuracy for smooth data.
     """
 
-    def __init__(self, wavelength, pol, array, dim, axes, axes_order=["x", "y", "t"]):
+    def __init__(self, wavelength, pol, array, dim, axes, axes_order=["x", "y", "t"], interp_method = 'linear'):
         super().__init__(wavelength, pol)
 
         assert dim in ["xyt", "rt"]
@@ -62,6 +68,7 @@ class FromArrayProfile(Profile):
             self.field_interp = RegularGridInterpolator(
                 (axes["x"], axes["y"], axes["t"]),
                 self.array,
+                method = interp_method,
                 bounds_error=False,
                 fill_value=0.0 + 0.0j,
             )
@@ -96,6 +103,7 @@ class FromArrayProfile(Profile):
                         (r, axes["t"]),
                         xp.abs(self.array[imode, :, :])
                         + 1.0j * xp.unwrap(xp.angle(self.array[imode, :, :]), axis=0),
+                        method = interp_method,
                         bounds_error=False,
                         fill_value=0.0,
                     )

--- a/lasy/profiles/from_array_profile.py
+++ b/lasy/profiles/from_array_profile.py
@@ -53,7 +53,16 @@ class FromArrayProfile(Profile):
         methods may improve accuracy for smooth data.
     """
 
-    def __init__(self, wavelength, pol, array, dim, axes, axes_order=["x", "y", "t"], interp_method = 'linear'):
+    def __init__(
+        self,
+        wavelength,
+        pol,
+        array,
+        dim,
+        axes,
+        axes_order=["x", "y", "t"],
+        interp_method="linear",
+    ):
         super().__init__(wavelength, pol)
 
         assert dim in ["xyt", "rt"]
@@ -68,7 +77,7 @@ class FromArrayProfile(Profile):
             self.field_interp = RegularGridInterpolator(
                 (axes["x"], axes["y"], axes["t"]),
                 self.array,
-                method = interp_method,
+                method=interp_method,
                 bounds_error=False,
                 fill_value=0.0 + 0.0j,
             )
@@ -103,7 +112,7 @@ class FromArrayProfile(Profile):
                         (r, axes["t"]),
                         xp.abs(self.array[imode, :, :])
                         + 1.0j * xp.unwrap(xp.angle(self.array[imode, :, :]), axis=0),
-                        method = interp_method,
+                        method=interp_method,
                         bounds_error=False,
                         fill_value=0.0,
                     )

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -37,7 +37,7 @@ class FromOpenPMDProfile(FromArrayProfile):
         If true, print some intermediate steps.
     """
 
-    def __init__(self, file_name, envelope_name=None, iteration=None, verbose=False):
+    def __init__(self, file_name, envelope_name=None, iteration=None, verbose=False,interp_method="linear"):
         series = io.Series(file_name, io.Access.read_only)
         iterations = xp.array(series.iterations)
         if iteration is None:
@@ -122,4 +122,5 @@ class FromOpenPMDProfile(FromArrayProfile):
             dim=dim,
             axes=axes,
             axes_order=axes_order,
+            interp_method=interp_method
         )

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -37,7 +37,14 @@ class FromOpenPMDProfile(FromArrayProfile):
         If true, print some intermediate steps.
     """
 
-    def __init__(self, file_name, envelope_name=None, iteration=None, verbose=False,interp_method="linear"):
+    def __init__(
+        self,
+        file_name,
+        envelope_name=None,
+        iteration=None,
+        verbose=False,
+        interp_method="linear",
+    ):
         series = io.Series(file_name, io.Access.read_only)
         iterations = xp.array(series.iterations)
         if iteration is None:
@@ -122,5 +129,5 @@ class FromOpenPMDProfile(FromArrayProfile):
             dim=dim,
             axes=axes,
             axes_order=axes_order,
-            interp_method=interp_method
+            interp_method=interp_method,
         )

--- a/lasy/profiles/transverse/transverse_profile_from_data.py
+++ b/lasy/profiles/transverse/transverse_profile_from_data.py
@@ -47,7 +47,9 @@ class TransverseProfileFromData(TransverseProfile):
         methods may improve accuracy for smooth data.
     """
 
-    def __init__(self, intensity_data, lo, hi, center_data=True, interp_method = "linear"):
+    def __init__(
+        self, intensity_data, lo, hi, center_data=True, interp_method="linear"
+    ):
         super().__init__()
 
         intensity_data = intensity_data.astype("float64")
@@ -81,7 +83,7 @@ class TransverseProfileFromData(TransverseProfile):
         self.field_interp = RegularGridInterpolator(
             (y_data, x_data),
             xp.sqrt(intensity_data),
-            method = interp_method,
+            method=interp_method,
             bounds_error=False,
             fill_value=0.0,
         )

--- a/lasy/profiles/transverse/transverse_profile_from_data.py
+++ b/lasy/profiles/transverse/transverse_profile_from_data.py
@@ -39,9 +39,15 @@ class TransverseProfileFromData(TransverseProfile):
         center of mass at the center of the image. It will
         also shift the x and y data axes such that (x,y) = (0,0)
         is also located at the center of the image. Default is True
+
+    interp_method : String
+        Interpolation method used to evaluate the array-defined field on the grid.
+        Supported options are "linear", "nearest", "slinear", "cubic",
+        "quintic", and "pchip". The default is "linear", but higher-order
+        methods may improve accuracy for smooth data.
     """
 
-    def __init__(self, intensity_data, lo, hi, center_data=True):
+    def __init__(self, intensity_data, lo, hi, center_data=True, interp_method = "linear"):
         super().__init__()
 
         intensity_data = intensity_data.astype("float64")
@@ -75,6 +81,7 @@ class TransverseProfileFromData(TransverseProfile):
         self.field_interp = RegularGridInterpolator(
             (y_data, x_data),
             xp.sqrt(intensity_data),
+            method = interp_method,
             bounds_error=False,
             fill_value=0.0,
         )


### PR DESCRIPTION
This PR adds an ```interp_method``` option to array-based laser profile interpolation.
Previously, RegularGridInterpolator used its default interpolation method, which is "linear". While linear interpolation is robust and efficient, it can introduce noticeable interpolation errors for smooth or highly structured laser fields. This PR exposes the interpolation method as a user-configurable argument, allowing users to select higher-order interpolation schemes when needed.