### PR TITLE
Replace backend pi with scipy constant

### DIFF
--- a/lasy/laser.py
+++ b/lasy/laser.py
@@ -1,3 +1,5 @@
+from scipy.constants import pi
+
 from lasy.backend import xp
 from lasy.utils.grid import Grid
 from lasy.utils.laser_utils import (
@@ -140,7 +142,7 @@ class Laser:
                     n_theta_evals = 2 * self.grid.n_azimuthal_modes - 1
                 # Make sure that there are enough points to resolve the azimuthal modes
                 assert n_theta_evals >= 2 * self.grid.n_azimuthal_modes - 1
-                theta1d = 2 * xp.pi / n_theta_evals * xp.arange(n_theta_evals)
+                theta1d = 2 * pi / n_theta_evals * xp.arange(n_theta_evals)
                 theta, r, t = xp.meshgrid(theta1d, *self.grid.axes, indexing="ij")
                 x = r * xp.cos(theta)
                 y = r * xp.sin(theta)

--- a/lasy/optical_elements/chromatic_lens.py
+++ b/lasy/optical_elements/chromatic_lens.py
@@ -1,4 +1,4 @@
-from scipy.constants import c
+from scipy.constants import c, pi
 
 from lasy.backend import xp
 
@@ -60,7 +60,7 @@ class ChromaticLens(OpticalElement):
         multiplier : ndarray of complex numbers
             Contains the value of the multiplier at the specified points
         """
-        lam = 2 * xp.pi * c / omega * 1e6  # Wavelength in microns
+        lam = 2 * pi * c / omega * 1e6  # Wavelength in microns
         n = self.n_func(lam)
 
         f = 1 / (

--- a/lasy/profiles/from_insight_file.py
+++ b/lasy/profiles/from_insight_file.py
@@ -1,5 +1,5 @@
 import h5py
-from scipy.constants import c
+from scipy.constants import c, pi
 
 from lasy.backend import xp
 
@@ -65,7 +65,7 @@ class FromInsightFile(FromArrayProfile):
         data *= xp.exp(1j * omega0 * t[None, None, :])
 
         # created LASY profile using FromArrayProfile class
-        wavelength = 2 * xp.pi * c / omega0
+        wavelength = 2 * pi * c / omega0
         dim = "xyt"
         axes = {"x": x, "y": y, "t": t}
         super().__init__(

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -1,5 +1,5 @@
 import openpmd_api as io
-from scipy.constants import c
+from scipy.constants import c, pi
 
 from lasy.backend import xp
 from lasy.utils.laser_utils import (
@@ -113,7 +113,7 @@ class FromOpenPMDProfile(FromArrayProfile):
             env_array_list[imajor] = grid_major.get_temporal_field()
             env_array_list[iminor] = grid_minor.get_temporal_field()
             array, pol = isolate_polarization(env_array_list, dim)
-        wavelength = 2 * xp.pi * c / omg0
+        wavelength = 2 * pi * c / omg0
 
         super().__init__(
             wavelength=wavelength,

--- a/lasy/profiles/gaussian_profile.py
+++ b/lasy/profiles/gaussian_profile.py
@@ -1,3 +1,5 @@
+from scipy.constants import pi
+
 from lasy.backend import xp
 
 from .profile import Profile
@@ -146,7 +148,7 @@ class GaussianProfile(Profile):
         self.t_peak = t_peak
         self.cep_phase = cep_phase
         self.z_foc = z_foc
-        self.z_foc_over_zr = z_foc * wavelength / (xp.pi * w0**2)
+        self.z_foc_over_zr = z_foc * wavelength / (pi * w0**2)
         self.phi2 = phi2
         self.beta = beta
         self.zeta = zeta

--- a/lasy/profiles/longitudinal/cosine_profile.py
+++ b/lasy/profiles/longitudinal/cosine_profile.py
@@ -1,3 +1,5 @@
+from scipy.constants import pi
+
 from lasy.backend import xp
 
 from .longitudinal_profile import LongitudinalProfile
@@ -62,7 +64,7 @@ class CosineLongitudinalProfile(LongitudinalProfile):
         tn = (t - self.t_peak) / self.tau_fwhm
 
         envelope = (
-            xp.cos(0.5 * xp.pi * tn)
+            xp.cos(0.5 * pi * tn)
             * (tn > -1)
             * (tn < 1)
             * xp.exp(+1.0j * (self.cep_phase + self.omega0 * self.t_peak))

--- a/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
+++ b/lasy/profiles/longitudinal/longitudinal_profile_from_data.py
@@ -1,4 +1,4 @@
-from scipy.constants import c
+from scipy.constants import c, pi
 
 from lasy.backend import xp
 
@@ -73,9 +73,9 @@ class LongitudinalProfileFromData(LongitudinalProfile):
                 wavelength = data["axis"]  # Accept as wavelength
                 spectral_intensity = data["intensity"]
             else:
-                wavelength = 2.0 * xp.pi * c / data["axis"]  # Convert to wavelength
+                wavelength = 2.0 * pi * c / data["axis"]  # Convert to wavelength
                 spectral_intensity = (
-                    data["intensity"] * 2.0 * xp.pi * c / wavelength**2
+                    data["intensity"] * 2.0 * pi * c / wavelength**2
                 )  # Convert spectral data
             assert xp.all(xp.diff(wavelength) > 0) or xp.all(xp.diff(wavelength) < 0), (
                 'data["axis"] must be in monotonically increasing or decreasing order.'

--- a/lasy/profiles/profile.py
+++ b/lasy/profiles/profile.py
@@ -1,4 +1,4 @@
-from scipy.constants import c
+from scipy.constants import c, pi
 
 from lasy.backend import xp
 
@@ -38,8 +38,8 @@ class Profile(object):
         norm_pol = xp.sqrt(xp.abs(pol[0]) ** 2 + xp.abs(pol[1]) ** 2)
         self.pol = xp.array([pol[0] / norm_pol, pol[1] / norm_pol])
         self.lambda0 = wavelength
-        self.omega0 = 2 * xp.pi * c / self.lambda0
-        self.k0 = 2.0 * xp.pi / wavelength
+        self.omega0 = 2 * pi * c / self.lambda0
+        self.k0 = 2.0 * pi / wavelength
         self.is_cw = False
         self.is_plane_wave = False
 

--- a/lasy/profiles/speckle_profile.py
+++ b/lasy/profiles/speckle_profile.py
@@ -1,4 +1,4 @@
-from scipy.constants import c
+from scipy.constants import c, pi
 
 from lasy.backend import xp
 
@@ -28,7 +28,7 @@ def gen_gaussian_time_series(t_num, dt, fwhm, rms_mean):
         temporal_amplitude = xp.zeros(t_num, dtype=xp.complex128)
     else:
         omega = xp.fft.fftshift(xp.fft.fftfreq(t_num, d=dt))
-        psd = xp.exp(-xp.log(2) * 0.5 * xp.square(omega / fwhm * 2 * xp.pi))
+        psd = xp.exp(-xp.log(2) * 0.5 * xp.square(omega / fwhm * 2 * pi))
         spectral_amplitude = xp.array(psd) * (
             xp.random.normal(size=t_num) + 1j * xp.random.normal(size=t_num)
         )
@@ -317,13 +317,13 @@ class SpeckleProfile(Profile):
             pm_phase0 = gen_gaussian_time_series(
                 series_time.size + int(ssd_time_delay_sum / self.dt_update) + 2,
                 self.dt_update,
-                2 * xp.pi * self.ssd_phase_modulation_frequency[0],
+                2 * pi * self.ssd_phase_modulation_frequency[0],
                 self.ssd_phase_modulation_amplitude[0],
             )
             pm_phase1 = gen_gaussian_time_series(
                 series_time.size + int(ssd_time_delay_sum / self.dt_update) + 2,
                 self.dt_update,
-                2 * xp.pi * self.ssd_phase_modulation_frequency[1],
+                2 * pi * self.ssd_phase_modulation_frequency[1],
                 self.ssd_phase_modulation_amplitude[1],
             )
             time_interp = xp.arange(
@@ -395,7 +395,7 @@ class SpeckleProfile(Profile):
             phase_t = self.ssd_phase_modulation_amplitude[0] * xp.sin(
                 self.ssd_x_y_dephasing[0]
                 + 2
-                * xp.pi
+                * pi
                 * self.ssd_phase_modulation_frequency[0]
                 * (
                     t_now
@@ -404,7 +404,7 @@ class SpeckleProfile(Profile):
             ) + self.ssd_phase_modulation_amplitude[1] * xp.sin(
                 self.ssd_x_y_dephasing[1]
                 + 2
-                * xp.pi
+                * pi
                 * self.ssd_phase_modulation_frequency[1]
                 * (
                     t_now
@@ -474,7 +474,7 @@ class SpeckleProfile(Profile):
         y_focus_list = Y_focus_matrix[0, :]
         x_phase_focus_matrix = xp.exp(
             -2
-            * xp.pi
+            * pi
             * 1j
             / self.n_beamlets[0]
             * self.x_lens_list[:, xp.newaxis]
@@ -482,7 +482,7 @@ class SpeckleProfile(Profile):
         )
         y_phase_focus_matrix = xp.exp(
             -2
-            * xp.pi
+            * pi
             * 1j
             / self.n_beamlets[1]
             * self.y_lens_list[:, xp.newaxis]
@@ -530,13 +530,13 @@ class SpeckleProfile(Profile):
 
         # Calculate auxiliary parameters
         if "RPP" == self.temporal_smoothing_type.upper():
-            phase_plate = xp.random.choice([0, xp.pi], self.n_beamlets)
+            phase_plate = xp.random.choice([0, pi], self.n_beamlets)
         elif any(
             cpp_smoothing_type in self.temporal_smoothing_type.upper()
             for cpp_smoothing_type in ["CPP", "SSD"]
         ):
             phase_plate = xp.random.uniform(
-                -xp.pi, xp.pi, size=self.n_beamlets[0] * self.n_beamlets[1]
+                -pi, pi, size=self.n_beamlets[0] * self.n_beamlets[1]
             ).reshape(self.n_beamlets)
         elif "ISI" in self.temporal_smoothing_type.upper():
             phase_plate = xp.zeros(self.n_beamlets)  # ISI does not require phase plates
@@ -544,7 +544,7 @@ class SpeckleProfile(Profile):
             raise NotImplementedError
         exp_phase_plate = xp.exp(1j * phase_plate)
         if self.temporal_smoothing_type.upper() == "FM SSD":
-            self.ssd_x_y_dephasing = xp.random.standard_normal(2) * xp.pi
+            self.ssd_x_y_dephasing = xp.random.standard_normal(2) * pi
 
         series_time = xp.arange(0, t_max + self.dt_update, self.dt_update)
 

--- a/lasy/profiles/transverse/flattened_gaussian_profile.py
+++ b/lasy/profiles/transverse/flattened_gaussian_profile.py
@@ -1,5 +1,6 @@
 import math
 
+from scipy.constants import pi
 from scipy.special import binom
 
 from lasy.backend import to_cpu, to_gpu, xp
@@ -106,7 +107,7 @@ class FlattenedGaussianTransverseProfile(TransverseProfile):
             # Calculate effective waist of the Laguerre-Gauss modes, at focus
             self.w_foc = w0 * (self.N + 1) ** 0.5
             # Calculate Rayleigh Length
-            self.zr = xp.pi * self.w_foc**2 / wavelength
+            self.zr = pi * self.w_foc**2 / wavelength
             # Evaluation distance w.r.t focal position
             self.z_eval = z_foc
             # Calculate the coefficients for the Laguerre-Gaussian modes

--- a/lasy/profiles/transverse/gaussian_profile.py
+++ b/lasy/profiles/transverse/gaussian_profile.py
@@ -1,3 +1,5 @@
+from scipy.constants import pi
+
 from lasy.backend import xp
 
 from .transverse_profile import TransverseProfile
@@ -50,7 +52,7 @@ class GaussianTransverseProfile(TransverseProfile):
             assert wavelength is not None, (
                 "You need to pass the wavelength, when `z_foc` is non-zero."
             )
-            self.z_foc_over_zr = z_foc * wavelength / (xp.pi * w0**2)
+            self.z_foc_over_zr = z_foc * wavelength / (pi * w0**2)
 
     def _evaluate(self, x, y):
         """

--- a/lasy/profiles/transverse/hermite_gaussian_profile.py
+++ b/lasy/profiles/transverse/hermite_gaussian_profile.py
@@ -1,5 +1,6 @@
 from math import factorial
 
+from scipy.constants import pi
 from scipy.special import hermite
 
 from lasy.backend import to_cpu, to_gpu, xp
@@ -136,19 +137,19 @@ class HermiteGaussianTransverseProfile(TransverseProfile):
         self.z_foc = z_foc
         z_eval = -z_foc  # this links our observation position to Siegmann's definition
 
-        self.k0 = 2 * xp.pi / wavelength
+        self.k0 = 2 * pi / wavelength
 
         # Calculate Rayleigh Lengths
-        Zx = xp.pi * w_0x**2 / wavelength
-        Zy = xp.pi * w_0y**2 / wavelength
+        Zx = pi * w_0x**2 / wavelength
+        Zy = pi * w_0y**2 / wavelength
 
         # Calculate Size at Location Z
         wxZ = w_0x * xp.sqrt(1 + (z_eval / Zx) ** 2)
         wyZ = w_0y * xp.sqrt(1 + (z_eval / Zy) ** 2)
 
         # Calculate Multiplicative Factors
-        Anx = 1 / xp.sqrt(wxZ * 2 ** (m - 1 / 2) * factorial(m) * xp.sqrt(xp.pi))
-        Any = 1 / xp.sqrt(wyZ * 2 ** (n - 1 / 2) * factorial(n) * xp.sqrt(xp.pi))
+        Anx = 1 / xp.sqrt(wxZ * 2 ** (m - 1 / 2) * factorial(m) * xp.sqrt(pi))
+        Any = 1 / xp.sqrt(wyZ * 2 ** (n - 1 / 2) * factorial(n) * xp.sqrt(pi))
 
         # Calculate the Phase contributions from propagation
         phiXz = (m + 1 / 2) * xp.arctan2(z_eval, Zx)

--- a/lasy/profiles/transverse/laguerre_gaussian_profile.py
+++ b/lasy/profiles/transverse/laguerre_gaussian_profile.py
@@ -1,5 +1,6 @@
 from math import factorial
 
+from scipy.constants import pi
 from scipy.special import genlaguerre
 
 from lasy.backend import to_cpu, to_gpu, xp
@@ -127,16 +128,16 @@ class LaguerreGaussianTransverseProfile(TransverseProfile):
         self.z_foc = z_foc
         z_eval = -z_foc  # this links our observation position to Siegman's definition
 
-        self.k0 = 2 * xp.pi / wavelength
+        self.k0 = 2 * pi / wavelength
 
         # Calculate Rayleigh Length
-        Zr = xp.pi * w_0**2 / wavelength
+        Zr = pi * w_0**2 / wavelength
 
         # Calculate Size at Location Z
         w0Z = w_0 * xp.sqrt(1 + (z_eval / Zr) ** 2)
 
         # Calculate Multiplicative Factors
-        A = xp.sqrt(2.0 * factorial(p) / (xp.pi * factorial(m + p))) / w0Z
+        A = xp.sqrt(2.0 * factorial(p) / (pi * factorial(m + p))) / w0Z
 
         # Calculate the Phase contributions from propagation
         phiZ = (2.0 * p + m + 1) * xp.arctan2(z_eval, Zr)

--- a/lasy/propagators/angular_spectrum_propagator.py
+++ b/lasy/propagators/angular_spectrum_propagator.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from scipy.constants import c
+from scipy.constants import c, pi
 
 from lasy.backend import xp
 from lasy.utils.fft_wrapper import fft
@@ -144,11 +144,11 @@ class AngularSpectrumPropagator(Propagator):
             from_domain="frequency",
         )
 
-        kx = 2 * xp.pi * axes_freq[0]
-        ky = 2 * xp.pi * axes_freq[1]
+        kx = 2 * pi * axes_freq[0]
+        ky = 2 * pi * axes_freq[1]
 
         # Calculate the refractive index if it is a function of wavelength
-        n = self.n(2 * xp.pi * c / omega) if callable(self.n) else self.n
+        n = self.n(2 * pi * c / omega) if callable(self.n) else self.n
 
         # Calculate the phase shift in k-space
         phase = (
@@ -179,7 +179,7 @@ class AngularSpectrumPropagator(Propagator):
         field, _ = fft(
             arr_in=field_kspace,
             which="transverse",
-            axes_in=(kx / (2 * xp.pi), ky / (2 * xp.pi)),
+            axes_in=(kx / (2 * pi), ky / (2 * pi)),
             from_domain="real",
         )
 

--- a/lasy/propagators/collins_sfft_propagator.py
+++ b/lasy/propagators/collins_sfft_propagator.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from scipy.constants import c, epsilon_0
+from scipy.constants import c, epsilon_0, pi
 
 from lasy.backend import xp
 from lasy.utils.fft_wrapper import fft
@@ -130,11 +130,11 @@ class CollinsSFFTPropagator(Propagator):
             L0_width = xp.abs(x[-1] - x[0])
             N_points = len(x)
 
-            lambda0 = 2.0 * xp.pi * c / self.omega0
+            lambda0 = 2.0 * pi * c / self.omega0
             k0 = self.omega0 / c
 
             w0 = get_w0(grid_in, self.dim)  # Calculate input spot size
-            z_R = xp.pi * w0**2 / lambda0  # Calculate input Rayleigh range
+            z_R = pi * w0**2 / lambda0  # Calculate input Rayleigh range
 
             q1 = _q(0, 0, z_R)
 
@@ -259,8 +259,8 @@ class CollinsSFFTPropagator(Propagator):
             field
             * xp.exp(1j * OM / (2 * c) * (D / B) * R**2)
             * OM
-            / (2j * xp.pi * c * B)
-            / xp.abs(OM / (2j * xp.pi * c * B))
+            / (2j * pi * c * B)
+            / xp.abs(OM / (2j * pi * c * B))
         )
         field *= xp.sqrt(
             xp.sum(

--- a/lasy/propagators/fresnel_chirpztransform_propagator.py
+++ b/lasy/propagators/fresnel_chirpztransform_propagator.py
@@ -1,6 +1,6 @@
 import copy
 
-from scipy.constants import c
+from scipy.constants import c, pi
 
 from lasy.backend import xp, zoom_fft
 
@@ -99,7 +99,7 @@ class FresnelChirpZPropagator(Propagator):
     >>> # Propagate the laser pulse to the focal plane and visualise.
     >>> laser.propagate(focal_length, grid_out=newGrid)
     >>> laser.show(envelope_type="intensity")
-    >>> w0theory = 0.8e-6 * focal_length / (xp.pi * 5e-3)
+    >>> w0theory = 0.8e-6 * focal_length / (pi * 5e-3)
     >>> print("w0 theoretical: %.2e m" % (w0theory))
     """
 
@@ -135,8 +135,8 @@ class FresnelChirpZPropagator(Propagator):
         sample_frequency_y = (len(y) - 1) / y_range
 
         # Convert desired frequency from rad/s to Hz
-        freq_x = k_x / 2 / xp.pi
-        freq_y = k_y / 2 / xp.pi
+        freq_x = k_x / 2 / pi
+        freq_y = k_y / 2 / pi
 
         FreqX, FreqY = xp.meshgrid(
             freq_x,
@@ -165,7 +165,7 @@ class FresnelChirpZPropagator(Propagator):
         )
 
         # Apply the phase factor to shift the transform. Similar to a Fourier Transform shift.
-        F *= xp.exp(1j * FreqX * xp.pi * x_range) * xp.exp(1j * FreqY * xp.pi * y_range)
+        F *= xp.exp(1j * FreqX * pi * x_range) * xp.exp(1j * FreqY * pi * y_range)
 
         return F
 
@@ -233,14 +233,14 @@ class FresnelChirpZPropagator(Propagator):
 
         for indx in indxs:
             om = omega[indx]
-            wavelength = 2 * xp.pi * c / om
+            wavelength = 2 * pi * c / om
             k = om / c
 
             prefactor = xp.exp(1j * k / 2 / distance * (X**2 + Y**2))
 
             # Calculate the required fourier frequencies from output grid
-            k_x = 2 * xp.pi * xF / wavelength / distance
-            k_y = 2 * xp.pi * yF / wavelength / distance
+            k_x = 2 * pi * xF / wavelength / distance
+            k_y = 2 * pi * yF / wavelength / distance
 
             # Perform the 2D Zoom FFT
             F = self._zoomFourierTransform2D(

--- a/lasy/utils/fft_wrapper.py
+++ b/lasy/utils/fft_wrapper.py
@@ -1,3 +1,5 @@
+from scipy.constants import pi
+
 from lasy.backend import xp
 
 
@@ -170,8 +172,8 @@ def frequency_axis(which, axes_in, from_domain):
             xp.fft.fftfreq(axes_in[1].size, dy),
         ]
         if from_domain == "real":
-            axes_out[0] *= 2 * xp.pi
-            axes_out[1] *= 2 * xp.pi
+            axes_out[0] *= 2 * pi
+            axes_out[1] *= 2 * pi
 
         # Shift after FFT
         if shift_after:
@@ -193,7 +195,7 @@ def frequency_axis(which, axes_in, from_domain):
         # Build output axes data
         axes_out = xp.fft.fftfreq(axes_in.size, d)
         if from_domain == "real":
-            axes_out *= 2 * xp.pi
+            axes_out *= 2 * pi
 
         # Shift after FFT
         if shift_after:

--- a/lasy/utils/grid.py
+++ b/lasy/utils/grid.py
@@ -1,5 +1,7 @@
 import copy
 
+from scipy.constants import pi
+
 from lasy.backend import to_cpu, to_gpu, use_cupy, xp
 
 from .fft_wrapper import fft, frequency_axis
@@ -87,7 +89,7 @@ class Grid:
                 )
             if dim == "rt":
                 lo[0] = 0.0
-                hi[0] = xp.sqrt(1 / xp.pi)
+                hi[0] = xp.sqrt(1 / pi)
                 npoints[0] = 1
             else:
                 lo[0] = -0.5

--- a/lasy/utils/laser_utils.py
+++ b/lasy/utils/laser_utils.py
@@ -1,6 +1,6 @@
 from axiprop.containers import ScalarFieldEnvelope
 from axiprop.lib import PropagatorFFT2, PropagatorResampling
-from scipy.constants import c, e, epsilon_0, m_e
+from scipy.constants import c, e, epsilon_0, m_e, pi
 
 from lasy.backend import hilbert, to_cpu, to_gpu, use_cupy, xp
 
@@ -471,7 +471,7 @@ def get_spectrum(
 
     # Convert to spectral energy density (J/(m^2 rad Hz)).
     if method != "raw":
-        spectrum = xp.abs(spectrum) ** 2 * epsilon_0 * c / xp.pi
+        spectrum = xp.abs(spectrum) ** 2 * epsilon_0 * c / pi
 
     # Integrate transversely.
     if method == "sum":
@@ -798,7 +798,7 @@ def get_grid_cell_volume(grid, dim):
         r = grid.axes[0]
         dr = grid.dx[0]
         # 1D array that computes the volume of radial cells
-        dV = xp.pi * ((r + 0.5 * dr) ** 2 - (r - 0.5 * dr) ** 2) * dz
+        dV = pi * ((r + 0.5 * dr) ** 2 - (r - 0.5 * dr) ** 2) * dz
     return dV
 
 
@@ -1030,7 +1030,7 @@ def import_from_z(
     field_fft = xp.fft.fft(field_z, axis=z_axis_indx, norm="forward")
 
     # Create the axes for wavenumbers, and for corresponding frequency
-    omega = 2 * xp.pi * xp.fft.fftfreq(Nz, dz / c) + omega0
+    omega = 2 * pi * xp.fft.fftfreq(Nz, dz / c) + omega0
     k_z = omega / c
 
     if dim == "rt":
@@ -1527,7 +1527,7 @@ def get_bandwidth(grid, dim, method="sum", level=None, unit="rad/s", omega0=None
     # Choose axis along which to calculate the bandwidth
     if unit == "m":  # convert omega to wavelength
         assert omega0, "'omega0' must be provided to calculate bandwidth in meters."
-        width_axis = 2 * xp.pi * c / (omega + omega0)
+        width_axis = 2 * pi * c / (omega + omega0)
     else:  # keep omega as that axis
         width_axis = omega
 

--- a/lasy/utils/openpmd_helper.py
+++ b/lasy/utils/openpmd_helper.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import openpmd_api as io
-from scipy.constants import c
+from scipy.constants import c, pi
 
 from lasy import __version__ as lasy_version
 from lasy.backend import to_cpu, to_gpu, xp
@@ -117,7 +117,7 @@ def write_to_openpmd_file(
         m.axis_labels = ["t", "r"]
 
     # Store metadata needed to reconstruct the field
-    m.set_attribute("angularFrequency", to_cpu(2 * xp.pi * c / wavelength))
+    m.set_attribute("angularFrequency", to_cpu(2 * pi * c / wavelength))
     m.set_attribute("polarization", to_cpu(pol))
     if save_as_vector_potential:
         m.set_attribute("envelopeField", "normalized_vector_potential")
@@ -132,7 +132,7 @@ def write_to_openpmd_file(
         }
 
     if save_as_vector_potential:
-        array = field_to_vector_potential(grid, 2 * xp.pi * c / wavelength)
+        array = field_to_vector_potential(grid, 2 * pi * c / wavelength)
 
     # Pick the correct field
     assert dim in ["xyt", "rt"]

--- a/lasy/utils/refractive_index.py
+++ b/lasy/utils/refractive_index.py
@@ -12,6 +12,7 @@ from pprint import pprint
 import numpy as np
 import scipy.constants as ct
 import yaml
+from scipy.constants import pi
 from scipy.interpolate import CubicSpline
 
 from lasy.backend import to_cpu, to_gpu, xp
@@ -568,10 +569,10 @@ class Material:
             Third term (TOD), in units s^3/m
         """
         omega0 = float(omega0)
-        lam = 2 * xp.pi * ct.c / omega0  # Sellmeier and everything uses dn/dlambda!
+        lam = 2 * pi * ct.c / omega0  # Sellmeier and everything uses dn/dlambda!
         lam_mu = 1e6 * lam
         dphi = (self.calc_n(lam_mu) - lam * self._dn_dw(lam_mu, 1)) / ct.c
-        ddphi = lam**3 / (2 * xp.pi * ct.c**2) * self._dn_dw(lam_mu, 2)
+        ddphi = lam**3 / (2 * pi * ct.c**2) * self._dn_dw(lam_mu, 2)
         dddphi = (
             -1
             / (omega0**2 * ct.c)


### PR DESCRIPTION
Closes #470

Replace backend-dependent `np.pi`/`xp.pi` usage in the LASY source with `pi` imported from `scipy.constants`.

- Replaces all `xp.pi` occurrences under `lasy/`.
- Adds `from scipy.constants import pi` where needed.
- Leaves backend-specific array operations unchanged.

Validation:
- `uv run pre-commit run --files $(git diff --name-only)`
- `uv run pytest -q` → 67 passed, 1 warning