### PR TITLE
Flush before calling to_gpu

### DIFF
--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -199,12 +199,15 @@ def extract_array(m, series, component=None):
 
     """
     if component is not None:
-        array = to_gpu(m[component].load_chunk())
+        array_cpu = m[component].load_chunk()
         position = m[component].get_attribute("position")
+        series.flush()
+        array = to_gpu(array_cpu)
     else:
-        array = to_gpu(m[io.Mesh_Record_Component.SCALAR].load_chunk())
+        array_cpu = m[io.Mesh_Record_Component.SCALAR].load_chunk()
         position = m.get_attribute("position")
-    series.flush()
+        series.flush()
+        array = to_gpu(array_cpu)
     # node (0.0) or cell (0.5) centered info for each axis
     axis_labels = m.get_attribute("axisLabels")
     grid_offset = m.get_attribute("gridGlobalOffset")

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -201,13 +201,11 @@ def extract_array(m, series, component=None):
     if component is not None:
         array_cpu = m[component].load_chunk()
         position = m[component].get_attribute("position")
-        series.flush()
-        array = to_gpu(array_cpu)
     else:
         array_cpu = m[io.Mesh_Record_Component.SCALAR].load_chunk()
         position = m.get_attribute("position")
-        series.flush()
-        array = to_gpu(array_cpu)
+    series.flush()
+    array = to_gpu(array_cpu)
     # node (0.0) or cell (0.5) centered info for each axis
     axis_labels = m.get_attribute("axisLabels")
     grid_offset = m.get_attribute("gridGlobalOffset")


### PR DESCRIPTION
When reading from openPMD profile, we copied the array from the file to GPU before actually filling it with `flush`. As a result, the array was 0 afterwards. This should fix it. @CriMariani could you confirm this fixes your issue?