### PR TITLE
Fix bug reading laser from HIPACE++

### DIFF
--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -56,10 +56,28 @@ class FromOpenPMDProfile(FromArrayProfile):
             m = it.meshes[envelope_name]
             geometry = m.get_attribute("geometry")
             dim = "xyt" if geometry == "cartesian" else "rt"
-            if omega0 == None :
-                omg0 = m.get_attribute("angularFrequency")
-            else:
-                omg0 = omega0
+            try:
+                # Prefer the value stored in the openPMD file
+                omg0 = float(m.get_attribute("angularFrequency"))
+            
+            except (RuntimeError, KeyError):
+                # Use the manually supplied value only if the attribute is missing
+                if omega0 is None:
+                    raise ValueError(
+                        "The openPMD envelope does not contain the "
+                        "'angularFrequency' attribute. Please provide omega0 manually."
+                    )
+            
+                omg0 = float(omega0)
+            
+                if omg0 <= 0:
+                    raise ValueError("omega0 must be positive and given in rad/s.")
+            
+                if verbose:
+                    print(
+                        "The 'angularFrequency' attribute is missing. "
+                        f"Using manually supplied omega0 = {omg0:.6e} rad/s."
+                    )
             position = m.grid_global_offset[0] * c
             try:
                 envelopeField = m.get_attribute("envelopeField")

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -35,6 +35,9 @@ class FromOpenPMDProfile(FromArrayProfile):
 
     verbose : bool (optional)
         If true, print some intermediate steps.
+
+    omega0 : float (optional)
+        Set the central frequency for the envelope construction. Necessary when "angularFrequency" is not detected in the openpmd file.
     """
 
     def __init__(self, file_name, envelope_name=None, iteration=None, verbose=False, omega0 = None):

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -37,7 +37,7 @@ class FromOpenPMDProfile(FromArrayProfile):
         If true, print some intermediate steps.
     """
 
-    def __init__(self, file_name, envelope_name=None, iteration=None, verbose=False):
+    def __init__(self, file_name, envelope_name=None, iteration=None, verbose=False, omega0 = None):
         series = io.Series(file_name, io.Access.read_only)
         iterations = xp.array(series.iterations)
         if iteration is None:
@@ -56,7 +56,10 @@ class FromOpenPMDProfile(FromArrayProfile):
             m = it.meshes[envelope_name]
             geometry = m.get_attribute("geometry")
             dim = "xyt" if geometry == "cartesian" else "rt"
-            omg0 = m.get_attribute("angularFrequency")
+            if omega0 == None :
+                omg0 = m.get_attribute("angularFrequency")
+            else:
+                omg0 = omega0
             position = m.grid_global_offset[0] * c
             try:
                 envelopeField = m.get_attribute("envelopeField")

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -57,27 +57,19 @@ class FromOpenPMDProfile(FromArrayProfile):
             geometry = m.get_attribute("geometry")
             dim = "xyt" if geometry == "cartesian" else "rt"
             try:
-                # Prefer the value stored in the openPMD file
                 omg0 = float(m.get_attribute("angularFrequency"))
             
-            except (RuntimeError, KeyError):
-                # Use the manually supplied value only if the attribute is missing
+            except io.ErrorNoSuchAttribute:
                 if omega0 is None:
                     raise ValueError(
-                        "The openPMD envelope does not contain the "
-                        "'angularFrequency' attribute. Please provide omega0 manually."
+                        "'angularFrequency' is missing from the openPMD file. "
+                        "Please provide omega0 manually in rad/s."
                     )
             
                 omg0 = float(omega0)
             
                 if omg0 <= 0:
-                    raise ValueError("omega0 must be positive and given in rad/s.")
-            
-                if verbose:
-                    print(
-                        "The 'angularFrequency' attribute is missing. "
-                        f"Using manually supplied omega0 = {omg0:.6e} rad/s."
-                    )
+                    raise ValueError("omega0 must be positive.")
             position = m.grid_global_offset[0] * c
             try:
                 envelopeField = m.get_attribute("envelopeField")

--- a/lasy/profiles/from_openpmd_profile.py
+++ b/lasy/profiles/from_openpmd_profile.py
@@ -40,7 +40,9 @@ class FromOpenPMDProfile(FromArrayProfile):
         Set the central frequency for the envelope construction. Necessary when "angularFrequency" is not detected in the openpmd file.
     """
 
-    def __init__(self, file_name, envelope_name=None, iteration=None, verbose=False, omega0 = None):
+    def __init__(
+        self, file_name, envelope_name=None, iteration=None, verbose=False, omega0=None
+    ):
         series = io.Series(file_name, io.Access.read_only)
         iterations = xp.array(series.iterations)
         if iteration is None:
@@ -61,16 +63,16 @@ class FromOpenPMDProfile(FromArrayProfile):
             dim = "xyt" if geometry == "cartesian" else "rt"
             try:
                 omg0 = float(m.get_attribute("angularFrequency"))
-            
+
             except io.ErrorNoSuchAttribute:
                 if omega0 is None:
                     raise ValueError(
                         "'angularFrequency' is missing from the openPMD file. "
                         "Please provide omega0 manually in rad/s."
                     )
-            
+
                 omg0 = float(omega0)
-            
+
                 if omg0 <= 0:
                     raise ValueError("omega0 must be positive.")
             position = m.grid_global_offset[0] * c


### PR DESCRIPTION
```FromOpenPMDProfile``` currently raises ```ErrorNoSuchAttribute``` when the input file lacks the angularFrequency attribute, preventing users from loading the laser envelope even when its central frequency is known.
This PR adds an optional omega0 argument to provide the central angular frequency in rad/s when this metadata is missing.
Raises a clear ValueError if neither is available, guiding users to provide omega0 manually.
Rejects non-positive fallback frequencies and documents the new argument.